### PR TITLE
NuttX graduated the Incubator; update repository links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout NuttX repo
       uses: actions/checkout@v2
       with:
-        repository: apache/incubator-nuttx
+        repository: apache/nuttx
         fetch-depth: 0
         ref: master
         path: nuttx

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ runs it the results will be visible [here](https://nuttx.apache.org).
 
 If a dependency has changed such as the external documentation you may
 need to force the deployment CI to run. This can be done from the [CI
-Actions](https://github.com/apache/incubator-nuttx-website/actions?query=workflow%3ACI)
+Actions](https://github.com/apache/nuttx-website/actions?query=workflow%3ACI)
 tab and selecting **Run workflow** -> **Branch: master** --> **Run workflow**
 
 ![Trigger Workflow](ci-workflow.png)

--- a/_data/project.yml
+++ b/_data/project.yml
@@ -18,7 +18,7 @@
 name: Apache NuttX
 short_name: NuttX
 unix_name: nuxxt
-incubator_name: incubator-nuttx
+incubator_name: nuttx
 incubator_slash_name: incubator/nuttx
 description: Apache NuttX is a mature, real-time embedded operating system (RTOS).
 
@@ -48,13 +48,13 @@ commits_list_archive_markmail:
 
 jira: NUTTX
 wiki: confluence/display/NUTTX
-github_project_name: incubator-nuttx
+github_project_name: nuttx
 
-source_repository_os: https://gitbox.apache.org/repos/asf?p=incubator-nuttx.git
-source_repository_os_mirror: https://github.com/apache/incubator-nuttx
-source_repository_apps: https://gitbox.apache.org/repos/asf?p=incubator-nuttx-apps.git
-source_repository_apps_mirror: https://github.com/apache/incubator-nuttx-apps
+source_repository_os: https://gitbox.apache.org/repos/asf?p=nuttx.git
+source_repository_os_mirror: https://github.com/apache/nuttx
+source_repository_apps: https://gitbox.apache.org/repos/asf?p=nuttx-apps.git
+source_repository_apps_mirror: https://github.com/apache/nuttx-apps
 
-website_repository: https://gitbox.apache.org/repos/asf?p=incubator-nuttx-website.git
-website_repository_mirror: https://github.com/apache/incubator-nuttx-website
+website_repository: https://gitbox.apache.org/repos/asf?p=nuttx-website.git
+website_repository_mirror: https://github.com/apache/nuttx-website
 

--- a/_releases/10.0.0.md
+++ b/_releases/10.0.0.md
@@ -48,7 +48,7 @@ limitations under the License.
 ### Watchdog Callback Argument Change
 The wdog timer call backs used to support a variable number of arguments.
 Now they support only a single argument ([PR
-#1565](https://github.com/apache/incubator-nuttx/pull/1565)). This eliminates
+#1565](https://github.com/apache/nuttx/pull/1565)). This eliminates
 (1) the configuration option `CONFIG_MAX_WDOGPARMS` and the OS interfaces
 `wd_create()` and `wd_delete()` *   wdog timer data structures are no longer
 pre-allocated. Now they are allocated by the caller of `wd_start()`. This (1)
@@ -77,372 +77,372 @@ will require modification. The following summaries the required modifications:
 
 ### New Features
 
- * [PR-1877](https://github.com/apache/incubator-nuttx/pull/1877) libc:
+ * [PR-1877](https://github.com/apache/nuttx/pull/1877) libc:
  Implement "j" modifier for scanf
 
- * [PR-1864](https://github.com/apache/incubator-nuttx/pull/1864) libc: fs: Add
+ * [PR-1864](https://github.com/apache/nuttx/pull/1864) libc: fs: Add
  relative path support
 
- * [PR-1863](https://github.com/apache/incubator-nuttx/pull/1863) libc:
+ * [PR-1863](https://github.com/apache/nuttx/pull/1863) libc:
  Implement `access()`
 
- * [PR-1866](https://github.com/apache/incubator-nuttx/pull/1866) libc: uio:
+ * [PR-1866](https://github.com/apache/nuttx/pull/1866) libc: uio:
  enable `writev()` for sockets
 
- * [PR-1853](https://github.com/apache/incubator-nuttx/pull/1853) libc:
+ * [PR-1853](https://github.com/apache/nuttx/pull/1853) libc:
  Implement `popcount/popcountl/popcountll`
 
- * [PR-1850](https://github.com/apache/incubator-nuttx/pull/1850) Add tool for
+ * [PR-1850](https://github.com/apache/nuttx/pull/1850) Add tool for
  parsing the callstack for Trace32
 
- * [PR-1840](https://github.com/apache/incubator-nuttx/pull/1840) Add POLLPRI
+ * [PR-1840](https://github.com/apache/nuttx/pull/1840) Add POLLPRI
  for exception condition on the file descriptor
 
- * [PR-1828](https://github.com/apache/incubator-nuttx/pull/1828) Implement
+ * [PR-1828](https://github.com/apache/nuttx/pull/1828) Implement
  mkdtemp syscall
 
- * [PR-1826](https://github.com/apache/incubator-nuttx/pull/1826) libc: Add
+ * [PR-1826](https://github.com/apache/nuttx/pull/1826) libc: Add
  "tm\_zone" member to tm
 
- * [PR-1824](https://github.com/apache/incubator-nuttx/pull/1824) Implement
+ * [PR-1824](https://github.com/apache/nuttx/pull/1824) Implement
  etpriority syscall
 
- * [PR-1821](https://github.com/apache/incubator-nuttx/pull/1821) Implement
+ * [PR-1821](https://github.com/apache/nuttx/pull/1821) Implement
  gettid syscall
 
- * [PR-1818](https://github.com/apache/incubator-nuttx/pull/1818) Implement
+ * [PR-1818](https://github.com/apache/nuttx/pull/1818) Implement
  pipe2 syscall
 
- * [PR-1779](https://github.com/apache/incubator-nuttx/pull/1779) libc: Minimal
+ * [PR-1779](https://github.com/apache/nuttx/pull/1779) libc: Minimal
  umask implementation
 
- * [PR-1758](https://github.com/apache/incubator-nuttx/pull/1758) mm: Add lock
+ * [PR-1758](https://github.com/apache/nuttx/pull/1758) mm: Add lock
  to protect call to mm\_addregion
 
- * [PR-1756](https://github.com/apache/incubator-nuttx/pull/1756) libc:
+ * [PR-1756](https://github.com/apache/nuttx/pull/1756) libc:
  Implement gethrtime, getrlimit, setrlimit
 
- * [PR-1658](https://github.com/apache/incubator-nuttx/pull/1658) libc: Add
+ * [PR-1658](https://github.com/apache/nuttx/pull/1658) libc: Add
  stubs for utimes
 
- * [PR-1615](https://github.com/apache/incubator-nuttx/pull/1615) libc:
+ * [PR-1615](https://github.com/apache/nuttx/pull/1615) libc:
  Implement tm::tm\_gmtoff field
 
- * [PR-1611](https://github.com/apache/incubator-nuttx/pull/1611) libc: Allocate
+ * [PR-1611](https://github.com/apache/nuttx/pull/1611) libc: Allocate
  file\_struct dynamically
 
- * [PR-1684](https://github.com/apache/incubator-nuttx/pull/1684) Add gdb script
+ * [PR-1684](https://github.com/apache/nuttx/pull/1684) Add gdb script
  for NuttX thread debugging
 
- * [PR-1607](https://github.com/apache/incubator-nuttx/pull/1607) mm: Implement
+ * [PR-1607](https://github.com/apache/nuttx/pull/1607) mm: Implement
  malloc\_usable\_size
 
- * [PR-1606](https://github.com/apache/incubator-nuttx/pull/1606) sched/pthread:
+ * [PR-1606](https://github.com/apache/nuttx/pull/1606) sched/pthread:
  Implement pthread\_attr\_detachstate
 
- * [PR-1600](https://github.com/apache/incubator-nuttx/pull/1600) Implement
+ * [PR-1600](https://github.com/apache/nuttx/pull/1600) Implement
  epol\_pwait and EPOLLONESHOT flag
 
- * [PR-1597](https://github.com/apache/incubator-nuttx/pull/1597) sched: Support
+ * [PR-1597](https://github.com/apache/nuttx/pull/1597) sched: Support
  passing non empty argument to init task
 
- * [PR-1596](https://github.com/apache/incubator-nuttx/pull/1596) libc: Replace
+ * [PR-1596](https://github.com/apache/nuttx/pull/1596) libc: Replace
  all sem\_xxx with \_SEM\_XXX. This insures the correct semaphore interface is
  used by userspace and the kernel.
 
- * [PR-1517](https://github.com/apache/incubator-nuttx/pull/1517) sched/wdog:
+ * [PR-1517](https://github.com/apache/nuttx/pull/1517) sched/wdog:
  Change the default value of MAX\_WDOGPARMS from 4 to 2 as wd\_start is two every
  where in the code base. Also bump CONFIG\_MAX\_WDOGPARAMS from 1 to 2 in
  defconfigs to support pthread\_condclockwait()
 
- * [PR-1486](https://github.com/apache/incubator-nuttx/pull/1486) libc:
+ * [PR-1486](https://github.com/apache/nuttx/pull/1486) libc:
  Implement ftw and nftw functions
 
- * [PR-1567](https://github.com/apache/incubator-nuttx/pull/1567) libc:
+ * [PR-1567](https://github.com/apache/nuttx/pull/1567) libc:
  Implement proposed POSIX \_clockwait variants of \_timedwait functions
 
- * [PR-1411](https://github.com/apache/incubator-nuttx/pull/1411) libxx:
+ * [PR-1411](https://github.com/apache/nuttx/pull/1411) libxx:
  Integrate latest uclibcxx 0.2.5
 
- * [PR-1586](https://github.com/apache/incubator-nuttx/pull/1586) libc: Add open
+ * [PR-1586](https://github.com/apache/nuttx/pull/1586) libc: Add open
  for text (translated) access support
 
- * [PR-1584](https://github.com/apache/incubator-nuttx/pull/1584) libc:
+ * [PR-1584](https://github.com/apache/nuttx/pull/1584) libc:
  Implement strlcpy function
 
- * [PR-1580](https://github.com/apache/incubator-nuttx/pull/1580) libc:
+ * [PR-1580](https://github.com/apache/nuttx/pull/1580) libc:
  Implement pthread\_conattr\_etclock
 
- * [PR-1545](https://github.com/apache/incubator-nuttx/pull/1545) sched/wdog: Do
+ * [PR-1545](https://github.com/apache/nuttx/pull/1545) sched/wdog: Do
  not dynamically allocate wdog\_s. Reduces overhead and brings it inline with
  work\_s
 
- * [PR-1534](https://github.com/apache/incubator-nuttx/pull/1534) sched/wdog:
+ * [PR-1534](https://github.com/apache/nuttx/pull/1534) sched/wdog:
  Replace all callback arguments from uint32\_t to wdparm\_t
 
- * [PR-1420](https://github.com/apache/incubator-nuttx/pull/1420) libc: Do not
+ * [PR-1420](https://github.com/apache/nuttx/pull/1420) libc: Do not
  define localtime\[\_r\] to macro with CONFIG\_LIBC\_LOCALTIME is not defined.
 
- * [PR-1375](https://github.com/apache/incubator-nuttx/pull/1375) libc: Always
+ * [PR-1375](https://github.com/apache/nuttx/pull/1375) libc: Always
  declare getenv, link/symlink and atexist/on\_exit. Many C++ libraries reference
  these but dont use them
 
- * [PR-1371](https://github.com/apache/incubator-nuttx/pull/1371) libc: Improve
+ * [PR-1371](https://github.com/apache/nuttx/pull/1371) libc: Improve
  stat/readdir to be more POSIX compliant with S\_xxx macro definition as with
  Linux
 
- * [PR-1369](https://github.com/apache/incubator-nuttx/pull/1369) Initialize the
+ * [PR-1369](https://github.com/apache/nuttx/pull/1369) Initialize the
  idle stack at the arch layer to better support stack coloring and also make it
  compatible with new TLS implementation
 
- * [PR-1292](https://github.com/apache/incubator-nuttx/pull/1292) pthread/mutex:
+ * [PR-1292](https://github.com/apache/nuttx/pull/1292) pthread/mutex:
  Add PTHREAD\_RECURSIVE\_MUTEX\_INITIALIZER\_NP support
 
- * [PR-1280](https://github.com/apache/incubator-nuttx/pull/1280) libc:
+ * [PR-1280](https://github.com/apache/nuttx/pull/1280) libc:
  Implement fseeko and ftello
 
- * [PR-1279](https://github.com/apache/incubator-nuttx/pull/1279) libc:
+ * [PR-1279](https://github.com/apache/nuttx/pull/1279) libc:
  Implement lstat and realpath
 
- * [PR-1278](https://github.com/apache/incubator-nuttx/pull/1278) libc:
+ * [PR-1278](https://github.com/apache/nuttx/pull/1278) libc:
  Implement pathconf and fpathconf
 
- * [PR-1269](https://github.com/apache/incubator-nuttx/pull/1269) cstdlib: Add
+ * [PR-1269](https://github.com/apache/nuttx/pull/1269) cstdlib: Add
  missing atox to std namespace
 
- * [PR-1264](https://github.com/apache/incubator-nuttx/pull/1264) sched/pthread:
+ * [PR-1264](https://github.com/apache/nuttx/pull/1264) sched/pthread:
  Prohibit the use of pthread\_cleanup API's by kernel threads
 
- * [PR-1440](https://github.com/apache/incubator-nuttx/pull/1440) libc: Add the
+ * [PR-1440](https://github.com/apache/nuttx/pull/1440) libc: Add the
  UUID libc functions
 
- * [PR-1308](https://github.com/apache/incubator-nuttx/pull/1308) libc: Add
+ * [PR-1308](https://github.com/apache/nuttx/pull/1308) libc: Add
  support for \_SC\_NPROCESSORS\_CONF/\_SC\_NPROCESSORS\_ONLN to sysconf
 
- * [PR-1305](https://github.com/apache/incubator-nuttx/pull/1305) libc:
+ * [PR-1305](https://github.com/apache/nuttx/pull/1305) libc:
  Implement WNOHANG for waitpid and waitid
 
- * [PR-1237](https://github.com/apache/incubator-nuttx/pull/1237) libc: Add
+ * [PR-1237](https://github.com/apache/nuttx/pull/1237) libc: Add
  minimal support for locale\_t operation: suplocale, freelocale, newlocale,
  userlocale
 
- * [PR-1317](https://github.com/apache/incubator-nuttx/pull/1317) sched/task:
+ * [PR-1317](https://github.com/apache/nuttx/pull/1317) sched/task:
  Unify task initialization
 
- * [PR-1187](https://github.com/apache/incubator-nuttx/pull/1187) sched: Unify
+ * [PR-1187](https://github.com/apache/nuttx/pull/1187) sched: Unify
  main thread and pthread behavior
 
- * [PR-2263](https://github.com/apache/incubator-nuttx/pull/2263) libc/stdio:
+ * [PR-2263](https://github.com/apache/nuttx/pull/2263) libc/stdio:
  Preallocate stdin, stdout, stderr
 
- * [PR-2053](https://github.com/apache/incubator-nuttx/pull/2053) / [PR-2040](https://github.com/apache/incubator-nuttx/pull/2040) serial/termios:
+ * [PR-2053](https://github.com/apache/nuttx/pull/2053) / [PR-2040](https://github.com/apache/nuttx/pull/2040) serial/termios:
  Support custom baudrate setting
 
 ### Bug Fixes
 
- * [PR-1911](https://github.com/apache/incubator-nuttx/pull/1911) init\_section
+ * [PR-1911](https://github.com/apache/nuttx/pull/1911) init\_section
  was not being emitted resulting in C++ static constructors not being called.
 
- * [PR-1889](https://github.com/apache/incubator-nuttx/pull/1889) Fix build
+ * [PR-1889](https://github.com/apache/nuttx/pull/1889) Fix build
  error for ::setbuf if CONFIG\_STDIO\_DISABLE\_BUFFERING is set
 
- * [PR-1619](https://github.com/apache/incubator-nuttx/pull/1619) Fix inverted
+ * [PR-1619](https://github.com/apache/nuttx/pull/1619) Fix inverted
  errno in mq\_open
 
- * [PR-1595](https://github.com/apache/incubator-nuttx/pull/1595) epoll\_wait()
+ * [PR-1595](https://github.com/apache/nuttx/pull/1595) epoll\_wait()
  must loop until "maxevents" to fille output evs array
 
- * [PR-1519](https://github.com/apache/incubator-nuttx/pull/1519) libc: Replace
+ * [PR-1519](https://github.com/apache/nuttx/pull/1519) libc: Replace
  index/rindex from macro to function to protect against side effects with
  conflicting local variables
 
- * [PR-1514](https://github.com/apache/incubator-nuttx/pull/1514) Remove usage
+ * [PR-1514](https://github.com/apache/nuttx/pull/1514) Remove usage
  for user-space memalign() from kernel/driver code. Instead use the proper
  kernel memory interface.
 
- * [PR-1512](https://github.com/apache/incubator-nuttx/pull/1512) /
- [PR-1510](https://github.com/apache/incubator-nuttx/pull/1510) /
- [PR-1507](https://github.com/apache/incubator-nuttx/pull/1507) Remove usage for
+ * [PR-1512](https://github.com/apache/nuttx/pull/1512) /
+ [PR-1510](https://github.com/apache/nuttx/pull/1510) /
+ [PR-1507](https://github.com/apache/nuttx/pull/1507) Remove usage for
  user-space malloc()/zalloc()/free() from kernel/driver code. Instead use the
  proper kernel memory interface.
 
- * [PR-1496](https://github.com/apache/incubator-nuttx/pull/1496) libc: Change
+ * [PR-1496](https://github.com/apache/nuttx/pull/1496) libc: Change
  ctype macro to normal function to resolve macro evaluation side effects
 
- * [PR-1463](https://github.com/apache/incubator-nuttx/pull/146) libc: Replace
+ * [PR-1463](https://github.com/apache/nuttx/pull/146) libc: Replace
  all malloc/free with lib\_malloc/lib\_free inside libc
 
- * [PR-1365](https://github.com/apache/incubator-nuttx/pull/1365) up\_assert
+ * [PR-1365](https://github.com/apache/nuttx/pull/1365) up\_assert
  should not call exit() directly because it is only callable from userspace
 
- * [PR-1336](https://github.com/apache/incubator-nuttx/pull/1336) syscall: Fix
+ * [PR-1336](https://github.com/apache/nuttx/pull/1336) syscall: Fix
  prctl PR\_SET\_NAME failure if called without pid argument
 
- * [PR-1289](https://github.com/apache/incubator-nuttx/pull/1289) Clear the
+ * [PR-1289](https://github.com/apache/nuttx/pull/1289) Clear the
  error indicator with rewind()
 
- * [PR-1254](https://github.com/apache/incubator-nuttx/pull/1254) libc: mkstemp
+ * [PR-1254](https://github.com/apache/nuttx/pull/1254) libc: mkstemp
  only look at the trailing X's instead of the first X
 
- * [PR-1311](https://github.com/apache/incubator-nuttx/pull/1311) libc: Move
+ * [PR-1311](https://github.com/apache/nuttx/pull/1311) libc: Move
  double\_t typedef from sys/types.h to math.h
 
- * [PR-1328](https://github.com/apache/incubator-nuttx/pull/1328) Make sure that
+ * [PR-1328](https://github.com/apache/nuttx/pull/1328) Make sure that
  pthread\_cleanup functions are only called from userspace
 
- * [PR-1318](https://github.com/apache/incubator-nuttx/pull/1318)
+ * [PR-1318](https://github.com/apache/nuttx/pull/1318)
  nxsched\_release\_tcb should release stack in kernel build, fixes memory leak
 
- * [PR-2951](https://github.com/apache/incubator-nuttx/pull/2951) sched: Fix
+ * [PR-2951](https://github.com/apache/nuttx/pull/2951) sched: Fix
  deadlock in nxtask\_exit() for SMP
 
- * [PR-2229](https://github.com/apache/incubator-nuttx/pulls/2229)  /
- [PR-2298](https://github.com/apache/incubator-nuttx/pulls/2298)  /
- [PR-2279](https://github.com/apache/incubator-nuttx/pulls/2279)  /
- [PR-2272](https://github.com/apache/incubator-nuttx/pulls/2272)  /
- [PR-2264](https://github.com/apache/incubator-nuttx/pulls/2264)  /
- [PR-1992](https://github.com/apache/incubator-nuttx/pulls/1992)  /
- [PR-2022](https://github.com/apache/incubator-nuttx/pulls/2022) sched: SMP
+ * [PR-2229](https://github.com/apache/nuttx/pulls/2229)  /
+ [PR-2298](https://github.com/apache/nuttx/pulls/2298)  /
+ [PR-2279](https://github.com/apache/nuttx/pulls/2279)  /
+ [PR-2272](https://github.com/apache/nuttx/pulls/2272)  /
+ [PR-2264](https://github.com/apache/nuttx/pulls/2264)  /
+ [PR-1992](https://github.com/apache/nuttx/pulls/1992)  /
+ [PR-2022](https://github.com/apache/nuttx/pulls/2022) sched: SMP
  fixups that caused locking and removal of some no longer required workarounds
 
- * [PR-1993](https://github.com/apache/incubator-nuttx/pull/1993) libc: Skip
+ * [PR-1993](https://github.com/apache/nuttx/pull/1993) libc: Skip
  close stdin/stdout/stderr in fclose
 
- * [PR-1997](https://github.com/apache/incubator-nuttx/pull/1997) libc: Remove
+ * [PR-1997](https://github.com/apache/nuttx/pull/1997) libc: Remove
  all calls to fclose with stdin/stdout/stderr with fclose
 
 
 
 ## Major Changes to Documentation
 
- * [PR-1763](https://github.com/apache/incubator-nuttx/pulls/1763) Add
+ * [PR-1763](https://github.com/apache/nuttx/pulls/1763) Add
  quickstart documentation
 
- * [PR-1677](https://github.com/apache/incubator-nuttx/pull/1677) Add simulator,
+ * [PR-1677](https://github.com/apache/nuttx/pull/1677) Add simulator,
  drivers, and contributing instructions for new users
 
- * [PR-1675](https://github.com/apache/incubator-nuttx/pull/1675) Add quickstart
+ * [PR-1675](https://github.com/apache/nuttx/pull/1675) Add quickstart
  documentation from NuttX Companion
 
- * [PR-1673](https://github.com/apache/incubator-nuttx/pull/1673) Update all the
+ * [PR-1673](https://github.com/apache/nuttx/pull/1673) Update all the
  links in the documentation to point to nuttx.apache.org or the Apache NuttX
  wiki instead of old nuttx.org resources
 
- * [PR-1501](https://github.com/apache/incubator-nuttx/pull/1501) Port all the
+ * [PR-1501](https://github.com/apache/nuttx/pull/1501) Port all the
  existing documentation from HTML files to Sphinx based documentation along with
  a bunch of updates and improvments
 
- * [PR-1433](https://github.com/apache/incubator-nuttx/pull/1433) Convert README
+ * [PR-1433](https://github.com/apache/nuttx/pull/1433) Convert README
  documentation to Markdown
 
 ## Major Changes to the Build System
 
 ### New Features
 
- * [PR-1786](https://github.com/apache/incubator-nuttx/pull/1786) Support
+ * [PR-1786](https://github.com/apache/nuttx/pull/1786) Support
  building external code into the OS
 
- * [PR-1396](https://github.com/apache/incubator-nuttx/pull/1396) Make C/C++
+ * [PR-1396](https://github.com/apache/nuttx/pull/1396) Make C/C++
  search path common so all boards support uClibc++/libc++ automatically
 
- * [PR-1682](https://github.com/apache/incubator-nuttx/pull/1682) configure.sh
+ * [PR-1682](https://github.com/apache/nuttx/pull/1682) configure.sh
  can now list configurations with "-L" option
 
- * [PR-2023](https://github.com/apache/incubator-nuttx/pull/2023) tools: Remove
+ * [PR-2023](https://github.com/apache/nuttx/pull/2023) tools: Remove
  WSL configuration. This is just Linux now.
 
 ### Bug Fixes
 
- * [PR-1713](https://github.com/apache/incubator-nuttx/pull/1713) Fix export
+ * [PR-1713](https://github.com/apache/nuttx/pull/1713) Fix export
  target: libboard was missing KERNEL flag.
 
- * [PR-1470](https://github.com/apache/incubator-nuttx/pull/1470) Fix Make.dep
+ * [PR-1470](https://github.com/apache/nuttx/pull/1470) Fix Make.dep
  not updated by .config changes
 
- * [PR-1345](https://github.com/apache/incubator-nuttx/pull/1786) Enhance export
+ * [PR-1345](https://github.com/apache/nuttx/pull/1786) Enhance export
  target: make BIN directory configurable, export post build script, use LDNAME
  instead of LDSCRIPT
 
- * [PR-1332](https://github.com/apache/incubator-nuttx/pull/1332) Include
+ * [PR-1332](https://github.com/apache/nuttx/pull/1332) Include
  incdir.c in the export target
 
- * [PR-1995](https://github.com/apache/incubator-nuttx/pull/1995) Fix issue
+ * [PR-1995](https://github.com/apache/nuttx/pull/1995) Fix issue
  where wrong extension was generated for mkconfig in WSL builds
 
- * [PR-1949](https://github.com/apache/incubator-nuttx/pull/1949) Fix issue in
+ * [PR-1949](https://github.com/apache/nuttx/pull/1949) Fix issue in
  make export where nuttx-names.dat was not being generated
 
- * [PR-1682](https://github.com/apache/incubator-nuttx/pull/1682): Fix issue
+ * [PR-1682](https://github.com/apache/nuttx/pull/1682): Fix issue
  where windows style paths might not be handled correctly breaking Cygwin builds
 
 ## Architectural Support
 
 ### New Architecture Support
 
- * [PR-1847](https://github.com/apache/incubator-nuttx/pull/1847) ARM: Initial
+ * [PR-1847](https://github.com/apache/nuttx/pull/1847) ARM: Initial
  support for ARMV6M to support CortexM0+
 
- * [PR-1397](https://github.com/apache/incubator-nuttx/pull/1379): EOSS3:
+ * [PR-1397](https://github.com/apache/nuttx/pull/1379): EOSS3:
  Initial support for the QuickLogic EOS S3 SoC
 
 ### Architectures With Significant Improvements
 
 #### cxd56xx
 
- * [PR-1753](https://github.com/apache/incubator-nuttx/pull/1753) cxd56xx: Use
+ * [PR-1753](https://github.com/apache/nuttx/pull/1753) cxd56xx: Use
  spinlock in gpioint to improve SMP performance
 
- * [PR-1650](https://github.com/apache/incubator-nuttx/pull/1650) cxd56xx: Use
+ * [PR-1650](https://github.com/apache/nuttx/pull/1650) cxd56xx: Use
  spinlock in rtc to improve SMP performance
 
- * [PR-1621](https://github.com/apache/incubator-nuttx/pull/1621) cxd56xx: Use
+ * [PR-1621](https://github.com/apache/nuttx/pull/1621) cxd56xx: Use
  spinlock in serial to improve SMP performance
 
- * [PR-1569](https://github.com/apache/incubator-nuttx/pull/1569) cxd56xx: Add
+ * [PR-1569](https://github.com/apache/nuttx/pull/1569) cxd56xx: Add
  SMP support to cxd56\_farapi.c
 
- * [PR-1689](https://github.com/apache/incubator-nuttx/pull/1689) cxd56xx: Use
+ * [PR-1689](https://github.com/apache/nuttx/pull/1689) cxd56xx: Use
  spinlock in uart to improve SMP performance
 
 #### ESP32
 
- * [PR-1422](https://github.com/apache/incubator-nuttx/pull/1422) ESP32: Add SPI
+ * [PR-1422](https://github.com/apache/nuttx/pull/1422) ESP32: Add SPI
  driver (Master & Slave)
 
- * [PR-1435](https://github.com/apache/incubator-nuttx/pull/1435) ESP32: Add I2C
+ * [PR-1435](https://github.com/apache/nuttx/pull/1435) ESP32: Add I2C
  driver
 
- * [PR-1491](https://github.com/apache/incubator-nuttx/pull/1491) ESP32: Add SPI
+ * [PR-1491](https://github.com/apache/nuttx/pull/1491) ESP32: Add SPI
  Flash driver
 
- * [PR-1525](https://github.com/apache/incubator-nuttx/pull/1525) ESP32: Add
+ * [PR-1525](https://github.com/apache/nuttx/pull/1525) ESP32: Add
  Ethernet driver
 
- * [PR-1610](https://github.com/apache/incubator-nuttx/pull/1610) ESP32: Improve
+ * [PR-1610](https://github.com/apache/nuttx/pull/1610) ESP32: Improve
  SPI transmision (DMA, IOMUX, software CS)
 
- * [PR-1630](https://github.com/apache/incubator-nuttx/pull/1630) ESP32: Add
+ * [PR-1630](https://github.com/apache/nuttx/pull/1630) ESP32: Add
  support for HW RNG
 
- * [PR-1830](https://github.com/apache/incubator-nuttx/pull/1830) ESP32: Add
+ * [PR-1830](https://github.com/apache/nuttx/pull/1830) ESP32: Add
  Power Management of Force-Sleep
 
- * [PR-1754](https://github.com/apache/incubator-nuttx/pull/1754) ESP32: Add
+ * [PR-1754](https://github.com/apache/nuttx/pull/1754) ESP32: Add
  support for external SPIFLASH
 
- * [PR-1613](https://github.com/apache/incubator-nuttx/pull/1613) ESP32: Add
+ * [PR-1613](https://github.com/apache/nuttx/pull/1613) ESP32: Add
  function for switching CPU from 80MHz to 240MHz
 
 PR-1712 ESP32: Add support for external MMCSD card over SPI
 
 #### IMXRT
 
- * [PR-1868](https://github.com/apache/incubator-nuttx/pull/1868) IMXRT: Add ADC
+ * [PR-1868](https://github.com/apache/nuttx/pull/1868) IMXRT: Add ADC
  driver
 
 #### Kinetis
 
- * [PR-1624](https://github.com/apache/incubator-nuttx/pull/1624) Kinetis:
+ * [PR-1624](https://github.com/apache/nuttx/pull/1624) Kinetis:
  USBHOST improvements to avoid race condition durring freeing for queue head
  structure by using Async Advance Doorbell.
 
@@ -456,77 +456,77 @@ PR-1456 Kinetis K28: Reworked USB driver for setup out data phase
 
 #### NRF52
 
- * [PR-1418](https://github.com/apache/incubator-nuttx/pull/1418) NRF52: Add
+ * [PR-1418](https://github.com/apache/nuttx/pull/1418) NRF52: Add
  Timer and RTC drivers
 
- * [PR-1432](https://github.com/apache/incubator-nuttx/pull/1422) NRF52: Add
+ * [PR-1432](https://github.com/apache/nuttx/pull/1422) NRF52: Add
  timer lowerhalf
 
- * [PR-1635](https://github.com/apache/incubator-nuttx/pull/1635) NRF52: Add
+ * [PR-1635](https://github.com/apache/nuttx/pull/1635) NRF52: Add
  support for RTC event handling
 
- * [PR-1636](https://github.com/apache/incubator-nuttx/pull/1636) NRF52: Add
+ * [PR-1636](https://github.com/apache/nuttx/pull/1636) NRF52: Add
  support for PPI peripheral
 
- * [PR-1681](https://github.com/apache/incubator-nuttx/pull/1681) NRF52: Add
+ * [PR-1681](https://github.com/apache/nuttx/pull/1681) NRF52: Add
  support for GPIOTE task mode
 
- * [PR-1726](https://github.com/apache/incubator-nuttx/pull/1726) NRF52: Extend
+ * [PR-1726](https://github.com/apache/nuttx/pull/1726) NRF52: Extend
  systimer support
 
- * [PR-1773](https://github.com/apache/incubator-nuttx/pull/1773) NRF52: Add ADC
+ * [PR-1773](https://github.com/apache/nuttx/pull/1773) NRF52: Add ADC
  and PWM support
 
- * [PR-1915](https://github.com/apache/incubator-nuttx/pull/1915) NRF52: Add
+ * [PR-1915](https://github.com/apache/nuttx/pull/1915) NRF52: Add
  serial termios support (no flow control)
 
- * [PR-1907](https://github.com/apache/incubator-nuttx/pull/1907) NRF52: Add
+ * [PR-1907](https://github.com/apache/nuttx/pull/1907) NRF52: Add
  basic error handing for i2c in polling mode to support i2ctool. Still not
  handled in DMA mode.
 
- * [PR-1839](https://github.com/apache/incubator-nuttx/pull/1839) NRF52: Add
+ * [PR-1839](https://github.com/apache/nuttx/pull/1839) NRF52: Add
  missing SPI callback register hooks to support drivers like mmcsd
 
- * [PR-1646](https://github.com/apache/incubator-nuttx/pull/1646) NRF52: Better
+ * [PR-1646](https://github.com/apache/nuttx/pull/1646) NRF52: Better
  differentiation between NRF52840 and NRF52832
 
- * [PR-1685](https://github.com/apache/incubator-nuttx/pull/1685) NRF52: Add ARM system reset support. Add UID support.
+ * [PR-1685](https://github.com/apache/nuttx/pull/1685) NRF52: Add ARM system reset support. Add UID support.
 
- * [PR-1674](https://github.com/apache/incubator-nuttx/pull/1674) NRF52: Add LFCLK/HFCLK support for selecting oscillator sources.
+ * [PR-1674](https://github.com/apache/nuttx/pull/1674) NRF52: Add LFCLK/HFCLK support for selecting oscillator sources.
 
 #### RISCV
 
- * [PR-1858](https://github.com/apache/incubator-nuttx/pull/1858) RISCV: Add
+ * [PR-1858](https://github.com/apache/nuttx/pull/1858) RISCV: Add
  missing CSR macros listed in RISC-V spec V1.10.
 
- * [PR-1314](https://github.com/apache/incubator-nuttx/pull/1314) rv32im: Add schedulesigaction.c, SYS\_save\_context handling, skip ECALL
+ * [PR-1314](https://github.com/apache/nuttx/pull/1314) rv32im: Add schedulesigaction.c, SYS\_save\_context handling, skip ECALL
 instruction when calling up\_swint()
 
 #### RX65N
 
- * [PR-1622](https://github.com/apache/incubator-nuttx/pull/1622) RX65N: Add
+ * [PR-1622](https://github.com/apache/nuttx/pull/1622) RX65N: Add
  I2C(RIIC) support
 
- * [PR-1894](https://github.com/apache/incubator-nuttx/pull/1894) RX65N: Add USB
+ * [PR-1894](https://github.com/apache/nuttx/pull/1894) RX65N: Add USB
  device support
 
- * [PR-1899](https://github.com/apache/incubator-nuttx/pull/1899) RX65N: Add DTC
+ * [PR-1899](https://github.com/apache/nuttx/pull/1899) RX65N: Add DTC
  driver
 
 PR-1910 RX65N: Add SPI driver support
 
 #### SAMD5E5
 
- * [PR-1515](https://github.com/apache/incubator-nuttx/pull/1515) SAMD5E5: Add
+ * [PR-1515](https://github.com/apache/nuttx/pull/1515) SAMD5E5: Add
  Watchdog timer support
 
- * [PR-1574](https://github.com/apache/incubator-nuttx/pull/1574) SAMD5E5: Add
+ * [PR-1574](https://github.com/apache/nuttx/pull/1574) SAMD5E5: Add
  USB host support
 
- * [PR-1594](https://github.com/apache/incubator-nuttx/pull/1594) SAMD5E5:
+ * [PR-1594](https://github.com/apache/nuttx/pull/1594) SAMD5E5:
  Freerun timer, oneshot timer and tickless support
 
- * [PR-1816](https://github.com/apache/incubator-nuttx/pull/1816) SAMD5E5: Add
+ * [PR-1816](https://github.com/apache/nuttx/pull/1816) SAMD5E5: Add
  MTD progmem support and NVM USER PAGE IOTCLs
 
 #### SAMA5D2
@@ -543,202 +543,202 @@ PR-1337 S32K: Allow FlexCAN to use to NETDEV\_LATEINIT to handle the case where
 both FlexCAN and ENET are used
 
 #### SIM
- * [PR-1914](https://github.com/apache/incubator-nuttx/pull/1914) SIM: SIGUSR1
+ * [PR-1914](https://github.com/apache/nuttx/pull/1914) SIM: SIGUSR1
  handling now uses NuttX interrupt logic
 
- * [PR-1859](https://github.com/apache/incubator-nuttx/pull/1859) ESIM: Add
+ * [PR-1859](https://github.com/apache/nuttx/pull/1859) ESIM: Add
  host timer and improve the oneshot timer logic
 
- * [PR-1767](https://github.com/apache/incubator-nuttx/pull/1767) SIM: Allow
+ * [PR-1767](https://github.com/apache/nuttx/pull/1767) SIM: Allow
  access to tty interfaces for better termios support
 
- * [PR-1655](https://github.com/apache/incubator-nuttx/pull/1655) SIM: Add
+ * [PR-1655](https://github.com/apache/nuttx/pull/1655) SIM: Add
  support for Linux HCI Socket as a NuttX BLE adapter. Full NuttX BLE stack can
  be run against any Linux Bluetooth adapter in sim.
 
- * [PR-1558](https://github.com/apache/incubator-nuttx/pull/1558) SIM: Add
+ * [PR-1558](https://github.com/apache/nuttx/pull/1558) SIM: Add
  support for Stack Smashing Protector.
 
- * [PR-1392](https://github.com/apache/incubator-nuttx/pull/1392) SIM: Make
+ * [PR-1392](https://github.com/apache/nuttx/pull/1392) SIM: Make
  uClibc++ and libcxx work on sim platform
 
- * [PR-1460](https://github.com/apache/incubator-nuttx/pull/1460) SIM: Call
+ * [PR-1460](https://github.com/apache/nuttx/pull/1460) SIM: Call
  sched\_note\_cpu\_\* when scheduler instrumentation is enabled
 
 #### STM32
 
- * [PR-1865](https://github.com/apache/incubator-nuttx/pull/1865) STM32F4: Add
+ * [PR-1865](https://github.com/apache/nuttx/pull/1865) STM32F4: Add
  support for STM32F412CE fixing I2C2/I2C3 and USART1 alt
 
- * [PR-1506](https://github.com/apache/incubator-nuttx/pull/1506) STM32: Add
+ * [PR-1506](https://github.com/apache/nuttx/pull/1506) STM32: Add
  support for single wire UART push/pull mode
 
- * [PR-1572](https://github.com/apache/incubator-nuttx/pull/1572) STM32F2/F4:
+ * [PR-1572](https://github.com/apache/nuttx/pull/1572) STM32F2/F4:
  Add options for I-Cache and D-Cache to be enabled/disable. Previously they were
  always enabled.
 
- * [PR-1287](https://github.com/apache/incubator-nuttx/pull/1286) STM32F7:
+ * [PR-1287](https://github.com/apache/nuttx/pull/1286) STM32F7:
  Refactor the FMC driver to support STM32F7 family and add support to the
  STM32F46G-DISCO board
 
- * [PR-1275](https://github.com/apache/incubator-nuttx/pull/1275) STM32: Allow
+ * [PR-1275](https://github.com/apache/nuttx/pull/1275) STM32: Allow
  SysTick to be a tickless clock source option
 
- * [PR-1268](https://github.com/apache/incubator-nuttx/pull/1268) STM32: Add
+ * [PR-1268](https://github.com/apache/nuttx/pull/1268) STM32: Add
  support for STM32F412 with UART / SPI / CAN / I2C / DMA
 
- * [PR-1250](https://github.com/apache/incubator-nuttx/pull/1250) STM32L4: Add
+ * [PR-1250](https://github.com/apache/nuttx/pull/1250) STM32L4: Add
  support for booting into DFU mode
 
 ### Bug Fixes
 
 #### ARM
 
- * [PR-1562](https://github.com/apache/incubator-nuttx/pull/1562) ARM: Save
+ * [PR-1562](https://github.com/apache/nuttx/pull/1562) ARM: Save
  tcb-adj\_stack\_size should be saved without tls overhead
 
- * [PR-1900](https://github.com/apache/incubator-nuttx/pull/1900) ARM: Fix false
+ * [PR-1900](https://github.com/apache/nuttx/pull/1900) ARM: Fix false
  reporting for stack usage for unaligned stacks
 
 #### AVR
 
- * [PR-1410](https://github.com/apache/incubator-nuttx/pull/1410) avr: Implement
+ * [PR-1410](https://github.com/apache/nuttx/pull/1410) avr: Implement
  missing double\_t type, CONFIG\_STACK\_ALIGNMENT, linker emulation flags
 
 #### CXD56xx
 
- * [PR-1930](https://github.com/apache/incubator-nuttx/pull/1930) cxd56xx: Fix
+ * [PR-1930](https://github.com/apache/nuttx/pull/1930) cxd56xx: Fix
  handle\_irqreq() in cxd56\_cpupause.c
 
- * [PR-1789](https://github.com/apache/incubator-nuttx/pull/1789) cxd56xx: Fix
+ * [PR-1789](https://github.com/apache/nuttx/pull/1789) cxd56xx: Fix
  deadlock issue in up\_txinit() in SMP mode.
 
- * [PR-1620](https://github.com/apache/incubator-nuttx/pull/1620) cxd56xx: Fix
+ * [PR-1620](https://github.com/apache/nuttx/pull/1620) cxd56xx: Fix
  IRQ control in cxd56\_dmac.c
 
- * [PR-1253](https://github.com/apache/incubator-nuttx/pull/1253) cxd56xx: Fix
+ * [PR-1253](https://github.com/apache/nuttx/pull/1253) cxd56xx: Fix
  audio cxd56\_stop where a deadlock could be hit if the worker thread took too
  long to turn on AMP
 
- * [PR-1950](https://github.com/apache/incubator-nuttx/pull/1950) cxd56xx: Fix
+ * [PR-1950](https://github.com/apache/nuttx/pull/1950) cxd56xx: Fix
  deadlock and tcb corruption in SMP mode
 
 #### ESP32
 
- * [PR-1908](https://github.com/apache/incubator-nuttx/pull/1908) ESP32: Fix
+ * [PR-1908](https://github.com/apache/nuttx/pull/1908) ESP32: Fix
  task signal process preemption
 
- * [PR-1941](https://github.com/apache/incubator-nuttx/pull/1941) ESP32: Fix
+ * [PR-1941](https://github.com/apache/nuttx/pull/1941) ESP32: Fix
  interrupt clearing of edge interrupt due to issuing in masking interrupt state
 
 #### IMXRT
 
- * [PR-1527](https://github.com/apache/incubator-nuttx/pull/1527) IMXRT: Fix
+ * [PR-1527](https://github.com/apache/nuttx/pull/1527) IMXRT: Fix
  kconfig so that IMXRT\_ENET\_NRXBUFFERS can be set
 
- * [PR-1455](https://github.com/apache/incubator-nuttx/pull/1455) IMXRT: Fix
+ * [PR-1455](https://github.com/apache/nuttx/pull/1455) IMXRT: Fix
  auto-negotiation for KSZ8081 PHY
 
 #### Kinetis
 
- * [PR-1273](https://github.com/apache/incubator-nuttx/pull/1273) Kinetis: Fix
+ * [PR-1273](https://github.com/apache/nuttx/pull/1273) Kinetis: Fix
  issue in ethernet driver where buffers were blindly initialized and could cause
  the TX of the MAC to be in a bad state. Also resolves an issue with interrupts
  being throttled in the NVIC.
 
 #### NRF52
 
- * [PR-1928](https://github.com/apache/incubator-nuttx/pull/1928) NRF52: Fix PPI
+ * [PR-1928](https://github.com/apache/nuttx/pull/1928) NRF52: Fix PPI
  group disable and add group clear
 
- * [PR-1885](https://github.com/apache/incubator-nuttx/pull/1885) NRF52: Fix SPI
+ * [PR-1885](https://github.com/apache/nuttx/pull/1885) NRF52: Fix SPI
  driver structures when SPI\_EXCHANGE is not set
 
- * [PR-1799](https://github.com/apache/incubator-nuttx/pull/1799) NRF52: Fix
+ * [PR-1799](https://github.com/apache/nuttx/pull/1799) NRF52: Fix
  SPI\_MASTER entry in kconfig
 
- * [PR-1787](https://github.com/apache/incubator-nuttx/pull/1787) NRF52: Fix
+ * [PR-1787](https://github.com/apache/nuttx/pull/1787) NRF52: Fix
  base address for SPIM{1,2,3}
 
- * [PR-1777](https://github.com/apache/incubator-nuttx/pull/1777) NRF52: Handle
+ * [PR-1777](https://github.com/apache/nuttx/pull/1777) NRF52: Handle
  case where rx or tx buffer could be 0 but data would still be transferred. Also
  error if more than max data is requested.
 
- * [PR-1770](https://github.com/apache/incubator-nuttx/pull/1770) NRF52: Fix bug
+ * [PR-1770](https://github.com/apache/nuttx/pull/1770) NRF52: Fix bug
  where SPI cmddata was not properly mapped for SPIM 0,2,3
 
 #### RISC-V
 
- * [PR-1909](https://github.com/apache/incubator-nuttx/pull/1909) RISC-V: MIE
+ * [PR-1909](https://github.com/apache/nuttx/pull/1909) RISC-V: MIE
  instead of MPIE register was being used in up\_schedule\_sigaction for storing
  interrupt state
 
 #### SIM
 
- * [PR-1903](https://github.com/apache/incubator-nuttx/pull/1903) SIM: Fix
+ * [PR-1903](https://github.com/apache/nuttx/pull/1903) SIM: Fix
  complication issue for WPCAP in Cygwin build
 
- * [PR-1888](https://github.com/apache/incubator-nuttx/pull/1888) SIM: Fix
+ * [PR-1888](https://github.com/apache/nuttx/pull/1888) SIM: Fix
  EOVERFLOW returned when CONFIG\_SIM\_M32 is set
 
- * [PR-1709](https://github.com/apache/incubator-nuttx/pull/1709) SIM: Fix
+ * [PR-1709](https://github.com/apache/nuttx/pull/1709) SIM: Fix
  up\_cpu\_start initialization for macOS with SMP enabled
 
 #### STM32
 
- * [PR-1898](https://github.com/apache/incubator-nuttx/pull/1898) STM32F7: Fixes
+ * [PR-1898](https://github.com/apache/nuttx/pull/1898) STM32F7: Fixes
  data loss bug in UART5 with TX DMA
 
- * [PR-1841](https://github.com/apache/incubator-nuttx/pull/1841) STM32: Remove
+ * [PR-1841](https://github.com/apache/nuttx/pull/1841) STM32: Remove
  broken overdriver support
 
- * [PR-1719](https://github.com/apache/incubator-nuttx/pull/1719) STM32:
+ * [PR-1719](https://github.com/apache/nuttx/pull/1719) STM32:
  Lowputc: Ensure USART is disabled before attempting to configuring it
 
- * [PR-1714](https://github.com/apache/incubator-nuttx/pull/1714) STM32H7: Fix
+ * [PR-1714](https://github.com/apache/nuttx/pull/1714) STM32H7: Fix
  I2C driver interrupt storm
 
- * [PR-1556](https://github.com/apache/incubator-nuttx/pull/1556) STM32: Fix IO
+ * [PR-1556](https://github.com/apache/nuttx/pull/1556) STM32: Fix IO
  compentation support in STM32F7 and remove incorrect reference in STM32F0/L0/G0
 
- * [PR-1529](https://github.com/apache/incubator-nuttx/pull/1529) STM32: Fix
+ * [PR-1529](https://github.com/apache/nuttx/pull/1529) STM32: Fix
  initialization bug in ADC that prevented adc\_reset() from working correctly
 
- * [PR-1561](https://github.com/apache/incubator-nuttx/pull/1561) STM32: Make
+ * [PR-1561](https://github.com/apache/nuttx/pull/1561) STM32: Make
  sure that core over-drive is enabled for all chips that support it and operating
  at 180MHz. Some were enabled at 180MHz but may have not been stable without
  over-drive not configured.
 
- * [PR-1553](https://github.com/apache/incubator-nuttx/pull/1553) STM32F7: Fix
+ * [PR-1553](https://github.com/apache/nuttx/pull/1553) STM32F7: Fix
  possible interrupt blocking in serial TXDMA ISR
 
- * [PR-1544](https://github.com/apache/incubator-nuttx/pull/1544) STM32: Make
+ * [PR-1544](https://github.com/apache/nuttx/pull/1544) STM32: Make
  sure IO compensation cell is configured prior to call to
  rcc\_enableperipherals() causing syscfg is accessed before it is enabled
 
- * [PR-1380](https://github.com/apache/incubator-nuttx/pull/1380) STM32F7: Fix
+ * [PR-1380](https://github.com/apache/nuttx/pull/1380) STM32F7: Fix
  tickless driver where th compare register could be set to a value that has
  just passed preventing expiration
 
- * [PR-1252](https://github.com/apache/incubator-nuttx/pull/1252) STM32L4: Fix
+ * [PR-1252](https://github.com/apache/nuttx/pull/1252) STM32L4: Fix
  48MHz MSI clock selection that could cause boot to hang
 
- * [PR-1310](https://github.com/apache/incubator-nuttx/pull/1310) STM32L4:
+ * [PR-1310](https://github.com/apache/nuttx/pull/1310) STM32L4:
  Configure flash wait states earlier to prevent corruption of execution state
 
- * [PR-1248](https://github.com/apache/incubator-nuttx/pull/1248) STM32L4: Fix
+ * [PR-1248](https://github.com/apache/nuttx/pull/1248) STM32L4: Fix
  oneshot timer so that a minimum period is set otherwise it will never be
  triggered.
 
- * [PR-1247](https://github.com/apache/incubator-nuttx/pull/1247) STM32L47x/8x:
+ * [PR-1247](https://github.com/apache/nuttx/pull/1247) STM32L47x/8x:
  Set additional registers required to place a pin in analog mode
 
- * [PR-1246](https://github.com/apache/incubator-nuttx/pull/1246) STM32L4: Fix
+ * [PR-1246](https://github.com/apache/nuttx/pull/1246) STM32L4: Fix
  issue where clock divider for serial baud rate was not set correctly
 
 #### Miscellaneous
 
- * [PR-1912](https://github.com/apache/incubator-nuttx/pull/1912) Fix
+ * [PR-1912](https://github.com/apache/nuttx/pull/1912) Fix
  up\_interrupt\_contex() in case of SMP - Make sure the operation is atomic in
  case of SMP
 
@@ -746,376 +746,376 @@ both FlexCAN and ENET are used
 
 ### Bug Fixes
 
- * [PR-1896](https://github.com/apache/incubator-nuttx/pull/1896) spi\_xx25xx
+ * [PR-1896](https://github.com/apache/nuttx/pull/1896) spi\_xx25xx
  EEPROM: return the number of bytes written instead of 0 or error
 
- * [PR-1891](https://github.com/apache/incubator-nuttx/pull/1891) serial: Don't
+ * [PR-1891](https://github.com/apache/nuttx/pull/1891) serial: Don't
  mangle PID when ISIG is changed
 
- * [PR-1856](https://github.com/apache/incubator-nuttx/pull/1856) pipe: In case
+ * [PR-1856](https://github.com/apache/nuttx/pull/1856) pipe: In case
  of empty pipe with no writers, return EOF instead of EAGAIN
 
- * [PR-1836](https://github.com/apache/incubator-nuttx/pull/1836) stmpe811: Fix
+ * [PR-1836](https://github.com/apache/nuttx/pull/1836) stmpe811: Fix
  incorrect GPIO interrupt register logic
 
- * [PR-1741](https://github.com/apache/incubator-nuttx/pull/1741) mmcsd\_sdio:
+ * [PR-1741](https://github.com/apache/nuttx/pull/1741) mmcsd\_sdio:
  Properly arm the write completion detection
 
- * [PR-1370](https://github.com/apache/incubator-nuttx/pull/1370) can: Fix
+ * [PR-1370](https://github.com/apache/nuttx/pull/1370) can: Fix
  incorrect usage of nxsem\_getvalue which caused fifo->rx\_sem to increase with
  teach received msg
 
- * [PR-1452](https://github.com/apache/incubator-nuttx/pull/1452) lcd: Fix
+ * [PR-1452](https://github.com/apache/nuttx/pull/1452) lcd: Fix
  memory leak when board\_graphics\_setup fail
 
 
 
 ### New Driver Support
 
- * [PR-1797](https://github.com/apache/incubator-nuttx/pull/1797) leds: WS2812
+ * [PR-1797](https://github.com/apache/nuttx/pull/1797) leds: WS2812
  LED controller (aka Adafruit NeoPixel)
 
- * [PR-1851](https://github.com/apache/incubator-nuttx/pull/1851) kbd: Add
+ * [PR-1851](https://github.com/apache/nuttx/pull/1851) kbd: Add
  support for SolderParty BlackBerry Q10 Keyboard
 
- * [PR-1618](https://github.com/apache/incubator-nuttx/pull/1618) BQ27426 fuel
+ * [PR-1618](https://github.com/apache/nuttx/pull/1618) BQ27426 fuel
  gauge
 
- * [PR-1276](https://github.com/apache/incubator-nuttx/pull/1276) Add support
+ * [PR-1276](https://github.com/apache/nuttx/pull/1276) Add support
  for the ST7735 TFT Controller
 
- * [PR-1233](https://github.com/apache/incubator-nuttx/pull/1233) usbhost: Add
+ * [PR-1233](https://github.com/apache/nuttx/pull/1233) usbhost: Add
  support for CDC-MBIM USB host driver
 
 ### Drivers With Significant Improvements
 
- * [PR-1816](https://github.com/apache/incubator-nuttx/pull/1816) stmpe811: Add
+ * [PR-1816](https://github.com/apache/nuttx/pull/1816) stmpe811: Add
  SPI support for touch screen controller
 
- * [PR-1800](https://github.com/apache/incubator-nuttx/pull/1800) vfs: Add
+ * [PR-1800](https://github.com/apache/nuttx/pull/1800) vfs: Add
  `FIOCLEX/FIONCLEX` ioctl support
 
- * [PR-1798](https://github.com/apache/incubator-nuttx/pull/1798) mmcsd: Allow
+ * [PR-1798](https://github.com/apache/nuttx/pull/1798) mmcsd: Allow
  setting `IDMODE_CLOCK` via kconfig
 
- * [PR-1587](https://github.com/apache/incubator-nuttx/pull/1587) BCH: Delay the
+ * [PR-1587](https://github.com/apache/nuttx/pull/1587) BCH: Delay the
  sector flush to avoid multiple erase/write operations in sequence write
 
- * [PR-1577](https://github.com/apache/incubator-nuttx/pull/1577) rwbuffer:
+ * [PR-1577](https://github.com/apache/nuttx/pull/1577) rwbuffer:
  Avoid allocating memory for the temporary erase buffer by the FTL driver
 
- * [PR-1466](https://github.com/apache/incubator-nuttx/pull/1466) Altair Modem:
+ * [PR-1466](https://github.com/apache/nuttx/pull/1466) Altair Modem:
  Add board specific logic, Fix issue that SPI4 RX frequency violated AC Spec,
  Fix priority of SPI transfer task is too low, Modify timeout value for RX ready
 
- * [PR-1471](https://github.com/apache/incubator-nuttx/pull/1471) ramlog: Add
+ * [PR-1471](https://github.com/apache/nuttx/pull/1471) ramlog: Add
  option to overwrite buffer
 
- * [PR-1547](https://github.com/apache/incubator-nuttx/pull/1547) usbhub: Make
+ * [PR-1547](https://github.com/apache/nuttx/pull/1547) usbhub: Make
  sure to enumerate hubs that report protocol = 1 (High Speed Hub)
 
- * [PR-1374](https://github.com/apache/incubator-nuttx/pull/1374) gpio: Extend
+ * [PR-1374](https://github.com/apache/nuttx/pull/1374) gpio: Extend
  gpio\_pintype\_e for pulldown/up and opendrain
 
- * [PR-1249](https://github.com/apache/incubator-nuttx/pull/1249) bmp280: Add
+ * [PR-1249](https://github.com/apache/nuttx/pull/1249) bmp280: Add
  support for reading temperature
 
- * [PR-1299](https://github.com/apache/incubator-nuttx/pull/1299) mpu60x0: Add
+ * [PR-1299](https://github.com/apache/nuttx/pull/1299) mpu60x0: Add
  I2C support for the MPU60x0 sensor driver
 
- * [PR-1325](https://github.com/apache/incubator-nuttx/pull/1325) can: expose
+ * [PR-1325](https://github.com/apache/nuttx/pull/1325) can: expose
  NART/ABOM and RTR settings via ioctls
 
- * [PR-1520](https://github.com/apache/incubator-nuttx/pull/1520) note: Move
+ * [PR-1520](https://github.com/apache/nuttx/pull/1520) note: Move
  note driver from syslog to drivers/note
 
- * [PR-1288](https://github.com/apache/incubator-nuttx/pull/1288) / PR-1449
+ * [PR-1288](https://github.com/apache/nuttx/pull/1288) / PR-1449
  note: Add sched\_note\_syscall\_enter/leave hooks for syscall instrumentation
 
- * [PR-1259](https://github.com/apache/incubator-nuttx/pull/1259) note: Add
+ * [PR-1259](https://github.com/apache/nuttx/pull/1259) note: Add
  buffering support for syscall instrumentation
 
- * [PR-1256](https://github.com/apache/incubator-nuttx/pull/1256) note: Add
+ * [PR-1256](https://github.com/apache/nuttx/pull/1256) note: Add
  hooks for note driver for interrupt instrumentation
 
 ## Board Support
 
 ### **Significant Improvements**
 
- * [PR-1618](https://github.com/apache/incubator-nuttx/pull/1618) metro-m4: Add
+ * [PR-1618](https://github.com/apache/nuttx/pull/1618) metro-m4: Add
  support for: SmartFS initialization, AT24 EEPROM, GPIO dev, BQ27426 gauge
  initialization
 
- * [PR-1727](https://github.com/apache/incubator-nuttx/pull/1729) b-g474e-dpow1:
+ * [PR-1727](https://github.com/apache/nuttx/pull/1729) b-g474e-dpow1:
  Add support for FLASH bootloader
 
- * [PR-1683](https://github.com/apache/incubator-nuttx/pull/1683) cxd56xx: Add
+ * [PR-1683](https://github.com/apache/nuttx/pull/1683) cxd56xx: Add
  wifi\_smp configuration
 
- * [PR-1668](https://github.com/apache/incubator-nuttx/pull/1668) sim: Add new
+ * [PR-1668](https://github.com/apache/nuttx/pull/1668) sim: Add new
  configuration for SMP
 
- * [PR-1644](https://github.com/apache/incubator-nuttx/pull/1644)
+ * [PR-1644](https://github.com/apache/nuttx/pull/1644)
  stm32f746g-disco: Move serial console from USART6 to USART1 which is attached
  to the USB virtual COM port.
 
- * [PR-1464](https://github.com/apache/incubator-nuttx/pull/1464) cxd56xx: Add
+ * [PR-1464](https://github.com/apache/nuttx/pull/1464) cxd56xx: Add
  new GNSS functions, support for lower PWM frequency,
  CONFIG\_CPUFREQ\_RELEASE\_LOCK, high speed ADC, HPADC input gain configuration,
  eMMC device, frame buffer support
 
- * [PR-1405](https://github.com/apache/incubator-nuttx/pull/1405)
+ * [PR-1405](https://github.com/apache/nuttx/pull/1405)
  stm32f4discovery: Add ELF support to wifi configuration
 
- * [PR-1402](https://github.com/apache/incubator-nuttx/pull/1402) imxrt1060: Add
+ * [PR-1402](https://github.com/apache/nuttx/pull/1402) imxrt1060: Add
  buttons support to iMXRT1060
 
- * [PR-1590](https://github.com/apache/incubator-nuttx/pull/1590) sim: Add
+ * [PR-1590](https://github.com/apache/nuttx/pull/1590) sim: Add
  duktape configuration
 
- * [PR-1532](https://github.com/apache/incubator-nuttx/pull/1532) sim: Add
+ * [PR-1532](https://github.com/apache/nuttx/pull/1532) sim: Add
  cromfs configuration
 
- * [PR-1335](https://github.com/apache/incubator-nuttx/pull/1335) cxd56xx:
+ * [PR-1335](https://github.com/apache/nuttx/pull/1335) cxd56xx:
  Enable basic snapshop camera example
 
 ### New Board Support
 
- * [PR-1664](https://github.com/apache/incubator-nuttx/pull/1664) NRF52: Add
+ * [PR-1664](https://github.com/apache/nuttx/pull/1664) NRF52: Add
  support for NRF52832 MakerDiary MDK board
 
- * [PR-1633](https://github.com/apache/incubator-nuttx/pull/1633) NRF52: Add
+ * [PR-1633](https://github.com/apache/nuttx/pull/1633) NRF52: Add
  support for Sparkfun NRF52832 Breakout Board
 
- * [PR-1728](https://github.com/apache/incubator-nuttx/pull/1728) SAMA5D27: Add
+ * [PR-1728](https://github.com/apache/nuttx/pull/1728) SAMA5D27: Add
  support for Giant Board
 
- * [PR-1397](https://github.com/apache/incubator-nuttx/pull/1397) EOSS3: Initial
+ * [PR-1397](https://github.com/apache/nuttx/pull/1397) EOSS3: Initial
  support for the QuickLogic EOS S3 SoC QuickFeather board
 
- * [PR-1268](https://github.com/apache/incubator-nuttx/pull/1268) STM32: Add
+ * [PR-1268](https://github.com/apache/nuttx/pull/1268) STM32: Add
  support for nucleo-f412zg board
 
 ## File System
 
 ### **Bug Fixes**
 
- * [PR-1796](https://github.com/apache/incubator-nuttx/pull/1796) vfs: Fix
+ * [PR-1796](https://github.com/apache/nuttx/pull/1796) vfs: Fix
  memory leak calling `pseudorename`
 
- * [PR-1794](https://github.com/apache/incubator-nuttx/pull/1794) vfs: Fix issue
+ * [PR-1794](https://github.com/apache/nuttx/pull/1794) vfs: Fix issue
  where opendir would remove the trailing whitespace or /
 
- * [PR-1793](https://github.com/apache/incubator-nuttx/pull/1793) vfs: Make sure
+ * [PR-1793](https://github.com/apache/nuttx/pull/1793) vfs: Make sure
  that rename of mount point uses pseudorename. Previously mv on a mountpoint
  would return err 88.
 
- * [PR-1737](https://github.com/apache/incubator-nuttx/pull/1737) vfs: reuse
+ * [PR-1737](https://github.com/apache/nuttx/pull/1737) vfs: reuse
  file\_dup2 direction in file\_dup to prevent segfault issue
 
- * [PR-1490](https://github.com/apache/incubator-nuttx/pull/1490) Ensure that
+ * [PR-1490](https://github.com/apache/nuttx/pull/1490) Ensure that
  filesystems can all support paths that end with '/'
 
- * [PR-1546](https://github.com/apache/incubator-nuttx/pull/1546) ROMFS: Fix
+ * [PR-1546](https://github.com/apache/nuttx/pull/1546) ROMFS: Fix
  issue with how hard links are followed for ROMFS
 
- * [PR-1442](https://github.com/apache/incubator-nuttx/pull/1442) SmartFS: Fix
+ * [PR-1442](https://github.com/apache/nuttx/pull/1442) SmartFS: Fix
  file size corruption when opening with overwriting mode
 
- * [PR-1431](https://github.com/apache/incubator-nuttx/pull/1431) nxffs: Fix
+ * [PR-1431](https://github.com/apache/nuttx/pull/1431) nxffs: Fix
  scan good block slowly and scan an invalid block
 
 PR-1295 fs: for setfd correct the return value
 
 ### **Significant Improvements**
 
- * [PR-1554](https://github.com/apache/incubator-nuttx/pull/1554) CROMFS: Add
+ * [PR-1554](https://github.com/apache/nuttx/pull/1554) CROMFS: Add
  support for hard links
 
- * [PR-1499](https://github.com/apache/incubator-nuttx/pull/1499) FAT: Add
+ * [PR-1499](https://github.com/apache/nuttx/pull/1499) FAT: Add
  support for UTF8 long filename
 
- * [PR-1479](https://github.com/apache/incubator-nuttx/pull/1479) vfs: Add file
+ * [PR-1479](https://github.com/apache/nuttx/pull/1479) vfs: Add file
  descriptor based events support eventfd()
 
- * [PR-1582](https://github.com/apache/incubator-nuttx/pull/1482) vfs: Add
+ * [PR-1582](https://github.com/apache/nuttx/pull/1482) vfs: Add
  epoll\_create1() support
 
- * [PR-1579](https://github.com/apache/incubator-nuttx/pull/1579) vfs: Do not
+ * [PR-1579](https://github.com/apache/nuttx/pull/1579) vfs: Do not
  check CONFIG\_NFILE\_STREAMS for mkdir/rename/rmdir/fs\_unlink
 
- * [PR-1355](https://github.com/apache/incubator-nuttx/pull/1355) vfs: Implement
+ * [PR-1355](https://github.com/apache/nuttx/pull/1355) vfs: Implement
  statvfs and fstatvfs
 
- * [PR-1323](https://github.com/apache/incubator-nuttx/pull/1323) vfs: Add
+ * [PR-1323](https://github.com/apache/nuttx/pull/1323) vfs: Add
  chmod/fchmod/utimes function prototypes
 
 ## Networking
 
 ### **Bug Fixes**
 
- * [PR-1267](https://github.com/apache/incubator-nuttx/pull/1267) SocketCAN:
+ * [PR-1267](https://github.com/apache/nuttx/pull/1267) SocketCAN:
  When timestamped frame was received while in CAN2.0B mode the frame got dropped.
 
- * [PR-1446](https://github.com/apache/incubator-nuttx/pull/1446) usrsock: Fix
+ * [PR-1446](https://github.com/apache/nuttx/pull/1446) usrsock: Fix
  recv() cannot peek data
 
 ### **Significant Improvements**
 
- * [PR-1666](https://github.com/apache/incubator-nuttx/pull/1666) Bluetooth:
+ * [PR-1666](https://github.com/apache/nuttx/pull/1666) Bluetooth:
  Bluetooth sockets now use Linux sockaddr types of sockaddr\_l2 sockaddr\_hci
  sockaddr\_rc. There are slight breaking changes here that may require
  applications to be updated, but this brings the interface inline with Linux.
 
- * [PR-1581](https://github.com/apache/incubator-nuttx/pull/1581) Socket: Add
+ * [PR-1581](https://github.com/apache/nuttx/pull/1581) Socket: Add
  SOCK\_CLOEXEC/SOCK\_NONBLOCK support
 
- * [PR-1443](https://github.com/apache/incubator-nuttx/pull/1443) usrsock: Add
+ * [PR-1443](https://github.com/apache/nuttx/pull/1443) usrsock: Add
  flag argument to sendto/recvfrom interface in usrsock
 
- * [PR-1238](https://github.com/apache/incubator-nuttx/pull/1238) SocketCAN: Add
+ * [PR-1238](https://github.com/apache/nuttx/pull/1238) SocketCAN: Add
  support for SocketCAN interface API
 
 ## Applications
 
 ### **Significant Improvements**
 
- * [PR-409](https://github.com/apache/incubator-nuttx-apps/pull/409) wamr:
+ * [PR-409](https://github.com/apache/nuttx-apps/pull/409) wamr:
  Update version to 09-29-2020 that supports NuttX directly and remove patches
 
- * [PR-407](https://github.com/apache/incubator-nuttx-apps/pull/407) ipcfg: Add
+ * [PR-407](https://github.com/apache/nuttx-apps/pull/407) ipcfg: Add
  IPv4 configuration file access helper
 
- * [PR-406](https://github.com/apache/incubator-nuttx-apps/pull/406) wamr: Add
+ * [PR-406](https://github.com/apache/nuttx-apps/pull/406) wamr: Add
  configs for heap pool and custom name sections
 
- * [PR-404](https://github.com/apache/incubator-nuttx-apps/pull/404) timer: Add
+ * [PR-404](https://github.com/apache/nuttx-apps/pull/404) timer: Add
  supplying timer dev path to example
 
- * [PR-403](https://github.com/apache/incubator-nuttx-apps/pull/402)
+ * [PR-403](https://github.com/apache/nuttx-apps/pull/402)
  nxplayer/nxrecorder: Add channel map support
 
- * [PR-396](https://github.com/apache/incubator-nuttx-apps/pull/396) wamr: Add
+ * [PR-396](https://github.com/apache/nuttx-apps/pull/396) wamr: Add
  missing options to kconfig
 
- * [PR-395](https://github.com/apache/incubator-nuttx-apps/pull/395) dhcpc: Try
+ * [PR-395](https://github.com/apache/nuttx-apps/pull/395) dhcpc: Try
  to get hostname via syscall first
 
- * [PR-391](https://github.com/apache/incubator-nuttx-apps/pull/391) wapi: Add
+ * [PR-391](https://github.com/apache/nuttx-apps/pull/391) wapi: Add
  option to assocated directly via bssid
 
- * [PR-390](https://github.com/apache/incubator-nuttx-apps/pull/390) wapi: App
+ * [PR-390](https://github.com/apache/nuttx-apps/pull/390) wapi: App
  option to scan partial channel
 
- * [PR-387](https://github.com/apache/incubator-nuttx-apps/pull/387) wamr: Add
+ * [PR-387](https://github.com/apache/nuttx-apps/pull/387) wamr: Add
  support for WAMR web assembly interpreter
 
- * [PR-337](https://github.com/apache/incubator-nuttx-apps/pull/337) docs:
+ * [PR-337](https://github.com/apache/nuttx-apps/pull/337) docs:
  Convert all README files to markdown
 
- * [PR-333](https://github.com/apache/incubator-nuttx-apps/pull/333) webclient:
+ * [PR-333](https://github.com/apache/nuttx-apps/pull/333) webclient:
  Add hooks for TLS, extra request headers, PUT method, report status code,
  improved error handling
 
- * [PR-329](https://github.com/apache/incubator-nuttx-apps/pull/329) gpio: Add
+ * [PR-329](https://github.com/apache/nuttx-apps/pull/329) gpio: Add
  support for new GPIO pin types
 
- * [PR-317](https://github.com/apache/incubator-nuttx-apps/pull/317) nshlib:
+ * [PR-317](https://github.com/apache/nuttx-apps/pull/317) nshlib:
  Call symlink if user pass -s for ln command
 
- * [PR-315](https://github.com/apache/incubator-nuttx-apps/pull/315) c++:
+ * [PR-315](https://github.com/apache/nuttx-apps/pull/315) c++:
  Support uClibc++ and libcxx in examples/testing
 
- * [PR-314](https://github.com/apache/incubator-nuttx-apps/pull/314) camera: Add
+ * [PR-314](https://github.com/apache/nuttx-apps/pull/314) camera: Add
  a simple camera snapshot example
 
- * [PR-378](https://github.com/apache/incubator-nuttx-apps/pull/378) wasm3:
+ * [PR-378](https://github.com/apache/nuttx-apps/pull/378) wasm3:
  Initial WebAssembly runtime support
 
- * [PR-374](https://github.com/apache/incubator-nuttx-apps/pull/374) bluetooth:
+ * [PR-374](https://github.com/apache/nuttx-apps/pull/374) bluetooth:
  Use the new l2cap socket address type
 
- * [PR-373](https://github.com/apache/incubator-nuttx-apps/pull/373) duktape:
+ * [PR-373](https://github.com/apache/nuttx-apps/pull/373) duktape:
  Add duktape to global search path so it can be used as a library
 
- * [PR-372](https://github.com/apache/incubator-nuttx-apps/pull/372) quickjs:
+ * [PR-372](https://github.com/apache/nuttx-apps/pull/372) quickjs:
  Add support for QuickJS interpreter
 
- * [PR-367](https://github.com/apache/incubator-nuttx-apps/pull/367) nsh: Accept
+ * [PR-367](https://github.com/apache/nuttx-apps/pull/367) nsh: Accept
  the command line arguments like sh
 
- * [PR-365](https://github.com/apache/incubator-nuttx-apps/pull/365) duktape:
+ * [PR-365](https://github.com/apache/nuttx-apps/pull/365) duktape:
  Add console, print, alert support
 
- * [PR-364](https://github.com/apache/incubator-nuttx-apps/pull/364) cu:
+ * [PR-364](https://github.com/apache/nuttx-apps/pull/364) cu:
  Refactor cu and add support for "-c" to disable \\n to \\r\\n conversion
 
- * [PR-362](https://github.com/apache/incubator-nuttx-apps/pull/362) libuv: Add
+ * [PR-362](https://github.com/apache/nuttx-apps/pull/362) libuv: Add
  support for libuv library
 
- * [PR-352](https://github.com/apache/incubator-nuttx-apps/pull/352) duktape:
+ * [PR-352](https://github.com/apache/nuttx-apps/pull/352) duktape:
  Add initial support for duktape
 
- * [PR-346](https://github.com/apache/incubator-nuttx-apps/pull/364) wget:
+ * [PR-346](https://github.com/apache/nuttx-apps/pull/364) wget:
  Enable URL from command line, can be used with ifup, hooks for HTTPS
 
- * [PR-302](https://github.com/apache/incubator-nuttx-apps/pull/302) lvgl: Use
+ * [PR-302](https://github.com/apache/nuttx-apps/pull/302) lvgl: Use
  the latest version 7.0.2
 
- * [PR-300](https://github.com/apache/incubator-nuttx-apps/pull/300) note: Add
+ * [PR-300](https://github.com/apache/nuttx-apps/pull/300) note: Add
  support for decoding interrupt and syscall instrumentation
 
- * [PR-299](https://github.com/apache/incubator-nuttx-apps/pull/299) nxrecorder:
+ * [PR-299](https://github.com/apache/nuttx-apps/pull/299) nxrecorder:
  Add O\_TRUNC when creating a file
 
- * [PR-296](https://github.com/apache/incubator-nuttx-apps/pull/296) bmp280: Add
+ * [PR-296](https://github.com/apache/nuttx-apps/pull/296) bmp280: Add
  support for BMP180 to BMP280 application
 
- * [PR-294](https://github.com/apache/incubator-nuttx-apps/pull/294) can: Add
+ * [PR-294](https://github.com/apache/nuttx-apps/pull/294) can: Add
  cansend and candump utilities for interacting with SocketCAN
 
 ### Bug Fixes
 
- * [PR-411](https://github.com/apache/incubator-nuttx-apps/pull/411) wgetjson:
+ * [PR-411](https://github.com/apache/nuttx-apps/pull/411) wgetjson:
  Fix build breakage
 
- * [PR-405](https://github.com/apache/incubator-nuttx-apps/pull/405) nxplayer:
+ * [PR-405](https://github.com/apache/nuttx-apps/pull/405) nxplayer:
  Fix missing "%d" in a sscanf call
 
- * [PR-400](https://github.com/apache/incubator-nuttx-apps/pull/400) dhcpc:
+ * [PR-400](https://github.com/apache/nuttx-apps/pull/400) dhcpc:
  Handle case where gethostname() might be empty
 
- * [PR-399](https://github.com/apache/incubator-nuttx-apps/pull/399) build: Fix
+ * [PR-399](https://github.com/apache/nuttx-apps/pull/399) build: Fix
  build system issue where compiler would only compile first assembly file
 
- * [PR-393](https://github.com/apache/incubator-nuttx-apps/pull/393) build: Fix
+ * [PR-393](https://github.com/apache/nuttx-apps/pull/393) build: Fix
  build system issue where ARCHCPUFLAGS in cxx command was lost
 
- * [PR-392](https://github.com/apache/incubator-nuttx-apps/pull/392) wapi: Make
+ * [PR-392](https://github.com/apache/nuttx-apps/pull/392) wapi: Make
  wapi more robust in failure cases
 
- * [PR-383](https://github.com/apache/incubator-nuttx-apps/pull/383) ntpclient:
+ * [PR-383](https://github.com/apache/nuttx-apps/pull/383) ntpclient:
  Fix NTP daemon state in case of DNS failure
 
- * [PR-344](https://github.com/apache/incubator-nuttx-apps/pull/344) gs2200m:
+ * [PR-344](https://github.com/apache/nuttx-apps/pull/344) gs2200m:
  Fix freeing of uninitialized memory
 
- * [PR-335](https://github.com/apache/incubator-nuttx-apps/pull/335) ntp: Fix
+ * [PR-335](https://github.com/apache/nuttx-apps/pull/335) ntp: Fix
  malformated authentication headers in NTP packet
 
- * [PR-331](https://github.com/apache/incubator-nuttx-apps/pull/331) telnetd:
+ * [PR-331](https://github.com/apache/nuttx-apps/pull/331) telnetd:
  Fix buffer overflow issue clearing socket address
 
- * [PR-312](https://github.com/apache/incubator-nuttx-apps/pull/312) build: Make
+ * [PR-312](https://github.com/apache/nuttx-apps/pull/312) build: Make
  sure to include incdir when running make export
 
- * [PR-377](https://github.com/apache/incubator-nuttx-apps/pull/377) readline:
+ * [PR-377](https://github.com/apache/nuttx-apps/pull/377) readline:
  Fix stack overflow when application name is too long
 
- * [PR-359](https://github.com/apache/incubator-nuttx-apps/pull/259) nshlib: Fix
+ * [PR-359](https://github.com/apache/nuttx-apps/pull/259) nshlib: Fix
  memory corrupt in nsh\_parse if pthread\_create() failed
 
- * [PR-354](https://github.com/apache/incubator-nuttx-apps/pull/354) dhcpd: Fix
+ * [PR-354](https://github.com/apache/nuttx-apps/pull/354) dhcpd: Fix
  member name for "ds\_pid"
 
 ## Security Issues Fixed In This Release
@@ -1139,9 +1139,9 @@ With this:
 
 include $(APPDIR)/Make.defs
 
-See  * [PR-326](https://github.com/apache/incubator-nuttx-apps/pull/326), git
+See  * [PR-326](https://github.com/apache/nuttx-apps/pull/326), git
 commit #
-`[deaa6c5b7bf8445b4a300691525f60aa506be0d7](https://github.com/apache/incubator-nuttx-apps/commit/deaa6c5b7bf8445b4a300691525f60aa506be0d7)`
+`[deaa6c5b7bf8445b4a300691525f60aa506be0d7](https://github.com/apache/nuttx-apps/commit/deaa6c5b7bf8445b4a300691525f60aa506be0d7)`
 in the NuttX 'apps' repository.
 
 ### Custom Boards Don't Need `ARCHINCLUDES` and `ARCHXXINCLUDES` Definitions
@@ -1166,14 +1166,14 @@ In case your `scripts/Make.defs` uses different names, such as `ARCHINCLUDESXX`
 instead of `ARCHXXINCLUDES`, you'll need to find all uses of that variable and
 update them to use `ARCHXXINCLUDES`.
 
-See  * [PR-1396](https://github.com/apache/incubator-nuttx/pull/1396), git
+See  * [PR-1396](https://github.com/apache/nuttx/pull/1396), git
 commit
-#[d32e9c38dfb0659a7f3c0cf586ba1584cd7eb3d6](https://github.com/apache/incubator-nuttx/commit/d32e9c38dfb0659a7f3c0cf586ba1584cd7eb3d6)
+#[d32e9c38dfb0659a7f3c0cf586ba1584cd7eb3d6](https://github.com/apache/nuttx/commit/d32e9c38dfb0659a7f3c0cf586ba1584cd7eb3d6)
 in the main NuttX repository.
 
-See also  * [PR-1399](https://github.com/apache/incubator-nuttx/pull/1399), git
+See also  * [PR-1399](https://github.com/apache/nuttx/pull/1399), git
 commit
-#[6abd03d53ff9164fb17ea4aca701a49fbbf751c0](https://github.com/apache/incubator-nuttx/commit/6abd03d53ff9164fb17ea4aca701a49fbbf751c0).
+#[6abd03d53ff9164fb17ea4aca701a49fbbf751c0](https://github.com/apache/nuttx/commit/6abd03d53ff9164fb17ea4aca701a49fbbf751c0).
 
 ### Custom Boards Don't Need `HOSTCC` and `HOSTCFLAGS` Definitions
 
@@ -1207,9 +1207,9 @@ Also, you may override these definitions for a single run by providing them on
 the make command line. This is useful if, for example, you wish to build debug
 versions of these host binaries: define HOSTCFLAGS with -g on the command line.
 
-See  * [PR-1398](https://github.com/apache/incubator-nuttx/pull/1398), git
+See  * [PR-1398](https://github.com/apache/nuttx/pull/1398), git
 commit
-#[ee875b2a260cb4cc532b8ca303c2515e24c39b4e](https://github.com/apache/incubator-nuttx/commit/ee875b2a260cb4cc532b8ca303c2515e24c39b4e)
+#[ee875b2a260cb4cc532b8ca303c2515e24c39b4e](https://github.com/apache/nuttx/commit/ee875b2a260cb4cc532b8ca303c2515e24c39b4e)
 in the main NuttX repository.
 
 ### Removal of Unused `ARCHCCVERSION` and `ARCHCCMAJOR`
@@ -1227,9 +1227,9 @@ ARCHCCVERSION = ${shell $(CC) -v 2>&1 | sed -n '/^gcc version/p' | sed -e
 's/^gcc version \\(\[0-9\\.\]\\)/\\1/g' -e 's/\[-\\ \].\*//g' -e '1q'}
 ARCHCCMAJOR = ${shell echo $(ARCHCCVERSION) | cut -d'.' -f1}
 
-See  * [PR-1344](https://github.com/apache/incubator-nuttx/pull/1344), git
+See  * [PR-1344](https://github.com/apache/nuttx/pull/1344), git
 commit
-#[f5311de6b42466ab5c6ef299dab0ecc417131bbe](https://github.com/apache/incubator-nuttx/commit/f5311de6b42466ab5c6ef299dab0ecc417131bbe)
+#[f5311de6b42466ab5c6ef299dab0ecc417131bbe](https://github.com/apache/nuttx/commit/f5311de6b42466ab5c6ef299dab0ecc417131bbe)
 in the main NuttX repository.
 
 ### Custom Boards May Not Need `EXTRA_LIBS` and `EXTRA_LIBPATHS` Definitions
@@ -1253,9 +1253,9 @@ additional needed libraries and paths not present in
 `arch/*/src/*/Toolchain.defs`, remove any redundant definitions and change the
 assignment '`=`' to '`+=`'.
 
-See  * [PR-1404](https://github.com/apache/incubator-nuttx/pull/1404), git
+See  * [PR-1404](https://github.com/apache/nuttx/pull/1404), git
 commit
-#[4910d43ab0fc360dbddb1f8a31db2a3ee383b46d](https://github.com/apache/incubator-nuttx/commit/4910d43ab0fc360dbddb1f8a31db2a3ee383b46d)
+#[4910d43ab0fc360dbddb1f8a31db2a3ee383b46d](https://github.com/apache/nuttx/commit/4910d43ab0fc360dbddb1f8a31db2a3ee383b46d)
 in the main NuttX repository.
 
 ### Custom Boards May Not Need CC, CXX, CPP, LD, STRIP, AR, NM, OBJCOPY, and
@@ -1285,9 +1285,9 @@ You may want to do one of the following:
 from the definitions in `arch/*/src/*/Toolchain.defs`, leave them as-is and they
 will take precedence.
 
-See  * [PR-1426](https://github.com/apache/incubator-nuttx/pull/1426), git
+See  * [PR-1426](https://github.com/apache/nuttx/pull/1426), git
 commit
-#[b329e2377dd8816f37ad0408279926829efdf85d](https://github.com/apache/incubator-nuttx/commit/b329e2377dd8816f37ad0408279926829efdf85d)
+#[b329e2377dd8816f37ad0408279926829efdf85d](https://github.com/apache/nuttx/commit/b329e2377dd8816f37ad0408279926829efdf85d)
 in the main NuttX repository.
 
 ### Consolidated ARCROSSDEV and CROSSDEV
@@ -1297,7 +1297,7 @@ The `ARCROSSDEV` and `CROSSDEV` variables always had identical values. Therefore
 NuttX have been updated, but if you are building NuttX for a custom board, you
 may need to update your board's build scripts to use the `CROSSDEV` variable.
 
-See  * [PR-1439](https://github.com/apache/incubator-nuttx/pull/1439), git
+See  * [PR-1439](https://github.com/apache/nuttx/pull/1439), git
 commit
-#[5efa93ec26fd8a3fd85b24a2008bb743f96027fb](https://github.com/apache/incubator-nuttx/commit/5efa93ec26fd8a3fd85b24a2008bb743f96027fb)
+#[5efa93ec26fd8a3fd85b24a2008bb743f96027fb](https://github.com/apache/nuttx/commit/5efa93ec26fd8a3fd85b24a2008bb743f96027fb)
 in the main NuttX repository.

--- a/_releases/10.1.0.md
+++ b/_releases/10.1.0.md
@@ -62,882 +62,882 @@ limitations under the License.
 ## Major Changes to Core OS
 
 ### New Features
-* [#2324](https://github.com/apache/incubator-nuttx/pull/2324) audio: libsamplerate: add initial audio Sample Rate Converter
-* [#2820](https://github.com/apache/incubator-nuttx/pull/2820) arch, boards, drivers, include, sched, wireless: Change spinlock APIs.
-* [#2885](https://github.com/apache/incubator-nuttx/pull/2885) Ensure the kernel component don't call userspace API
+* [#2324](https://github.com/apache/nuttx/pull/2324) audio: libsamplerate: add initial audio Sample Rate Converter
+* [#2820](https://github.com/apache/nuttx/pull/2820) arch, boards, drivers, include, sched, wireless: Change spinlock APIs.
+* [#2885](https://github.com/apache/nuttx/pull/2885) Ensure the kernel component don't call userspace API
 
 ### Bug Fixes
-* [#1852](https://github.com/apache/incubator-nuttx/pull/1852) sysconf: add _SC_PAGESIZE sysconf support
-* [#1922](https://github.com/apache/incubator-nuttx/pull/1922) sched: nxtask_start should call entry point directly for kernel thread
-* [#1994](https://github.com/apache/incubator-nuttx/pull/1994) libc: Don't fclose and fopen file in freopen
-* [#2005](https://github.com/apache/incubator-nuttx/pull/2005) Fix note_syscall_leave_s to avoid unaligned access
-* [#2043](https://github.com/apache/incubator-nuttx/pull/2043) sched: Add SCHED_INSTRUMENTATION_HIRES support
-* [#2044](https://github.com/apache/incubator-nuttx/pull/2044) sched: Add note_syscall args support
-* [#2071](https://github.com/apache/incubator-nuttx/pull/2071) pollnotify: we should send poll events before semaphore incrementes.
-* [#2076](https://github.com/apache/incubator-nuttx/pull/2076) libc: math: Make this friendly with libcxx
-* [#2111](https://github.com/apache/incubator-nuttx/pull/2111) LIBCXX related fixes
-* [#2147](https://github.com/apache/incubator-nuttx/pull/2147) sched: Use nx_close() inside OS
-* [#2176](https://github.com/apache/incubator-nuttx/pull/2176) syscall/syscall.csv: Increase number of arguments for prctl()
-* [#2204](https://github.com/apache/incubator-nuttx/pull/2204) sched: irq: Fix enter_critical_section() in an irq handler for SMP
-* [#2218](https://github.com/apache/incubator-nuttx/pull/2218) sched: signal.h: fix compile failed when open TTY_SIGINT
-* [#2229](https://github.com/apache/incubator-nuttx/pull/2229) sched/sched/sched_waitid.c: Allow WNOHANG
-* [#2236](https://github.com/apache/incubator-nuttx/pull/2236) sched/task/task_exithook.c: Remove a redundant assignment
-* [#2243](https://github.com/apache/incubator-nuttx/pull/2243) libcxx: Update [0001-libcxx-Port-to-NuttX-https-nuttx.apache.org](http://0001-libcxx-Port-to-NuttX-https-nuttx.apache.org)-RTOS.patch
-* [#2255](https://github.com/apache/incubator-nuttx/pull/2255) sys/epoll: sync the epoll define with linux
-* [#2256](https://github.com/apache/incubator-nuttx/pull/2256) unistd/sched_sporadic: correct the disable value
-* [#2261](https://github.com/apache/incubator-nuttx/pull/2261) sched/timer: add support of CLOCK_MONOTONIC
-* [#2262](https://github.com/apache/incubator-nuttx/pull/2262) sched/init: init the default home directory to environment
-* [#2285](https://github.com/apache/incubator-nuttx/pull/2285) libc/stdlib: Fix range check in strtoul(l)
-* [#2326](https://github.com/apache/incubator-nuttx/pull/2326) libc: Enhance getopt function
-* [#2407](https://github.com/apache/incubator-nuttx/pull/2407) libc: machine: arch: Support armv8-m relocation
-* [#2418](https://github.com/apache/incubator-nuttx/pull/3447) libc: Change OK/ERROR from macro to enum
-* [#2420](https://github.com/apache/incubator-nuttx/pull/2420) sched/signal: Remove redundant checks
-* [#2437](https://github.com/apache/incubator-nuttx/pull/2765) sched/sched/sched_waitpid.c: Fix return value
-* [#2449](https://github.com/apache/incubator-nuttx/pull/2449) mm/circbuf: fix the problem of dividing by zero
-* [#2450](https://github.com/apache/incubator-nuttx/pull/2450) unistd/getopt: remove number of arguments limit
-* [#2451](https://github.com/apache/incubator-nuttx/pull/2451) libc: pthread_mutexattr_getprotocol: modify prototype
-* [#2455](https://github.com/apache/incubator-nuttx/pull/2455) sched/sched/sched_waitpid.c: Discard the correct child entry
-* [#2475](https://github.com/apache/incubator-nuttx/pull/2475) sched/sched_waitid.c: Fix two bugs when CONFIG_SCHED_CHILD_STATUS is enabled
-* [#2487](https://github.com/apache/incubator-nuttx/pull/2487) sched: clock/time: add CLOCK_BOOTTIME definition
-* [#2492](https://github.com/apache/incubator-nuttx/pull/2492) procfs: make array const to reduce memory use
-* [#2494](https://github.com/apache/incubator-nuttx/pull/2494) sched: Fix SMP
-* [#2509](https://github.com/apache/incubator-nuttx/pull/2509) libc: net: implement ether_aton/ether_aton_r
-* [#2517](https://github.com/apache/incubator-nuttx/pull/2517) sched: spinlock: Introduce SP_WFE() and SP_SEV()
-* [#2518](https://github.com/apache/incubator-nuttx/pull/2518) sched: Don't forward gettid to getpid directly
-* [#2530](https://github.com/apache/incubator-nuttx/pull/2530) libc: Implement posix_fallocate
-* [#2533](https://github.com/apache/incubator-nuttx/pull/2533) sched: Make the number of queue/signal used by irq handler configurable
-* [#2534](https://github.com/apache/incubator-nuttx/pull/2534) libc: Implement getppid
-* [#2538](https://github.com/apache/incubator-nuttx/pull/2538) sched: pthread: Fix potential bugs in pthread_condclockwait.c
-* [#2574](https://github.com/apache/incubator-nuttx/pull/2574) libc: dumpbuffer: dump buffer enhancement
-* [#2580](https://github.com/apache/incubator-nuttx/pull/2580) sched: arch & sched: task: Fix up_exit() and nxtask_exit() for SMP
-* [#2585](https://github.com/apache/incubator-nuttx/pull/2585) libc: netdb: Move hostbuffer out of the stack
-* [#2602](https://github.com/apache/incubator-nuttx/pull/2740) sched: Add include/sys/poll.h
-* [#2604](https://github.com/apache/incubator-nuttx/pull/2604) libc: Add b64_ntop and b64_pton implementation
-* [#2616](https://github.com/apache/incubator-nuttx/pull/2616) libc/dumpvbuffer: update the vector ptr correctly
-* [#2624](https://github.com/apache/incubator-nuttx/pull/2624) sched: implement the default test-and-set semantics
-* [#2627](https://github.com/apache/incubator-nuttx/pull/2627) OS internal function should indicate the error by return negative value
-* [#2630](https://github.com/apache/incubator-nuttx/pull/2630) libc: net: implement socketpair
-* [#2631](https://github.com/apache/incubator-nuttx/pull/2631) sched: mqueue: simplify the mqueue reailize
-* [#2650](https://github.com/apache/incubator-nuttx/pull/2650) libc: ctype/iscntrl: correct the control character function
-* [#2653](https://github.com/apache/incubator-nuttx/pull/2653) sched: Don't call sched_lock()/unlock() in nx_waitid()/waitpid() for SMP
-* [#2668](https://github.com/apache/incubator-nuttx/pull/2668) Kernel module should prefer functions with nx/kmm prefix
-* [#2675](https://github.com/apache/incubator-nuttx/pull/2675) libc: Add placement new and new[] function
-* [#2693](https://github.com/apache/incubator-nuttx/pull/2693) libxx: use built-in __aeabi_atexit() if LIBSUPCXX is enabled
-* [#2694](https://github.com/apache/incubator-nuttx/pull/2694) libc/machine/arch: fix build break if enable armv8 ELF
-* [#2719](https://github.com/apache/incubator-nuttx/pull/2719) sched/task: setup the scheduling policy to task
-* [#2726](https://github.com/apache/incubator-nuttx/pull/2726) sched: sched: Remove sched_lock/unlock from nxsched_set_affinity()
-* [#2737](https://github.com/apache/incubator-nuttx/pull/2737) sched: task: Fix a potential bug in nxtask_assign_pid()
-* [#2740](https://github.com/apache/incubator-nuttx/pull/2740) sched/timer: get the previous reload value correctly
-* [#2741](https://github.com/apache/incubator-nuttx/pull/2741) libc: unistd/fpathconf: enhance fpathconf
-* [#2742](https://github.com/apache/incubator-nuttx/pull/2742) libc: pthread/cond: enhance pthread_cond_destroy
-* [#2744](https://github.com/apache/incubator-nuttx/pull/2744) sched: task: Fix comments and label in nxtask_assign_pid()
-* [#2765](https://github.com/apache/incubator-nuttx/pull/2765) sched: pthread: Return get_errno instead the hardcode value
-* [#2767](https://github.com/apache/incubator-nuttx/pull/2767) sched/wqueue/notifier: protect the work notifier with critical section
-* [#2797](https://github.com/apache/incubator-nuttx/pull/2797) sched: group: Fix group_kill_children() for SMP
-* [#2849](https://github.com/apache/incubator-nuttx/pull/2849) mqueue: Add _MQ_OPEN, _MQ_CLOSE and _MQ_UNLINK macro
-* [#2855](https://github.com/apache/incubator-nuttx/pull/2855) libs: Remove the duplicated _NX_ and _MQ_ macro
-* [#2865](https://github.com/apache/incubator-nuttx/pull/2865) libc: :machine:risc-v:unifying elf relocation code
-* [#2872](https://github.com/apache/incubator-nuttx/pull/2872) sched: pthread: Fix pthread cmdline issue
-* [#2881](https://github.com/apache/incubator-nuttx/pull/2881) libc: Move stack check stuff from libc/stdlib/ to libc/assert/
-* [#2904](https://github.com/apache/incubator-nuttx/pull/2904) libc: unistd/getcwd: enhance getcwd when buf is NULL
-* [#2906](https://github.com/apache/incubator-nuttx/pull/2906) mm: umm_heap: valloc: support valloc (LEGACY)
-* [#2910](https://github.com/apache/incubator-nuttx/pull/2910) libc/hex2bin: fix handling of segment offsets
-* [#2919](https://github.com/apache/incubator-nuttx/pull/2919) sched: fix fd leak in dlopen
-* [#2938](https://github.com/apache/incubator-nuttx/pull/2938) libs: misc: Remove critical section in lib_filesem.c for SMP
-* [#2942](https://github.com/apache/incubator-nuttx/pull/2492) mtd: progmem: Add up_progmem_read callback guarded by ARCH_HAVE_PROGMEM_READ
-* [#2946](https://github.com/apache/incubator-nuttx/pull/2946) sched: task: Call nxtask_flushstreams() without critical section
-* [#2960](https://github.com/apache/incubator-nuttx/pull/2960) sched: signal: sigdeliver: fix system block when kill signal to idle in SMP
-* [#2980](https://github.com/apache/incubator-nuttx/pull/2980) include: Add iso646.h for alternative spellings
-* [#2981](https://github.com/apache/incubator-nuttx/pull/2981) sched: Remove all group id related stuff
-* [#3033](https://github.com/apache/incubator-nuttx/pull/3033) unistd: Fix getpriority not handling invalid input value
-* [#3080](https://github.com/apache/incubator-nuttx/pull/3080) sched: semaphore: Remove a redundant critical section in nxsem
-* [#3083](https://github.com/apache/incubator-nuttx/pull/3083) libc: stdio/lib_clearerr: Did not clear stream buffer flags in clearerr
-* [#3086](https://github.com/apache/incubator-nuttx/pull/3086) mm: improve the memory manager modularity and reduce the information explosion
-* [#3111](https://github.com/apache/incubator-nuttx/pull/3111) sched: Sporadic scheduler: Fix time calculation and compile errors when assertions are enabled:
-* [#3115](https://github.com/apache/incubator-nuttx/pull/3115) libc: time: localtime: fix race condition
-* [#3121](https://github.com/apache/incubator-nuttx/pull/3121) mm/heap: Move semaphore related declaration to private header
-* [#3123](https://github.com/apache/incubator-nuttx/pull/3123) sched: pthread: Remove a redundant critical section in pthread_condclockwait.c
-* [#3131](https://github.com/apache/incubator-nuttx/pull/3131) mm: Minor fix for heap manager
-* [#3159](https://github.com/apache/incubator-nuttx/pull/3159) mm: mm_heap: Remove critical section in mm_sem.c
-* [#3170](https://github.com/apache/incubator-nuttx/pull/3170) libc: Move getopt() variables into TLS
-* [#3196](https://github.com/apache/incubator-nuttx/pull/3196) sched/signal: Implement SA_NODEFER
-* [#3228](https://github.com/apache/incubator-nuttx/pull/3228) mm/mm_heap: fix compile failed when open DEBUG_MM
-* [#3244](https://github.com/apache/incubator-nuttx/pull/3244) libdsp: Improvements for libdsp and support for fixed16 libdsp implementation
-* [#3247](https://github.com/apache/incubator-nuttx/pull/3247) sched: Move the default Task Stack size to Stack menu
-* [#3251](https://github.com/apache/incubator-nuttx/pull/3251) libc: update pthread_once according to the specification
-* [#3253](https://github.com/apache/incubator-nuttx/pull/3253) libc pthread: Fix pthread_rwlock_init return error
-* [#3268](https://github.com/apache/incubator-nuttx/pull/3268) libdsp/fixed16: add open-loop handler
-* [#3272](https://github.com/apache/incubator-nuttx/pull/3272) libc: Implement getopt_long() and getopt_long_only()
-* [#3280](https://github.com/apache/incubator-nuttx/pull/3280) libc: Correct some getopt() logic
-* [#3289](https://github.com/apache/incubator-nuttx/pull/3289) sched: task: Fix to initialize the task-specific data
-* [#3294](https://github.com/apache/incubator-nuttx/pull/2418) libc: getopt(): Fix Use of Pointer before NULL check
-* [#3299](https://github.com/apache/incubator-nuttx/pull/3299) libc: getopt_common(): Correct handling of unsupported long options.
-* [#3308](https://github.com/apache/incubator-nuttx/pull/3308) libc: getopt_long(): Add support for required argument format
-* [#3445](https://github.com/apache/incubator-nuttx/pull/3445) libc: update stream getoffset to handle write case
-* [#3447](https://github.com/apache/incubator-nuttx/pull/2450) libc: correct zoneinfo genromfs source directory
+* [#1852](https://github.com/apache/nuttx/pull/1852) sysconf: add _SC_PAGESIZE sysconf support
+* [#1922](https://github.com/apache/nuttx/pull/1922) sched: nxtask_start should call entry point directly for kernel thread
+* [#1994](https://github.com/apache/nuttx/pull/1994) libc: Don't fclose and fopen file in freopen
+* [#2005](https://github.com/apache/nuttx/pull/2005) Fix note_syscall_leave_s to avoid unaligned access
+* [#2043](https://github.com/apache/nuttx/pull/2043) sched: Add SCHED_INSTRUMENTATION_HIRES support
+* [#2044](https://github.com/apache/nuttx/pull/2044) sched: Add note_syscall args support
+* [#2071](https://github.com/apache/nuttx/pull/2071) pollnotify: we should send poll events before semaphore incrementes.
+* [#2076](https://github.com/apache/nuttx/pull/2076) libc: math: Make this friendly with libcxx
+* [#2111](https://github.com/apache/nuttx/pull/2111) LIBCXX related fixes
+* [#2147](https://github.com/apache/nuttx/pull/2147) sched: Use nx_close() inside OS
+* [#2176](https://github.com/apache/nuttx/pull/2176) syscall/syscall.csv: Increase number of arguments for prctl()
+* [#2204](https://github.com/apache/nuttx/pull/2204) sched: irq: Fix enter_critical_section() in an irq handler for SMP
+* [#2218](https://github.com/apache/nuttx/pull/2218) sched: signal.h: fix compile failed when open TTY_SIGINT
+* [#2229](https://github.com/apache/nuttx/pull/2229) sched/sched/sched_waitid.c: Allow WNOHANG
+* [#2236](https://github.com/apache/nuttx/pull/2236) sched/task/task_exithook.c: Remove a redundant assignment
+* [#2243](https://github.com/apache/nuttx/pull/2243) libcxx: Update [0001-libcxx-Port-to-NuttX-https-nuttx.apache.org](http://0001-libcxx-Port-to-NuttX-https-nuttx.apache.org)-RTOS.patch
+* [#2255](https://github.com/apache/nuttx/pull/2255) sys/epoll: sync the epoll define with linux
+* [#2256](https://github.com/apache/nuttx/pull/2256) unistd/sched_sporadic: correct the disable value
+* [#2261](https://github.com/apache/nuttx/pull/2261) sched/timer: add support of CLOCK_MONOTONIC
+* [#2262](https://github.com/apache/nuttx/pull/2262) sched/init: init the default home directory to environment
+* [#2285](https://github.com/apache/nuttx/pull/2285) libc/stdlib: Fix range check in strtoul(l)
+* [#2326](https://github.com/apache/nuttx/pull/2326) libc: Enhance getopt function
+* [#2407](https://github.com/apache/nuttx/pull/2407) libc: machine: arch: Support armv8-m relocation
+* [#2418](https://github.com/apache/nuttx/pull/3447) libc: Change OK/ERROR from macro to enum
+* [#2420](https://github.com/apache/nuttx/pull/2420) sched/signal: Remove redundant checks
+* [#2437](https://github.com/apache/nuttx/pull/2765) sched/sched/sched_waitpid.c: Fix return value
+* [#2449](https://github.com/apache/nuttx/pull/2449) mm/circbuf: fix the problem of dividing by zero
+* [#2450](https://github.com/apache/nuttx/pull/2450) unistd/getopt: remove number of arguments limit
+* [#2451](https://github.com/apache/nuttx/pull/2451) libc: pthread_mutexattr_getprotocol: modify prototype
+* [#2455](https://github.com/apache/nuttx/pull/2455) sched/sched/sched_waitpid.c: Discard the correct child entry
+* [#2475](https://github.com/apache/nuttx/pull/2475) sched/sched_waitid.c: Fix two bugs when CONFIG_SCHED_CHILD_STATUS is enabled
+* [#2487](https://github.com/apache/nuttx/pull/2487) sched: clock/time: add CLOCK_BOOTTIME definition
+* [#2492](https://github.com/apache/nuttx/pull/2492) procfs: make array const to reduce memory use
+* [#2494](https://github.com/apache/nuttx/pull/2494) sched: Fix SMP
+* [#2509](https://github.com/apache/nuttx/pull/2509) libc: net: implement ether_aton/ether_aton_r
+* [#2517](https://github.com/apache/nuttx/pull/2517) sched: spinlock: Introduce SP_WFE() and SP_SEV()
+* [#2518](https://github.com/apache/nuttx/pull/2518) sched: Don't forward gettid to getpid directly
+* [#2530](https://github.com/apache/nuttx/pull/2530) libc: Implement posix_fallocate
+* [#2533](https://github.com/apache/nuttx/pull/2533) sched: Make the number of queue/signal used by irq handler configurable
+* [#2534](https://github.com/apache/nuttx/pull/2534) libc: Implement getppid
+* [#2538](https://github.com/apache/nuttx/pull/2538) sched: pthread: Fix potential bugs in pthread_condclockwait.c
+* [#2574](https://github.com/apache/nuttx/pull/2574) libc: dumpbuffer: dump buffer enhancement
+* [#2580](https://github.com/apache/nuttx/pull/2580) sched: arch & sched: task: Fix up_exit() and nxtask_exit() for SMP
+* [#2585](https://github.com/apache/nuttx/pull/2585) libc: netdb: Move hostbuffer out of the stack
+* [#2602](https://github.com/apache/nuttx/pull/2740) sched: Add include/sys/poll.h
+* [#2604](https://github.com/apache/nuttx/pull/2604) libc: Add b64_ntop and b64_pton implementation
+* [#2616](https://github.com/apache/nuttx/pull/2616) libc/dumpvbuffer: update the vector ptr correctly
+* [#2624](https://github.com/apache/nuttx/pull/2624) sched: implement the default test-and-set semantics
+* [#2627](https://github.com/apache/nuttx/pull/2627) OS internal function should indicate the error by return negative value
+* [#2630](https://github.com/apache/nuttx/pull/2630) libc: net: implement socketpair
+* [#2631](https://github.com/apache/nuttx/pull/2631) sched: mqueue: simplify the mqueue reailize
+* [#2650](https://github.com/apache/nuttx/pull/2650) libc: ctype/iscntrl: correct the control character function
+* [#2653](https://github.com/apache/nuttx/pull/2653) sched: Don't call sched_lock()/unlock() in nx_waitid()/waitpid() for SMP
+* [#2668](https://github.com/apache/nuttx/pull/2668) Kernel module should prefer functions with nx/kmm prefix
+* [#2675](https://github.com/apache/nuttx/pull/2675) libc: Add placement new and new[] function
+* [#2693](https://github.com/apache/nuttx/pull/2693) libxx: use built-in __aeabi_atexit() if LIBSUPCXX is enabled
+* [#2694](https://github.com/apache/nuttx/pull/2694) libc/machine/arch: fix build break if enable armv8 ELF
+* [#2719](https://github.com/apache/nuttx/pull/2719) sched/task: setup the scheduling policy to task
+* [#2726](https://github.com/apache/nuttx/pull/2726) sched: sched: Remove sched_lock/unlock from nxsched_set_affinity()
+* [#2737](https://github.com/apache/nuttx/pull/2737) sched: task: Fix a potential bug in nxtask_assign_pid()
+* [#2740](https://github.com/apache/nuttx/pull/2740) sched/timer: get the previous reload value correctly
+* [#2741](https://github.com/apache/nuttx/pull/2741) libc: unistd/fpathconf: enhance fpathconf
+* [#2742](https://github.com/apache/nuttx/pull/2742) libc: pthread/cond: enhance pthread_cond_destroy
+* [#2744](https://github.com/apache/nuttx/pull/2744) sched: task: Fix comments and label in nxtask_assign_pid()
+* [#2765](https://github.com/apache/nuttx/pull/2765) sched: pthread: Return get_errno instead the hardcode value
+* [#2767](https://github.com/apache/nuttx/pull/2767) sched/wqueue/notifier: protect the work notifier with critical section
+* [#2797](https://github.com/apache/nuttx/pull/2797) sched: group: Fix group_kill_children() for SMP
+* [#2849](https://github.com/apache/nuttx/pull/2849) mqueue: Add _MQ_OPEN, _MQ_CLOSE and _MQ_UNLINK macro
+* [#2855](https://github.com/apache/nuttx/pull/2855) libs: Remove the duplicated _NX_ and _MQ_ macro
+* [#2865](https://github.com/apache/nuttx/pull/2865) libc: :machine:risc-v:unifying elf relocation code
+* [#2872](https://github.com/apache/nuttx/pull/2872) sched: pthread: Fix pthread cmdline issue
+* [#2881](https://github.com/apache/nuttx/pull/2881) libc: Move stack check stuff from libc/stdlib/ to libc/assert/
+* [#2904](https://github.com/apache/nuttx/pull/2904) libc: unistd/getcwd: enhance getcwd when buf is NULL
+* [#2906](https://github.com/apache/nuttx/pull/2906) mm: umm_heap: valloc: support valloc (LEGACY)
+* [#2910](https://github.com/apache/nuttx/pull/2910) libc/hex2bin: fix handling of segment offsets
+* [#2919](https://github.com/apache/nuttx/pull/2919) sched: fix fd leak in dlopen
+* [#2938](https://github.com/apache/nuttx/pull/2938) libs: misc: Remove critical section in lib_filesem.c for SMP
+* [#2942](https://github.com/apache/nuttx/pull/2492) mtd: progmem: Add up_progmem_read callback guarded by ARCH_HAVE_PROGMEM_READ
+* [#2946](https://github.com/apache/nuttx/pull/2946) sched: task: Call nxtask_flushstreams() without critical section
+* [#2960](https://github.com/apache/nuttx/pull/2960) sched: signal: sigdeliver: fix system block when kill signal to idle in SMP
+* [#2980](https://github.com/apache/nuttx/pull/2980) include: Add iso646.h for alternative spellings
+* [#2981](https://github.com/apache/nuttx/pull/2981) sched: Remove all group id related stuff
+* [#3033](https://github.com/apache/nuttx/pull/3033) unistd: Fix getpriority not handling invalid input value
+* [#3080](https://github.com/apache/nuttx/pull/3080) sched: semaphore: Remove a redundant critical section in nxsem
+* [#3083](https://github.com/apache/nuttx/pull/3083) libc: stdio/lib_clearerr: Did not clear stream buffer flags in clearerr
+* [#3086](https://github.com/apache/nuttx/pull/3086) mm: improve the memory manager modularity and reduce the information explosion
+* [#3111](https://github.com/apache/nuttx/pull/3111) sched: Sporadic scheduler: Fix time calculation and compile errors when assertions are enabled:
+* [#3115](https://github.com/apache/nuttx/pull/3115) libc: time: localtime: fix race condition
+* [#3121](https://github.com/apache/nuttx/pull/3121) mm/heap: Move semaphore related declaration to private header
+* [#3123](https://github.com/apache/nuttx/pull/3123) sched: pthread: Remove a redundant critical section in pthread_condclockwait.c
+* [#3131](https://github.com/apache/nuttx/pull/3131) mm: Minor fix for heap manager
+* [#3159](https://github.com/apache/nuttx/pull/3159) mm: mm_heap: Remove critical section in mm_sem.c
+* [#3170](https://github.com/apache/nuttx/pull/3170) libc: Move getopt() variables into TLS
+* [#3196](https://github.com/apache/nuttx/pull/3196) sched/signal: Implement SA_NODEFER
+* [#3228](https://github.com/apache/nuttx/pull/3228) mm/mm_heap: fix compile failed when open DEBUG_MM
+* [#3244](https://github.com/apache/nuttx/pull/3244) libdsp: Improvements for libdsp and support for fixed16 libdsp implementation
+* [#3247](https://github.com/apache/nuttx/pull/3247) sched: Move the default Task Stack size to Stack menu
+* [#3251](https://github.com/apache/nuttx/pull/3251) libc: update pthread_once according to the specification
+* [#3253](https://github.com/apache/nuttx/pull/3253) libc pthread: Fix pthread_rwlock_init return error
+* [#3268](https://github.com/apache/nuttx/pull/3268) libdsp/fixed16: add open-loop handler
+* [#3272](https://github.com/apache/nuttx/pull/3272) libc: Implement getopt_long() and getopt_long_only()
+* [#3280](https://github.com/apache/nuttx/pull/3280) libc: Correct some getopt() logic
+* [#3289](https://github.com/apache/nuttx/pull/3289) sched: task: Fix to initialize the task-specific data
+* [#3294](https://github.com/apache/nuttx/pull/2418) libc: getopt(): Fix Use of Pointer before NULL check
+* [#3299](https://github.com/apache/nuttx/pull/3299) libc: getopt_common(): Correct handling of unsupported long options.
+* [#3308](https://github.com/apache/nuttx/pull/3308) libc: getopt_long(): Add support for required argument format
+* [#3445](https://github.com/apache/nuttx/pull/3445) libc: update stream getoffset to handle write case
+* [#3447](https://github.com/apache/nuttx/pull/2450) libc: correct zoneinfo genromfs source directory
 
 ## Major Changes to the Build System
 
 ### New Features
-* [#1834](https://github.com/apache/incubator-nuttx/pull/1834) License/authorship handling scripts
-* [#2107](https://github.com/apache/incubator-nuttx/pull/2107) build: Makefile should reference CONFIG_HOST_xxx
-* [#2392](https://github.com/apache/incubator-nuttx/pull/2392) configure.sh: support custom board build config with absolute path
-* [#2824](https://github.com/apache/incubator-nuttx/pull/2824) build/esp32: Create Flash size configuration and a new DOWNLOAD make target
-* [#3317](https://github.com/apache/incubator-nuttx/pull/3317) tols: Update python scripts to py3 and lint all of them againt Black
+* [#1834](https://github.com/apache/nuttx/pull/1834) License/authorship handling scripts
+* [#2107](https://github.com/apache/nuttx/pull/2107) build: Makefile should reference CONFIG_HOST_xxx
+* [#2392](https://github.com/apache/nuttx/pull/2392) configure.sh: support custom board build config with absolute path
+* [#2824](https://github.com/apache/nuttx/pull/2824) build/esp32: Create Flash size configuration and a new DOWNLOAD make target
+* [#3317](https://github.com/apache/nuttx/pull/3317) tols: Update python scripts to py3 and lint all of them againt Black
 
 ### Bug Fixes
-* [#1890](https://github.com/apache/incubator-nuttx/pull/1890) make/expression: improving up asm/C/C++ compile times(make with multi-jobs only)
-* [#1940](https://github.com/apache/incubator-nuttx/pull/1940) cygwin build - path issue fix for Renesas arch
-* [#2032](https://github.com/apache/incubator-nuttx/pull/2032) build: Change .external_dummy to dummy
-* [#2101](https://github.com/apache/incubator-nuttx/pull/2101) build: Add $(OBJS) and $(BIN) to CLEAN macro to clean objects also in subdirectories
-* [#2192](https://github.com/apache/incubator-nuttx/pull/2192) build: Move __NuttX__ definition to tools/[Config.mk](http://Config.mk)
-* [#2221](https://github.com/apache/incubator-nuttx/pull/2221) tools: Avoid messing the final binary nuttx.(bin,hex,...) compilation msg
-* [#2335](https://github.com/apache/incubator-nuttx/pull/2335) build: Parallelize depend file generation
-* [#2380](https://github.com/apache/incubator-nuttx/pull/2380) tools: Fix nuttx-gdbinit for armv7-m with FPU
-* [#2404](https://github.com/apache/incubator-nuttx/pull/2404) Update checkrelease script to check [readme.md](http://readme.md) instead of .txt
-* [#2411](https://github.com/apache/incubator-nuttx/pull/2411) tools: Add 'handle SIGUSR1' to nuttx-gdbinit for the NuttX sim SMP
-* [#2432](https://github.com/apache/incubator-nuttx/pull/2432) build system: add missing --obj-path to MKDEP
-* [#2557](https://github.com/apache/incubator-nuttx/pull/2557) tools/version.sh: Fix the version retrieved from GIT
-* [#2561](https://github.com/apache/incubator-nuttx/pull/2561) tools: Fix version.sh
-* [#2642](https://github.com/apache/incubator-nuttx/pull/2642) tools/version.sh: Fix the version retrieved from git-tag
-* [#2673](https://github.com/apache/incubator-nuttx/pull/2673) tools: esp32: add a gdb script to show backtrace
-* [#2679](https://github.com/apache/incubator-nuttx/pull/2679) tools: esp32: btdecode.sh: Script to decode the Xtensa backtrace.
-* [#2701](https://github.com/apache/incubator-nuttx/pull/2701) tools: gdbinit: add support for reporting total and used stack size
-* [#2729](https://github.com/apache/incubator-nuttx/pull/2729) tools: esp32: backtrace.gdbscript: Add comments
-* [#2803](https://github.com/apache/incubator-nuttx/pull/2803) tools: esp32: Remove some duplicated output
-* [#2882](https://github.com/apache/incubator-nuttx/pull/2882) tools: esp32: refine the QEMU image generation.
-* [#2895](https://github.com/apache/incubator-nuttx/pull/2895) tools: esp32: fix warnings from ShellCheck
-* [#2930](https://github.com/apache/incubator-nuttx/pull/2930) tools: version.sh: If the version is not available, use 0.0.0
-* [#2982](https://github.com/apache/incubator-nuttx/pull/2982) tools: nxstyle: Verify relative path in the file header
-* [#3004](https://github.com/apache/incubator-nuttx/pull/3004) tools: esp32XX: Delete the Makefile that downloads IDF.
-* [#3012](https://github.com/apache/incubator-nuttx/pull/3012) tools: esp32xx: Few fixes/improvements to the post build scripts
-* [#3017](https://github.com/apache/incubator-nuttx/pull/3017) tools: esp32: [Config.mk](http://Config.mk): Revert part of "Don't abort make when QEMU script fails"
-* [#3094](https://github.com/apache/incubator-nuttx/pull/3094) tools: version.sh: Fix PATCH including extra version
+* [#1890](https://github.com/apache/nuttx/pull/1890) make/expression: improving up asm/C/C++ compile times(make with multi-jobs only)
+* [#1940](https://github.com/apache/nuttx/pull/1940) cygwin build - path issue fix for Renesas arch
+* [#2032](https://github.com/apache/nuttx/pull/2032) build: Change .external_dummy to dummy
+* [#2101](https://github.com/apache/nuttx/pull/2101) build: Add $(OBJS) and $(BIN) to CLEAN macro to clean objects also in subdirectories
+* [#2192](https://github.com/apache/nuttx/pull/2192) build: Move __NuttX__ definition to tools/[Config.mk](http://Config.mk)
+* [#2221](https://github.com/apache/nuttx/pull/2221) tools: Avoid messing the final binary nuttx.(bin,hex,...) compilation msg
+* [#2335](https://github.com/apache/nuttx/pull/2335) build: Parallelize depend file generation
+* [#2380](https://github.com/apache/nuttx/pull/2380) tools: Fix nuttx-gdbinit for armv7-m with FPU
+* [#2404](https://github.com/apache/nuttx/pull/2404) Update checkrelease script to check [readme.md](http://readme.md) instead of .txt
+* [#2411](https://github.com/apache/nuttx/pull/2411) tools: Add 'handle SIGUSR1' to nuttx-gdbinit for the NuttX sim SMP
+* [#2432](https://github.com/apache/nuttx/pull/2432) build system: add missing --obj-path to MKDEP
+* [#2557](https://github.com/apache/nuttx/pull/2557) tools/version.sh: Fix the version retrieved from GIT
+* [#2561](https://github.com/apache/nuttx/pull/2561) tools: Fix version.sh
+* [#2642](https://github.com/apache/nuttx/pull/2642) tools/version.sh: Fix the version retrieved from git-tag
+* [#2673](https://github.com/apache/nuttx/pull/2673) tools: esp32: add a gdb script to show backtrace
+* [#2679](https://github.com/apache/nuttx/pull/2679) tools: esp32: btdecode.sh: Script to decode the Xtensa backtrace.
+* [#2701](https://github.com/apache/nuttx/pull/2701) tools: gdbinit: add support for reporting total and used stack size
+* [#2729](https://github.com/apache/nuttx/pull/2729) tools: esp32: backtrace.gdbscript: Add comments
+* [#2803](https://github.com/apache/nuttx/pull/2803) tools: esp32: Remove some duplicated output
+* [#2882](https://github.com/apache/nuttx/pull/2882) tools: esp32: refine the QEMU image generation.
+* [#2895](https://github.com/apache/nuttx/pull/2895) tools: esp32: fix warnings from ShellCheck
+* [#2930](https://github.com/apache/nuttx/pull/2930) tools: version.sh: If the version is not available, use 0.0.0
+* [#2982](https://github.com/apache/nuttx/pull/2982) tools: nxstyle: Verify relative path in the file header
+* [#3004](https://github.com/apache/nuttx/pull/3004) tools: esp32XX: Delete the Makefile that downloads IDF.
+* [#3012](https://github.com/apache/nuttx/pull/3012) tools: esp32xx: Few fixes/improvements to the post build scripts
+* [#3017](https://github.com/apache/nuttx/pull/3017) tools: esp32: [Config.mk](http://Config.mk): Revert part of "Don't abort make when QEMU script fails"
+* [#3094](https://github.com/apache/nuttx/pull/3094) tools: version.sh: Fix PATCH including extra version
 
 ## Architectural Support
 
 ### New Architectures
-* [#1995](https://github.com/apache/incubator-nuttx/pull/1995) arch: Add custom arch chip build support
-* [#2161](https://github.com/apache/incubator-nuttx/pull/2161) Added Support for more TI Tiva Microcontrollers: TM4C123GH6PZ, TM4C123GH6PGE, TM4C129ENCPDT, and TM4C129ENCZAD.
-* [#2566](https://github.com/apache/incubator-nuttx/pull/2566) arch/risc-v: Add BL602 support
-* [#2974](https://github.com/apache/incubator-nuttx/pull/2974) STM32L5 Architecture Support
-* [#3001](https://github.com/apache/incubator-nuttx/pull/3001) arch:riscv64:basic porting for C906
-* [#3023](https://github.com/apache/incubator-nuttx/pull/3023) Remove nr5m100 and gap8 support
+* [#1995](https://github.com/apache/nuttx/pull/1995) arch: Add custom arch chip build support
+* [#2161](https://github.com/apache/nuttx/pull/2161) Added Support for more TI Tiva Microcontrollers: TM4C123GH6PZ, TM4C123GH6PGE, TM4C129ENCPDT, and TM4C129ENCZAD.
+* [#2566](https://github.com/apache/nuttx/pull/2566) arch/risc-v: Add BL602 support
+* [#2974](https://github.com/apache/nuttx/pull/2974) STM32L5 Architecture Support
+* [#3001](https://github.com/apache/nuttx/pull/3001) arch:riscv64:basic porting for C906
+* [#3023](https://github.com/apache/nuttx/pull/3023) Remove nr5m100 and gap8 support
 
 ### Architectures with significant improvements
 
 #### ARM
-* [#2042](https://github.com/apache/incubator-nuttx/pull/2042) Fix interrupt stack handlings for ARM SMP
-* [#2061](https://github.com/apache/incubator-nuttx/pull/2061) Refactor arm interrupt stack related code
-* [#2309](https://github.com/apache/incubator-nuttx/pull/2309) Fix armv7-a L2CC and apply the code to the sabre-6quad board
-* [#2876](https://github.com/apache/incubator-nuttx/pull/2876) arm: ARMv6-M vector table offset register support
-* [#2932](https://github.com/apache/incubator-nuttx/pull/2932) arch: armv6-m: Apply armv7-m signal handling logic
-* [#2944](https://github.com/apache/incubator-nuttx/pull/2944) armv8-m: Fix EXC_RETURN for non-secure usage
-* [#2990](https://github.com/apache/incubator-nuttx/pull/2990) arch/armv7-m: Adds dwt helper functions for controlling watchpoints i…
+* [#2042](https://github.com/apache/nuttx/pull/2042) Fix interrupt stack handlings for ARM SMP
+* [#2061](https://github.com/apache/nuttx/pull/2061) Refactor arm interrupt stack related code
+* [#2309](https://github.com/apache/nuttx/pull/2309) Fix armv7-a L2CC and apply the code to the sabre-6quad board
+* [#2876](https://github.com/apache/nuttx/pull/2876) arm: ARMv6-M vector table offset register support
+* [#2932](https://github.com/apache/nuttx/pull/2932) arch: armv6-m: Apply armv7-m signal handling logic
+* [#2944](https://github.com/apache/nuttx/pull/2944) armv8-m: Fix EXC_RETURN for non-secure usage
+* [#2990](https://github.com/apache/nuttx/pull/2990) arch/armv7-m: Adds dwt helper functions for controlling watchpoints i…
 
 #### BL602
-* [#2614](https://github.com/apache/incubator-nuttx/pull/2614) bl602: Update register maps and lower half drivers
-* [#2633](https://github.com/apache/incubator-nuttx/pull/2633) BL602: Add support for system reset modes
-* [#2655](https://github.com/apache/incubator-nuttx/pull/2655) arch/risc-v/bl602 : add pwm onshot watchdog driver
-* [#2659](https://github.com/apache/incubator-nuttx/pull/2659) arch/risc-v/bl602 : add spiflash(hardware sf controller)
-* [#2669](https://github.com/apache/incubator-nuttx/pull/2669) risc-v/bl602 : add gpioirq、 i2c(master) driver.
-* [#2804](https://github.com/apache/incubator-nuttx/pull/2804) arch/risc-v/bl602: spi_master support.
-* [#2809](https://github.com/apache/incubator-nuttx/pull/2809) arch:risc-v:bl602: enable FPU for this target.
-* [#2836](https://github.com/apache/incubator-nuttx/pull/2836) :risc-v:bl602:add support for elf file apps
-* [#2991](https://github.com/apache/incubator-nuttx/pull/2991) risc-v/bl602: Add wifi and ble support
+* [#2614](https://github.com/apache/nuttx/pull/2614) bl602: Update register maps and lower half drivers
+* [#2633](https://github.com/apache/nuttx/pull/2633) BL602: Add support for system reset modes
+* [#2655](https://github.com/apache/nuttx/pull/2655) arch/risc-v/bl602 : add pwm onshot watchdog driver
+* [#2659](https://github.com/apache/nuttx/pull/2659) arch/risc-v/bl602 : add spiflash(hardware sf controller)
+* [#2669](https://github.com/apache/nuttx/pull/2669) risc-v/bl602 : add gpioirq、 i2c(master) driver.
+* [#2804](https://github.com/apache/nuttx/pull/2804) arch/risc-v/bl602: spi_master support.
+* [#2809](https://github.com/apache/nuttx/pull/2809) arch:risc-v:bl602: enable FPU for this target.
+* [#2836](https://github.com/apache/nuttx/pull/2836) :risc-v:bl602:add support for elf file apps
+* [#2991](https://github.com/apache/nuttx/pull/2991) risc-v/bl602: Add wifi and ble support
 
 #### CXD56XX
-* [#2750](https://github.com/apache/incubator-nuttx/pull/2750) arch: cxd56xx: Add i2c bitbang lower driver
-* [#2830](https://github.com/apache/incubator-nuttx/pull/2830) Driver-specific spinlock for cxd56_serial.c
+* [#2750](https://github.com/apache/nuttx/pull/2750) arch: cxd56xx: Add i2c bitbang lower driver
+* [#2830](https://github.com/apache/nuttx/pull/2830) Driver-specific spinlock for cxd56_serial.c
 
 #### ESP32
-* [#1893](https://github.com/apache/incubator-nuttx/pull/1893) Add ESP32 WiFi adapter and driver
-* [#1942](https://github.com/apache/incubator-nuttx/pull/1942) Implement BASIC reset logic
-* [#1945](https://github.com/apache/incubator-nuttx/pull/1945) Added Timer Support
-* [#1958](https://github.com/apache/incubator-nuttx/pull/1958) When PSRAM is enabled allow drivers and tasks to allocate memory from a separate internal memory
-* [#1978](https://github.com/apache/incubator-nuttx/pull/1978) Add power management of deep-sleep
-* [#2074](https://github.com/apache/incubator-nuttx/pull/2074) Add real-time timer support for WiFi
-* [#2138](https://github.com/apache/incubator-nuttx/pull/2138) Add Partition and OTA device
-* [#2199](https://github.com/apache/incubator-nuttx/pull/2199) SPI Flash driver uses global sem for all MTD
-* [#2224](https://github.com/apache/incubator-nuttx/pull/2224) Add SPI Flash hardware encryption I/O support
-* [#2234](https://github.com/apache/incubator-nuttx/pull/2234) Include cache workaround to PSRAM
-* [#2242](https://github.com/apache/incubator-nuttx/pull/2242) Watchdog support (MWDTs)
-* [#2269](https://github.com/apache/incubator-nuttx/pull/2269) Add high memory support to work with PSRAM
-* [#2294](https://github.com/apache/incubator-nuttx/pull/2294) Refactor ESP32 Wi-Fi driver
-* [#2296](https://github.com/apache/incubator-nuttx/pull/2296) added support to automonitor by capture
-* [#2474](https://github.com/apache/incubator-nuttx/pull/2474) Optimize IRAM usage based on esp-idf
-* [#2514](https://github.com/apache/incubator-nuttx/pull/2514) allows the rtc wdt to be configured in bootloader and used later
-* [#2515](https://github.com/apache/incubator-nuttx/pull/2515) Added support for RTC WDT
-* [#2550](https://github.com/apache/incubator-nuttx/pull/2550) enables started flag if the wdt was turned on in bootloader
-* [#2613](https://github.com/apache/incubator-nuttx/pull/2613) Added driver api to reload counter instantly
-* [#2716](https://github.com/apache/incubator-nuttx/pull/2716) Add AES hardware accelerator driver
-* [#2721](https://github.com/apache/incubator-nuttx/pull/2613) Add efuse driver
-* [#2831](https://github.com/apache/incubator-nuttx/pull/2831) Writeback PSRAM data when mapping SPI Flash address to ESP32's address bus
-* [#2840](https://github.com/apache/incubator-nuttx/pull/2840) Add esp32_gpio_matrix_in/out to replace ROM functions
-* [#2858](https://github.com/apache/incubator-nuttx/pull/2858) Fix a memory leak when discarding a large packet.
-* [#2939](https://github.com/apache/incubator-nuttx/pull/2939) Refactor ESP32 WiFi driver to support station and softAP coexistence
-* [#2947](https://github.com/apache/incubator-nuttx/pull/2947) esp32_ummap: write back spiram cache before calling Cache_Flush
-* [#2965](https://github.com/apache/incubator-nuttx/pull/2965) Add more flash options to esptool
-* [#2979](https://github.com/apache/incubator-nuttx/pull/2979) Add support for I2C tracing
-* [#2983](https://github.com/apache/incubator-nuttx/pull/2983) Extract memory layout definitions to a separate header
-* [#2999](https://github.com/apache/incubator-nuttx/pull/2999) Add WPA2 Enterprise and WPA3 support
-* [#3003](https://github.com/apache/incubator-nuttx/pull/3003) Re-organise the different heap regions
-* [#3048](https://github.com/apache/incubator-nuttx/pull/3048) timer driver refactor
-* [#3233](https://github.com/apache/incubator-nuttx/pull/3233) Bugfixes and Improvements for SPI DMA Exchange function
+* [#1893](https://github.com/apache/nuttx/pull/1893) Add ESP32 WiFi adapter and driver
+* [#1942](https://github.com/apache/nuttx/pull/1942) Implement BASIC reset logic
+* [#1945](https://github.com/apache/nuttx/pull/1945) Added Timer Support
+* [#1958](https://github.com/apache/nuttx/pull/1958) When PSRAM is enabled allow drivers and tasks to allocate memory from a separate internal memory
+* [#1978](https://github.com/apache/nuttx/pull/1978) Add power management of deep-sleep
+* [#2074](https://github.com/apache/nuttx/pull/2074) Add real-time timer support for WiFi
+* [#2138](https://github.com/apache/nuttx/pull/2138) Add Partition and OTA device
+* [#2199](https://github.com/apache/nuttx/pull/2199) SPI Flash driver uses global sem for all MTD
+* [#2224](https://github.com/apache/nuttx/pull/2224) Add SPI Flash hardware encryption I/O support
+* [#2234](https://github.com/apache/nuttx/pull/2234) Include cache workaround to PSRAM
+* [#2242](https://github.com/apache/nuttx/pull/2242) Watchdog support (MWDTs)
+* [#2269](https://github.com/apache/nuttx/pull/2269) Add high memory support to work with PSRAM
+* [#2294](https://github.com/apache/nuttx/pull/2294) Refactor ESP32 Wi-Fi driver
+* [#2296](https://github.com/apache/nuttx/pull/2296) added support to automonitor by capture
+* [#2474](https://github.com/apache/nuttx/pull/2474) Optimize IRAM usage based on esp-idf
+* [#2514](https://github.com/apache/nuttx/pull/2514) allows the rtc wdt to be configured in bootloader and used later
+* [#2515](https://github.com/apache/nuttx/pull/2515) Added support for RTC WDT
+* [#2550](https://github.com/apache/nuttx/pull/2550) enables started flag if the wdt was turned on in bootloader
+* [#2613](https://github.com/apache/nuttx/pull/2613) Added driver api to reload counter instantly
+* [#2716](https://github.com/apache/nuttx/pull/2716) Add AES hardware accelerator driver
+* [#2721](https://github.com/apache/nuttx/pull/2613) Add efuse driver
+* [#2831](https://github.com/apache/nuttx/pull/2831) Writeback PSRAM data when mapping SPI Flash address to ESP32's address bus
+* [#2840](https://github.com/apache/nuttx/pull/2840) Add esp32_gpio_matrix_in/out to replace ROM functions
+* [#2858](https://github.com/apache/nuttx/pull/2858) Fix a memory leak when discarding a large packet.
+* [#2939](https://github.com/apache/nuttx/pull/2939) Refactor ESP32 WiFi driver to support station and softAP coexistence
+* [#2947](https://github.com/apache/nuttx/pull/2947) esp32_ummap: write back spiram cache before calling Cache_Flush
+* [#2965](https://github.com/apache/nuttx/pull/2965) Add more flash options to esptool
+* [#2979](https://github.com/apache/nuttx/pull/2979) Add support for I2C tracing
+* [#2983](https://github.com/apache/nuttx/pull/2983) Extract memory layout definitions to a separate header
+* [#2999](https://github.com/apache/nuttx/pull/2999) Add WPA2 Enterprise and WPA3 support
+* [#3003](https://github.com/apache/nuttx/pull/3003) Re-organise the different heap regions
+* [#3048](https://github.com/apache/nuttx/pull/3048) timer driver refactor
+* [#3233](https://github.com/apache/nuttx/pull/3233) Bugfixes and Improvements for SPI DMA Exchange function
 
 #### ESP32C3
-* [#2870](https://github.com/apache/incubator-nuttx/pull/2870) Support for ESP32-C3 GPIO Driver
-* [#2875](https://github.com/apache/incubator-nuttx/pull/2875) risc-v/esp32c3: Add support for Main System Watchdog Timer
-* [#2901](https://github.com/apache/incubator-nuttx/pull/2901) esp32c3: Add system reset.
-* [#2965](https://github.com/apache/incubator-nuttx/pull/2965) ESP32XX: Add more flash options to esptool
-* [#3006](https://github.com/apache/incubator-nuttx/pull/3006) esp32-c3: Adds timer driver
-* [#3007](https://github.com/apache/incubator-nuttx/pull/3007) risc-v/esp32-c3: complements serial driver
-* [#3028](https://github.com/apache/incubator-nuttx/pull/3028) ESP32-C3: Add I2C drive
-* [#3029](https://github.com/apache/incubator-nuttx/pull/3029) esp32-c3: Adds termios support
-* [#3040](https://github.com/apache/incubator-nuttx/pull/3040) riscv/esp32c3: Add ESP32-C3 WLAN netcard driver
-* [#3126](https://github.com/apache/incubator-nuttx/pull/3126) risc-v/esp32-c3: Add support to SPI Flash
-* [#3160](https://github.com/apache/incubator-nuttx/pull/3160) riscv/esp32c3: Add standard C atomic function
+* [#2870](https://github.com/apache/nuttx/pull/2870) Support for ESP32-C3 GPIO Driver
+* [#2875](https://github.com/apache/nuttx/pull/2875) risc-v/esp32c3: Add support for Main System Watchdog Timer
+* [#2901](https://github.com/apache/nuttx/pull/2901) esp32c3: Add system reset.
+* [#2965](https://github.com/apache/nuttx/pull/2965) ESP32XX: Add more flash options to esptool
+* [#3006](https://github.com/apache/nuttx/pull/3006) esp32-c3: Adds timer driver
+* [#3007](https://github.com/apache/nuttx/pull/3007) risc-v/esp32-c3: complements serial driver
+* [#3028](https://github.com/apache/nuttx/pull/3028) ESP32-C3: Add I2C drive
+* [#3029](https://github.com/apache/nuttx/pull/3029) esp32-c3: Adds termios support
+* [#3040](https://github.com/apache/nuttx/pull/3040) riscv/esp32c3: Add ESP32-C3 WLAN netcard driver
+* [#3126](https://github.com/apache/nuttx/pull/3126) risc-v/esp32-c3: Add support to SPI Flash
+* [#3160](https://github.com/apache/nuttx/pull/3160) riscv/esp32c3: Add standard C atomic function
 
 #### IMX6
-* [#2595](https://github.com/apache/incubator-nuttx/pull/2595) Add imx_enet driver
+* [#2595](https://github.com/apache/nuttx/pull/2595) Add imx_enet driver
 
 #### IMXRT
-* [#2212](https://github.com/apache/incubator-nuttx/pull/2212) imxrt: adds support for WDOG1
-* [#2354](https://github.com/apache/incubator-nuttx/pull/2354) imxrt: Added support for DP83825I PHY
-* [#2461](https://github.com/apache/incubator-nuttx/pull/2461) imxrt: Added NETDEV_LATEINIT option for Ethernet
-* [#2471](https://github.com/apache/incubator-nuttx/pull/2471) imxrt: Support serial single-wire mode and fix parity settings
-* [#2929](https://github.com/apache/incubator-nuttx/pull/2929) imxrt: changes to FlexCAN driver support
+* [#2212](https://github.com/apache/nuttx/pull/2212) imxrt: adds support for WDOG1
+* [#2354](https://github.com/apache/nuttx/pull/2354) imxrt: Added support for DP83825I PHY
+* [#2461](https://github.com/apache/nuttx/pull/2461) imxrt: Added NETDEV_LATEINIT option for Ethernet
+* [#2471](https://github.com/apache/nuttx/pull/2471) imxrt: Support serial single-wire mode and fix parity settings
+* [#2929](https://github.com/apache/nuttx/pull/2929) imxrt: changes to FlexCAN driver support
 
 #### NRF52
-* [#2148](https://github.com/apache/incubator-nuttx/pull/2148) nrf52_wdt: split into low-level API and watchdog driver lower-half
-* [#2149](https://github.com/apache/incubator-nuttx/pull/2149) nrf52832: add errata mitigation code for various RADIO issues
-* [#2182](https://github.com/apache/incubator-nuttx/pull/2182) nrf52: support configuring no console/serial
-* [#2189](https://github.com/apache/incubator-nuttx/pull/2189) nrf52_spi: support unconnected MISO/MOSI pins
-* [#2207](https://github.com/apache/incubator-nuttx/pull/2207) nrf52: add POWER register definitions; support enabling DC/DC regulator
-* [#2270](https://github.com/apache/incubator-nuttx/pull/2270) nRF52 SPI improvements
-* [#2440](https://github.com/apache/incubator-nuttx/pull/2440) nrf52 ADC: minor fixes
-* [#2674](https://github.com/apache/incubator-nuttx/pull/2674) nrf52_i2c: add support for I2C_M_NOSTOP and I2C_M_NOSTART flags
-* [#2705](https://github.com/apache/incubator-nuttx/pull/2705) nrf52: Add a static copy buffer for i2c NOSTART transfers
-* [#2712](https://github.com/apache/incubator-nuttx/pull/2712) nRF52: support stack coloration
-* [#2717](https://github.com/apache/incubator-nuttx/pull/2717) I2C bitbang driver (and nRF52 implementation)
-* [#2735](https://github.com/apache/incubator-nuttx/pull/2735) nRF52: add support for building SoftDevice BLE controller
-* [#2756](https://github.com/apache/incubator-nuttx/pull/2756) nrf52: add stackcheck support
+* [#2148](https://github.com/apache/nuttx/pull/2148) nrf52_wdt: split into low-level API and watchdog driver lower-half
+* [#2149](https://github.com/apache/nuttx/pull/2149) nrf52832: add errata mitigation code for various RADIO issues
+* [#2182](https://github.com/apache/nuttx/pull/2182) nrf52: support configuring no console/serial
+* [#2189](https://github.com/apache/nuttx/pull/2189) nrf52_spi: support unconnected MISO/MOSI pins
+* [#2207](https://github.com/apache/nuttx/pull/2207) nrf52: add POWER register definitions; support enabling DC/DC regulator
+* [#2270](https://github.com/apache/nuttx/pull/2270) nRF52 SPI improvements
+* [#2440](https://github.com/apache/nuttx/pull/2440) nrf52 ADC: minor fixes
+* [#2674](https://github.com/apache/nuttx/pull/2674) nrf52_i2c: add support for I2C_M_NOSTOP and I2C_M_NOSTART flags
+* [#2705](https://github.com/apache/nuttx/pull/2705) nrf52: Add a static copy buffer for i2c NOSTART transfers
+* [#2712](https://github.com/apache/nuttx/pull/2712) nRF52: support stack coloration
+* [#2717](https://github.com/apache/nuttx/pull/2717) I2C bitbang driver (and nRF52 implementation)
+* [#2735](https://github.com/apache/nuttx/pull/2735) nRF52: add support for building SoftDevice BLE controller
+* [#2756](https://github.com/apache/nuttx/pull/2756) nrf52: add stackcheck support
 
 #### RP2040
-* [#2916](https://github.com/apache/incubator-nuttx/pull/2916) rp2040: Raspberry Pi Pico SMP support
-* [#2927](https://github.com/apache/incubator-nuttx/pull/2927) rp2040: Fix LDFLAGS for boot stage2
-* [#2952](https://github.com/apache/incubator-nuttx/pull/2952) rp2040: Add I2C driver support
-* [#2986](https://github.com/apache/incubator-nuttx/pull/2986) rp2040: Add SPI driver support
-* [#3002](https://github.com/apache/incubator-nuttx/pull/3002) rp2040: SPI driver DMA transfer support
-* [#3057](https://github.com/apache/incubator-nuttx/pull/3057) rp2040: Fix SPI halfword DMA transfer
+* [#2916](https://github.com/apache/nuttx/pull/2916) rp2040: Raspberry Pi Pico SMP support
+* [#2927](https://github.com/apache/nuttx/pull/2927) rp2040: Fix LDFLAGS for boot stage2
+* [#2952](https://github.com/apache/nuttx/pull/2952) rp2040: Add I2C driver support
+* [#2986](https://github.com/apache/nuttx/pull/2986) rp2040: Add SPI driver support
+* [#3002](https://github.com/apache/nuttx/pull/3002) rp2040: SPI driver DMA transfer support
+* [#3057](https://github.com/apache/nuttx/pull/3057) rp2040: Fix SPI halfword DMA transfer
 
 #### S32K1XX
-* [#2900](https://github.com/apache/incubator-nuttx/pull/2900) s32k1xx: Support ramfunc
+* [#2900](https://github.com/apache/nuttx/pull/2900) s32k1xx: Support ramfunc
 
 #### STM32
-* [#2010](https://github.com/apache/incubator-nuttx/pull/2010) arch/arm/src/stm32h7/stm32_spi.c: fixed build issue when SPI is configured
-* [#2095](https://github.com/apache/incubator-nuttx/pull/2095) arch: stm32: fix otghs logic to support interface requests
-* [#2177](https://github.com/apache/incubator-nuttx/pull/2177) FLASH waiting cycles are configured based on HCLK.
-* [#2180](https://github.com/apache/incubator-nuttx/pull/2180) stm32 - Add register mappings for STM32G474 VREFBUF
-* [#2194](https://github.com/apache/incubator-nuttx/pull/2194) stm32 - Add register mappings for STM32Gxxxxx-family DAC
-* [#2273](https://github.com/apache/incubator-nuttx/pull/2273) stm32/stm32_spi: Add SPI register definitions for STM32G47xxx
-* [#2288](https://github.com/apache/incubator-nuttx/pull/2288) stm32: Add DMAMUX register mappings and request IDs
-* [#2325](https://github.com/apache/incubator-nuttx/pull/2325) arch/arm/src/stm32/stm32_serial.c: for flowcontrol use common idiom for enabling/disabling RX interrupts
-* [#2473](https://github.com/apache/incubator-nuttx/pull/2473) STM32 - Add ADC register definitions for STM32G4 family
-* [#2477](https://github.com/apache/incubator-nuttx/pull/2477) STM32 FLASH latency is calculated based on Vin
-* [#2985](https://github.com/apache/incubator-nuttx/pull/2985) stm32 Ethernet hardening
+* [#2010](https://github.com/apache/nuttx/pull/2010) arch/arm/src/stm32h7/stm32_spi.c: fixed build issue when SPI is configured
+* [#2095](https://github.com/apache/nuttx/pull/2095) arch: stm32: fix otghs logic to support interface requests
+* [#2177](https://github.com/apache/nuttx/pull/2177) FLASH waiting cycles are configured based on HCLK.
+* [#2180](https://github.com/apache/nuttx/pull/2180) stm32 - Add register mappings for STM32G474 VREFBUF
+* [#2194](https://github.com/apache/nuttx/pull/2194) stm32 - Add register mappings for STM32Gxxxxx-family DAC
+* [#2273](https://github.com/apache/nuttx/pull/2273) stm32/stm32_spi: Add SPI register definitions for STM32G47xxx
+* [#2288](https://github.com/apache/nuttx/pull/2288) stm32: Add DMAMUX register mappings and request IDs
+* [#2325](https://github.com/apache/nuttx/pull/2325) arch/arm/src/stm32/stm32_serial.c: for flowcontrol use common idiom for enabling/disabling RX interrupts
+* [#2473](https://github.com/apache/nuttx/pull/2473) STM32 - Add ADC register definitions for STM32G4 family
+* [#2477](https://github.com/apache/nuttx/pull/2477) STM32 FLASH latency is calculated based on Vin
+* [#2985](https://github.com/apache/nuttx/pull/2985) stm32 Ethernet hardening
 
 #### STM32F7
-* [#2209](https://github.com/apache/incubator-nuttx/pull/2209) stm32f7/stm32_serial.c: fix console re-initialisation if DMA enabled
-* [#3489](https://github.com/apache/incubator-nuttx/pull/3489) stm32f7: Freeze tickless timer during debug halt.
+* [#2209](https://github.com/apache/nuttx/pull/2209) stm32f7/stm32_serial.c: fix console re-initialisation if DMA enabled
+* [#3489](https://github.com/apache/nuttx/pull/3489) stm32f7: Freeze tickless timer during debug halt.
 
 #### STM32H7
-* [#2880](https://github.com/apache/incubator-nuttx/pull/2880) stm32h7: add definitions for DAC
-* [#2955](https://github.com/apache/incubator-nuttx/pull/2955) stm32h7:Add DBGMCU missing from master
-* [#2994](https://github.com/apache/incubator-nuttx/pull/2994) stm32h7: Allow custom clock configuration to use stdclockconfig
-* [#3143](https://github.com/apache/incubator-nuttx/pull/3143) stm32h7: DMA BDMA does not auto disabled on completion
-* [#3207](https://github.com/apache/incubator-nuttx/pull/3207) usbhost: Add usb host tracing strings to stm32h7
-* [#3458](https://github.com/apache/incubator-nuttx/pull/3458) stm32h7: Adds stm32_dbgmcu.h to match stm32f7 port
-* [#3461](https://github.com/apache/incubator-nuttx/pull/3461) stm32h7: Expose flash lock, unlock, and write protect functions to boards
+* [#2880](https://github.com/apache/nuttx/pull/2880) stm32h7: add definitions for DAC
+* [#2955](https://github.com/apache/nuttx/pull/2955) stm32h7:Add DBGMCU missing from master
+* [#2994](https://github.com/apache/nuttx/pull/2994) stm32h7: Allow custom clock configuration to use stdclockconfig
+* [#3143](https://github.com/apache/nuttx/pull/3143) stm32h7: DMA BDMA does not auto disabled on completion
+* [#3207](https://github.com/apache/nuttx/pull/3207) usbhost: Add usb host tracing strings to stm32h7
+* [#3458](https://github.com/apache/nuttx/pull/3458) stm32h7: Adds stm32_dbgmcu.h to match stm32f7 port
+* [#3461](https://github.com/apache/nuttx/pull/3461) stm32h7: Expose flash lock, unlock, and write protect functions to boards
 
 #### STM32L4
-* [#2068](https://github.com/apache/incubator-nuttx/pull/2068) STM32L4: Improvements on ADC driver
-* [#2178](https://github.com/apache/incubator-nuttx/pull/2178) STM32L4 ADC driver: extenal event configuration
-* [#2220](https://github.com/apache/incubator-nuttx/pull/2220) STM32L4 TIMER: Add some helper functions
-* [#2232](https://github.com/apache/incubator-nuttx/pull/2232) STM32L4 ADC: Add injected channel support.
+* [#2068](https://github.com/apache/nuttx/pull/2068) STM32L4: Improvements on ADC driver
+* [#2178](https://github.com/apache/nuttx/pull/2178) STM32L4 ADC driver: extenal event configuration
+* [#2220](https://github.com/apache/nuttx/pull/2220) STM32L4 TIMER: Add some helper functions
+* [#2232](https://github.com/apache/nuttx/pull/2232) STM32L4 ADC: Add injected channel support.
 
 #### STM32L5
-* [#3090](https://github.com/apache/incubator-nuttx/pull/3090) stm32l5: Optional LSE xtal drive strength ramp-up
+* [#3090](https://github.com/apache/nuttx/pull/3090) stm32l5: Optional LSE xtal drive strength ramp-up
 
 #### Renesas RX65N
-* [#2469](https://github.com/apache/incubator-nuttx/pull/2469) USB Host Driver Support
+* [#2469](https://github.com/apache/nuttx/pull/2469) USB Host Driver Support
 
 #### Risc-V
-* [#2470](https://github.com/apache/incubator-nuttx/pull/2470) risc-v: Introduce basic setjmp support
-* [#2918](https://github.com/apache/incubator-nuttx/pull/2918) risc-v: up_sigdeliver missing fpu contexts.
+* [#2470](https://github.com/apache/nuttx/pull/2470) risc-v: Introduce basic setjmp support
+* [#2918](https://github.com/apache/nuttx/pull/2918) risc-v: up_sigdeliver missing fpu contexts.
 
 #### RV64
-* [#2928](https://github.com/apache/incubator-nuttx/pull/2928) rv64:add API up_copyfullstate for later FPU support
-* [#3018](https://github.com/apache/incubator-nuttx/pull/3018) rv64:c906:enable DP FPU support
-* [#3073](https://github.com/apache/incubator-nuttx/pull/3073) rv64:c906:demo protect build without the PMP
-* [#3087](https://github.com/apache/incubator-nuttx/pull/3087) rv64: keep the stack to be 16bytes aligned
-* [#3098](https://github.com/apache/incubator-nuttx/pull/3098) rv64:fix 64bit data type and instruction for FPU handlers
-* [#3203](https://github.com/apache/incubator-nuttx/pull/3203) rv64:c906:add risc-v PMP and change mem map for protect build.
+* [#2928](https://github.com/apache/nuttx/pull/2928) rv64:add API up_copyfullstate for later FPU support
+* [#3018](https://github.com/apache/nuttx/pull/3018) rv64:c906:enable DP FPU support
+* [#3073](https://github.com/apache/nuttx/pull/3073) rv64:c906:demo protect build without the PMP
+* [#3087](https://github.com/apache/nuttx/pull/3087) rv64: keep the stack to be 16bytes aligned
+* [#3098](https://github.com/apache/nuttx/pull/3098) rv64:fix 64bit data type and instruction for FPU handlers
+* [#3203](https://github.com/apache/nuttx/pull/3203) rv64:c906:add risc-v PMP and change mem map for protect build.
 
 #### Xtensa
-* [#1933](https://github.com/apache/incubator-nuttx/pull/1933) Add support to PSRAM using SPIRAM interface
-* [#2014](https://github.com/apache/incubator-nuttx/pull/2014) Add the optional interrupt stack to the Xtensa architecture
-* [#2352](https://github.com/apache/incubator-nuttx/pull/2352) Print the bakctrace on assertions
-* [#2504](https://github.com/apache/incubator-nuttx/pull/2504) Get full backtrace from interrupts.
-* [#3015](https://github.com/apache/incubator-nuttx/pull/3015) hostfs: Make host_stat populate st_size
+* [#1933](https://github.com/apache/nuttx/pull/1933) Add support to PSRAM using SPIRAM interface
+* [#2014](https://github.com/apache/nuttx/pull/2014) Add the optional interrupt stack to the Xtensa architecture
+* [#2352](https://github.com/apache/nuttx/pull/2352) Print the bakctrace on assertions
+* [#2504](https://github.com/apache/nuttx/pull/2504) Get full backtrace from interrupts.
+* [#3015](https://github.com/apache/nuttx/pull/3015) hostfs: Make host_stat populate st_size
 
 ### Minor changes
 
-* [#1904](https://github.com/apache/incubator-nuttx/pull/1904) xtensa: ESP32: Fixed the type of cpuint variables in esp32_emac.c
-* [#1943](https://github.com/apache/incubator-nuttx/pull/1943) xtensa: ESP32: Fix and clean some corners of GPIOs configuration.
-* [#1947](https://github.com/apache/incubator-nuttx/pull/1947) xtensa: esp32: Fix crash on startup
-* [#1948](https://github.com/apache/incubator-nuttx/pull/1948) xtensa: ESP32: Fixes the GPIO's function mask test
-* [#1960](https://github.com/apache/incubator-nuttx/pull/1960) xtensa: xtensa.h: Include sys/types.h needed if STACK_COLORATON is enabled
-* [#1968](https://github.com/apache/incubator-nuttx/pull/1968) arm: kinetis: freedom-k64f: Declare missing NUM_BUTTONS
-* [#1990](https://github.com/apache/incubator-nuttx/pull/1990) arm: kinetis: flexcan fixed compile error
-* [#2120](https://github.com/apache/incubator-nuttx/pull/2120) arm: stm32h7: Fix missing 'ret' reported by Frank-Christian Kruegel
-* [#2159](https://github.com/apache/incubator-nuttx/pull/2159) xtensa: esp32: Fix SPI master DMA RX buffer memcpy size erro
-* [#2160](https://github.com/apache/incubator-nuttx/pull/2160) arm: stm32l4/stm32l4_adc.c: fix copy-paste mistake with CONFI
-* [#2210](https://github.com/apache/incubator-nuttx/pull/2210) arm: stm32/stm32_adc.c: do not allow negative ref count
-* [#2214](https://github.com/apache/incubator-nuttx/pull/2214) xtensa: esp32: Fix rt-timer issues
-* [#2233](https://github.com/apache/incubator-nuttx/pull/2233) xtensa: esp32: Fix the memory regions with regards to the range used by the ROM
-* [#2240](https://github.com/apache/incubator-nuttx/pull/2240) arm: nrf52 GPIO/GPIOTE: better expose pin interrupt capability
-* [#2284](https://github.com/apache/incubator-nuttx/pull/2284) arm: stm32h7/stm32_dmamux.h: Fix errors in bitfield definitions
-* [#2286](https://github.com/apache/incubator-nuttx/pull/2286) arm: stm32f0l0g0/stm32_dmamux.h: Fix errors in bitfield definitions
-* [#2287](https://github.com/apache/incubator-nuttx/pull/2287) arm: stm32h7/stm32_dmamux.h: Add missing CCR SPOL defines
-* [#2300](https://github.com/apache/incubator-nuttx/pull/2300) arm: sam34: compile error on SAM34 TWI
-* [#2316](https://github.com/apache/incubator-nuttx/pull/2844) risc-v: minor fix
-* [#2330](https://github.com/apache/incubator-nuttx/pull/2330) xtensa: esp32/esp32_tim.c: Fix build when debug is enabled.
-* [#2336](https://github.com/apache/incubator-nuttx/pull/2336) arm: stm32l4: correct macros STM32L4_CAN_MCR_OFFSET, etc... to match defines
-* [#2344](https://github.com/apache/incubator-nuttx/pull/2344) xtensa: esp32/esp32_gpio.c: Fix GPIO IRQ assert condition
-* [#2351](https://github.com/apache/incubator-nuttx/pull/2351) xtensa: esp32: Fix issues of force-sleep
-* [#2355](https://github.com/apache/incubator-nuttx/pull/2355) xtensa: esp32_himem: Fix issue that was preventing to map all free memory
-* [#2361](https://github.com/apache/incubator-nuttx/pull/2361) arm: nrf52 GPIO: minor fixes
-* [#2364](https://github.com/apache/incubator-nuttx/pull/2364) arm: stm32h7: Fix bug where more than CONFIG_MM_REGIONS would be allocated
-* [#2372](https://github.com/apache/incubator-nuttx/pull/2372) rv64: Fix SCN/PRI.PTR definitions
-* [#2373](https://github.com/apache/incubator-nuttx/pull/2373) risc-v: Don't use non existent "saved_status"
-* [#2423](https://github.com/apache/incubator-nuttx/pull/2423) xetnsa: Couple of Xtensa fixes
-* [#2448](https://github.com/apache/incubator-nuttx/pull/2448) arm: stm32/stm32h7: fix the configuration of PWM outputs when subsequent channels are not enabled
-* [#2454](https://github.com/apache/incubator-nuttx/pull/2454) xtensa: esp32/esp32-core: Fix #ifdef warning and update MM_SECTIONS
-* [#2483](https://github.com/apache/incubator-nuttx/pull/2483) arm: stm32: convert all STM32G47X specific code to generic STM32G4 series code
-* [#2519](https://github.com/apache/incubator-nuttx/pull/2519) arm: imxrt: replace clock_systimespec with clock_systime_timespec
-* [#2536](https://github.com/apache/incubator-nuttx/pull/2536) xtensa: esp32: fixes enable int function and gets apb clk frequency through function
-* [#2546](https://github.com/apache/incubator-nuttx/pull/2546) arm: imxrt: imxrt_usdhc.c: fixed no DMA build error
-* [#2551](https://github.com/apache/incubator-nuttx/pull/2551) arm: stm32h7x3xx_memorymap.h invalid address map for fdcan
-* [#2554](https://github.com/apache/incubator-nuttx/pull/2554) xtensa: Esp32 wifi fixes
-* [#2555](https://github.com/apache/incubator-nuttx/pull/2555) xtensa: esp32/esp32_spiflash.c: Writeback PSRAM data before invalidating the cache
-* [#2559](https://github.com/apache/incubator-nuttx/pull/2559) risc-v: Remove duplicated declaration for up_irq_save and up_irq_restore
-* [#2560](https://github.com/apache/incubator-nuttx/pull/2560) risc-v: Move csr.h to common place
-* [#2568](https://github.com/apache/incubator-nuttx/pull/2568) risc-v: Move CSR register bit definition to csr.h
-* [#2569](https://github.com/apache/incubator-nuttx/pull/2569) risc-v: Reuse the common up_schedule_sigaction implementation
-* [#2570](https://github.com/apache/incubator-nuttx/pull/2570) arm: stm32g4: Fix incorrect FLASH wait states
-* [#2573](https://github.com/apache/incubator-nuttx/pull/2573) xtensa: esp32: Bump NAME_MAX where CONFIG_ESP32_WIFI_SAVE_PARAM=y
-* [#2584](https://github.com/apache/incubator-nuttx/pull/2584) xtensa: esp32_wifi_adapter.c: file mode for open doesn't make sense for O_RDONLY
-* [#2589](https://github.com/apache/incubator-nuttx/pull/2589) risc-v: fix redefined CSR_INSTRET
-* [#2612](https://github.com/apache/incubator-nuttx/pull/2612) arm: kinetis: S32K/Kinetis: Fix RTC settime prescaler
-* [#2612](https://github.com/apache/incubator-nuttx/pull/2612) arm: S32K/Kinetis: Fix RTC settime prescaler
-* [#2647](https://github.com/apache/incubator-nuttx/pull/2647) xtensa: esp32: Fix ESP32 serial UART tx ready check error
-* [#2666](https://github.com/apache/incubator-nuttx/pull/2666) xtensa: esp32: Fix ESP32 SPI3 slave ops data error
-* [#2676](https://github.com/apache/incubator-nuttx/pull/2676) arm: stm32412: Fixes pinmap CAN1
-* [#2689](https://github.com/apache/incubator-nuttx/pull/2689) arm: tiva: Fix lm3s_ethernet.c with DEBUGASSERT
-* [#2700](https://github.com/apache/incubator-nuttx/pull/2700) arm: nRF52 various minor fixes
-* [#2708](https://github.com/apache/incubator-nuttx/pull/2708) xtensa: esp32: Fix ESP32 I2C driver issues
-* [#2709](https://github.com/apache/incubator-nuttx/pull/2709) xtensa: esp32: Fix ESP32 SPI driver issues
-* [#2722](https://github.com/apache/incubator-nuttx/pull/2722) arm: stm32f412:Replaced Kludged pinmap with one for SoC.
-* [#2725](https://github.com/apache/incubator-nuttx/pull/2725) arm: nRF52: FIX wrong bitmask for DRIVE setting
-* [#2727](https://github.com/apache/incubator-nuttx/pull/2727) xtensa: esp32_free_cpuint: Fix an assertion
-* [#2728](https://github.com/apache/incubator-nuttx/pull/2728) xtensa: esp32_dma_init: Fix a dubious assertion
-* [#2731](https://github.com/apache/incubator-nuttx/pull/2731) xtensa: esp_allocateheap.c: Correct ROM memory boundaries in SMP case
-* [#2752](https://github.com/apache/incubator-nuttx/pull/2752) xtensa: esp32/esp32_spiflash.c: Fix the value of the page start address when invalidating the cache
-* [#2755](https://github.com/apache/incubator-nuttx/pull/2755) xtensa: esp32: Fix compile errors with CONFIG_SMP=y
-* [#2757](https://github.com/apache/incubator-nuttx/pull/2757) xtensa: esp32/esp32_wifi_adapter.c: Print debug output only when DEBUG_WIRLESS* are enabled
-* [#2758](https://github.com/apache/incubator-nuttx/pull/2758) xtensa: Kconfig: Reduce the default value of the internal memory
-* [#2759](https://github.com/apache/incubator-nuttx/pull/2759) xtensa: esp32/psram: Fix missing configs
-* [#2761](https://github.com/apache/incubator-nuttx/pull/2761) risc-v: Remove unused and undefined file section "Public Variables"
-* [#2763](https://github.com/apache/incubator-nuttx/pull/2763) arm: imx6: Apply the latest imxrt/imxrt_enet.c to imx6/imx_enet.c
-* [#2771](https://github.com/apache/incubator-nuttx/pull/2771) arm: imx6: Update imx6 enet
-* [#2772](https://github.com/apache/incubator-nuttx/pull/2771) arm: imx6 enet with TCP_WRITE_BUFFERS
-* [#2777](https://github.com/apache/incubator-nuttx/pull/2777) arm: imx6: Fix a compile error with CONFIG_DEBUG_ASSERTIONS=y
-* [#2779](https://github.com/apache/incubator-nuttx/pull/2779) arm: samv7/sam_mcan.c: fix some mismatches caused by renaming
-* [#2782](https://github.com/apache/incubator-nuttx/pull/2782) arm: nRF52 fixes
-* [#2788](https://github.com/apache/incubator-nuttx/pull/2788) risc-v: Don't declare riscv_addregion if CONFIG_MM_REGIONS is < 1.
-* [#2791](https://github.com/apache/incubator-nuttx/pull/2791) arm: stm32f7/stm32_qspi.c: Fix warning of format strings
-* [#2792](https://github.com/apache/incubator-nuttx/pull/2792) arm: [imxrt] Fix FlexCAN tx dropping frames
-* [#2793](https://github.com/apache/incubator-nuttx/pull/2316) risc-v: Remove nx_start prototype from riscv_internal.h
-* [#2795](https://github.com/apache/incubator-nuttx/pull/2795) arm: stm32f412:Corrected Pin count
-* [#2796](https://github.com/apache/incubator-nuttx/pull/2796) xtensa: esp32: Fix cache issue detected by DEBUG_ASSERTION
-* [#2799](https://github.com/apache/incubator-nuttx/pull/2799) RV64: handle relocation type R_RISCV_CALL_PLT in PIC build.
-* [#2805](https://github.com/apache/incubator-nuttx/pull/2805) arm: imxrt1060 iperf
-* [#2812](https://github.com/apache/incubator-nuttx/pull/2812) xtensa: esp32_spiflash.c: Fix preprocessor condition
-* [#2813](https://github.com/apache/incubator-nuttx/pull/2813) xtensa: esp32: Add extern modifier to ROM function declaration
-* [#2815](https://github.com/apache/incubator-nuttx/pull/2815) riscv: Fix files names in headers that were still using the old 'up_' prefix
-* [#2832](https://github.com/apache/incubator-nuttx/pull/2832) xtensa: esp32: Fix the issue of WiFi internal malloc from PSRAM
-* [#2844](https://github.com/apache/incubator-nuttx/pull/2844) risc-v: LiteX: Make Arty-A7 example work
-* [#2867](https://github.com/apache/incubator-nuttx/pull/2867) arm: lpc17xx_40xx/lpc17_40_i2c.c: Propagate I2C I/O errors
-* [#2886](https://github.com/apache/incubator-nuttx/pull/2886) arm: pic32mz: Chip does not have ANSEL register on port K
-* [#2889](https://github.com/apache/incubator-nuttx/pull/2889) arm: pic32mx7 cannot perform context switch
-* [#2892](https://github.com/apache/incubator-nuttx/pull/2892) risc-v: esp32-c3: Don't reserve any vectors for any special use.
-* [#2893](https://github.com/apache/incubator-nuttx/pull/2893) risc-v: esp32-c3: Build serial driver only when selected
-* [#2903](https://github.com/apache/incubator-nuttx/pull/2903) xtensa: esp32: xtensa_user: Implement a few more instructions
-* [#2912](https://github.com/apache/incubator-nuttx/pull/2912) risc-v: esp32-c3: Fix CPU interrupts freeing on WDT driver
-* [#2917](https://github.com/apache/incubator-nuttx/pull/2917) arm: Add 'select ARM_HAVE_WFE_SEV' to ARCH_CHIP_RP2040
-* [#2920](https://github.com/apache/incubator-nuttx/pull/2920) risc-v: esp32-c3: Configure clock and call board initialize at startup
-* [#2923](https://github.com/apache/incubator-nuttx/pull/2923) ez80: fix several bugs in emac driver
-* [#2931](https://github.com/apache/incubator-nuttx/pull/2931) arm: kinetis: [FlexCAN] Fix TX drop #2792 and correctly set CAN timings to non-zero
-* [#2931](https://github.com/apache/incubator-nuttx/pull/2931) arm: s32k1xx: [FlexCAN] Fix TX drop #2792 and correctly set CAN timings to non-zero
-* [#2943](https://github.com/apache/incubator-nuttx/pull/2943) arm: stm32x7:lse ensure it is started
-* [#2951](https://github.com/apache/incubator-nuttx/pull/2951) arm: stm32_wwdg debug log formatting
-* [#2967](https://github.com/apache/incubator-nuttx/pull/2967) arm: STM32F7 lse static values directly from Kconfig
-* [#2968](https://github.com/apache/incubator-nuttx/pull/2968) xtensa: esp32: Change I2C SCL default pin to a valid one
-* [#2972](https://github.com/apache/incubator-nuttx/pull/2972) risc-v: esp32-c3: Fix GPIO pin function configuration
-* [#2976](https://github.com/apache/incubator-nuttx/pull/2976) xtensa: ESP32: Fix I2C Kconfig bringing the character driver as a dependency
-* [#2977](https://github.com/apache/incubator-nuttx/pull/2977) xtensa: ESP32: Fix GPIO pin function configuration
-* [#2996](https://github.com/apache/incubator-nuttx/pull/2996) arm: stm32h747xi: Fix missing IO_CONFIG setting
-* [#3008](https://github.com/apache/incubator-nuttx/pull/3008) risc-v: esp32-c3: free cpu in case it was preallocated in wdt driver
-* [#3013](https://github.com/apache/incubator-nuttx/pull/3013) risc-v: bl602:fix bl602_flash_erase to erase the wrong block
-* [#3034](https://github.com/apache/incubator-nuttx/pull/3034) arm: imx6: Fix an error message in imx_enet.c
-* [#3051](https://github.com/apache/incubator-nuttx/pull/3051) risc-v: Internal functions should be prefixed with riscv_ not up
-* [#3075](https://github.com/apache/incubator-nuttx/pull/3075) arm: Fix syscall number out of swi range in thumb mode
-* [#3079](https://github.com/apache/incubator-nuttx/pull/3079) arm: kinetis: [FlexCAN] Correct reset state for CTRL1 register
-* [#3079](https://github.com/apache/incubator-nuttx/pull/3079) arm: s32k1xx: [FlexCAN] Correct reset state for CTRL1 register
-* [#3088](https://github.com/apache/incubator-nuttx/pull/3088) arm: samv7: Fix sam_putreg() parameter type
-* [#3092](https://github.com/apache/incubator-nuttx/pull/3092) xtensa: xtensa: esp32_allocateheap.c: Don't allocate ROM regions when running in QEMU.
-* [#3116](https://github.com/apache/incubator-nuttx/pull/3116) arm: stm32l5: Enable SPI support and license clearing
-* [#3119](https://github.com/apache/incubator-nuttx/pull/2976) xtensa: sp32: Fix buffer size word-alignment for DMA transfers
-* [#3125](https://github.com/apache/incubator-nuttx/pull/3125) risc-v: Internal functions should be prefixed with "riscv_"
-* [#3130](https://github.com/apache/incubator-nuttx/pull/3145) xtensa: esp32: Fix SPI polling mode when DMA is also enabled.
-* [#3135](https://github.com/apache/incubator-nuttx/pull/3135) rv64:c906:colorize the idle stack area;minor fixes.
-* [#3145](https://github.com/apache/incubator-nuttx/pull/3145) xtensa: esp32_part_ioctl: Return -ENOTTY for unknown commands
-* [#3162](https://github.com/apache/incubator-nuttx/pull/3162) arm: STM32 USB OTGFSDEV: Fix handling of SETUP OUT longer than 64 bytes
-* [#3167](https://github.com/apache/incubator-nuttx/pull/3167) arm: stm32h7:SPI Fix 16 bit SPI mode
-* [#3174](https://github.com/apache/incubator-nuttx/pull/3174) arm: Use macro defined swi range in dispatch_syscall
-* [#3178](https://github.com/apache/incubator-nuttx/pull/3178) arm: tiva:cc13x0_adi3_refsys fix typo
-* [#3198](https://github.com/apache/incubator-nuttx/pull/3198) arm: Stm32h7 fix heap clobber
-* [#3199](https://github.com/apache/incubator-nuttx/pull/3199) xtensa: ESP32: Fix math for DMA buffer length rounding
-* [#3200](https://github.com/apache/incubator-nuttx/pull/3200) xtensa: esp32: Fix DMA burst mode being unintendedly disabled
-* [#3219](https://github.com/apache/incubator-nuttx/pull/3219) risc-v: bl602: fix _heap_start not word aligned
-* [#3220](https://github.com/apache/incubator-nuttx/pull/3220) arm: Fix indexing for stm32h7 usbhost tracing
-* [#3248](https://github.com/apache/incubator-nuttx/pull/3248) xtensa: esp32: remove extra initial newline on syslog call
-* [#3283](https://github.com/apache/incubator-nuttx/pull/3283) rv64:add memory clobber to inline asm for syscall.
-* [#3285](https://github.com/apache/incubator-nuttx/pull/3285) arm: Remove .cpu directive from assemble file
-* [#3293](https://github.com/apache/incubator-nuttx/pull/3293) arm: armv6-m: Remove cpsid and cpsie from exception_common
-* [#3307](https://github.com/apache/incubator-nuttx/pull/3307) arm: Replace the hardcode syscall number with macro
-* [#3310](https://github.com/apache/incubator-nuttx/pull/3310) arm: armv8-m: Merge ite instruction to the previous one
-* [#3311](https://github.com/apache/incubator-nuttx/pull/3311) arm: fix the potential corruption in initialization
-* [#3313](https://github.com/apache/incubator-nuttx/pull/3313) arm: Replace "b lr" or "mov pc, lr" with "bx lr"
-* [#3315](https://github.com/apache/incubator-nuttx/pull/3315) arm: Move setjmp/longjmp to libc/machine
-* [#3326](https://github.com/apache/incubator-nuttx/pull/3326) arm: Update the old arm architecture with the recent fix
-* [#3440](https://github.com/apache/incubator-nuttx/pull/3440) arm: Change all spsr_cxsf to spsr
-* [#3448](https://github.com/apache/incubator-nuttx/pull/3448) arm: armv7-a: Remove the special process of the nest level
-* [#3451](https://github.com/apache/incubator-nuttx/pull/3451) arm: Remove g_irqtmp, g_undeftmp and g_aborttmp
-* [#3452](https://github.com/apache/incubator-nuttx/pull/3452) risc-v: esp32-c3: Refactors and fixes issues on serial driver.
-* [#3457](https://github.com/apache/incubator-nuttx/pull/3457) arm: stm32h7: Actually use the AXI SRAM as the main heap as the documentation describes in PROTECTED mode.
-* [#3459](https://github.com/apache/incubator-nuttx/pull/3459) arm: stm32h7: Fixes build error in stm32_sdmmc.c without DCACHE
-* [#3473](https://github.com/apache/incubator-nuttx/pull/3473) xtensa: esp32: move common XTAL and RUN_IRAM configs to ESP32 KConfig
-* [#3486](https://github.com/apache/incubator-nuttx/pull/3486) xtensa: esp32: Improve SPI polling to use the entire HW buffer
-* [#3492](https://github.com/apache/incubator-nuttx/pull/3492) risc-v: riscv_initialize.c: Add telnet_initialize to riscv's up_initialize
-* [#2868](https://github.com/apache/incubator-nuttx/pull/2868) xtensa: Fix xtensa stack coloring
+* [#1904](https://github.com/apache/nuttx/pull/1904) xtensa: ESP32: Fixed the type of cpuint variables in esp32_emac.c
+* [#1943](https://github.com/apache/nuttx/pull/1943) xtensa: ESP32: Fix and clean some corners of GPIOs configuration.
+* [#1947](https://github.com/apache/nuttx/pull/1947) xtensa: esp32: Fix crash on startup
+* [#1948](https://github.com/apache/nuttx/pull/1948) xtensa: ESP32: Fixes the GPIO's function mask test
+* [#1960](https://github.com/apache/nuttx/pull/1960) xtensa: xtensa.h: Include sys/types.h needed if STACK_COLORATON is enabled
+* [#1968](https://github.com/apache/nuttx/pull/1968) arm: kinetis: freedom-k64f: Declare missing NUM_BUTTONS
+* [#1990](https://github.com/apache/nuttx/pull/1990) arm: kinetis: flexcan fixed compile error
+* [#2120](https://github.com/apache/nuttx/pull/2120) arm: stm32h7: Fix missing 'ret' reported by Frank-Christian Kruegel
+* [#2159](https://github.com/apache/nuttx/pull/2159) xtensa: esp32: Fix SPI master DMA RX buffer memcpy size erro
+* [#2160](https://github.com/apache/nuttx/pull/2160) arm: stm32l4/stm32l4_adc.c: fix copy-paste mistake with CONFI
+* [#2210](https://github.com/apache/nuttx/pull/2210) arm: stm32/stm32_adc.c: do not allow negative ref count
+* [#2214](https://github.com/apache/nuttx/pull/2214) xtensa: esp32: Fix rt-timer issues
+* [#2233](https://github.com/apache/nuttx/pull/2233) xtensa: esp32: Fix the memory regions with regards to the range used by the ROM
+* [#2240](https://github.com/apache/nuttx/pull/2240) arm: nrf52 GPIO/GPIOTE: better expose pin interrupt capability
+* [#2284](https://github.com/apache/nuttx/pull/2284) arm: stm32h7/stm32_dmamux.h: Fix errors in bitfield definitions
+* [#2286](https://github.com/apache/nuttx/pull/2286) arm: stm32f0l0g0/stm32_dmamux.h: Fix errors in bitfield definitions
+* [#2287](https://github.com/apache/nuttx/pull/2287) arm: stm32h7/stm32_dmamux.h: Add missing CCR SPOL defines
+* [#2300](https://github.com/apache/nuttx/pull/2300) arm: sam34: compile error on SAM34 TWI
+* [#2316](https://github.com/apache/nuttx/pull/2844) risc-v: minor fix
+* [#2330](https://github.com/apache/nuttx/pull/2330) xtensa: esp32/esp32_tim.c: Fix build when debug is enabled.
+* [#2336](https://github.com/apache/nuttx/pull/2336) arm: stm32l4: correct macros STM32L4_CAN_MCR_OFFSET, etc... to match defines
+* [#2344](https://github.com/apache/nuttx/pull/2344) xtensa: esp32/esp32_gpio.c: Fix GPIO IRQ assert condition
+* [#2351](https://github.com/apache/nuttx/pull/2351) xtensa: esp32: Fix issues of force-sleep
+* [#2355](https://github.com/apache/nuttx/pull/2355) xtensa: esp32_himem: Fix issue that was preventing to map all free memory
+* [#2361](https://github.com/apache/nuttx/pull/2361) arm: nrf52 GPIO: minor fixes
+* [#2364](https://github.com/apache/nuttx/pull/2364) arm: stm32h7: Fix bug where more than CONFIG_MM_REGIONS would be allocated
+* [#2372](https://github.com/apache/nuttx/pull/2372) rv64: Fix SCN/PRI.PTR definitions
+* [#2373](https://github.com/apache/nuttx/pull/2373) risc-v: Don't use non existent "saved_status"
+* [#2423](https://github.com/apache/nuttx/pull/2423) xetnsa: Couple of Xtensa fixes
+* [#2448](https://github.com/apache/nuttx/pull/2448) arm: stm32/stm32h7: fix the configuration of PWM outputs when subsequent channels are not enabled
+* [#2454](https://github.com/apache/nuttx/pull/2454) xtensa: esp32/esp32-core: Fix #ifdef warning and update MM_SECTIONS
+* [#2483](https://github.com/apache/nuttx/pull/2483) arm: stm32: convert all STM32G47X specific code to generic STM32G4 series code
+* [#2519](https://github.com/apache/nuttx/pull/2519) arm: imxrt: replace clock_systimespec with clock_systime_timespec
+* [#2536](https://github.com/apache/nuttx/pull/2536) xtensa: esp32: fixes enable int function and gets apb clk frequency through function
+* [#2546](https://github.com/apache/nuttx/pull/2546) arm: imxrt: imxrt_usdhc.c: fixed no DMA build error
+* [#2551](https://github.com/apache/nuttx/pull/2551) arm: stm32h7x3xx_memorymap.h invalid address map for fdcan
+* [#2554](https://github.com/apache/nuttx/pull/2554) xtensa: Esp32 wifi fixes
+* [#2555](https://github.com/apache/nuttx/pull/2555) xtensa: esp32/esp32_spiflash.c: Writeback PSRAM data before invalidating the cache
+* [#2559](https://github.com/apache/nuttx/pull/2559) risc-v: Remove duplicated declaration for up_irq_save and up_irq_restore
+* [#2560](https://github.com/apache/nuttx/pull/2560) risc-v: Move csr.h to common place
+* [#2568](https://github.com/apache/nuttx/pull/2568) risc-v: Move CSR register bit definition to csr.h
+* [#2569](https://github.com/apache/nuttx/pull/2569) risc-v: Reuse the common up_schedule_sigaction implementation
+* [#2570](https://github.com/apache/nuttx/pull/2570) arm: stm32g4: Fix incorrect FLASH wait states
+* [#2573](https://github.com/apache/nuttx/pull/2573) xtensa: esp32: Bump NAME_MAX where CONFIG_ESP32_WIFI_SAVE_PARAM=y
+* [#2584](https://github.com/apache/nuttx/pull/2584) xtensa: esp32_wifi_adapter.c: file mode for open doesn't make sense for O_RDONLY
+* [#2589](https://github.com/apache/nuttx/pull/2589) risc-v: fix redefined CSR_INSTRET
+* [#2612](https://github.com/apache/nuttx/pull/2612) arm: kinetis: S32K/Kinetis: Fix RTC settime prescaler
+* [#2612](https://github.com/apache/nuttx/pull/2612) arm: S32K/Kinetis: Fix RTC settime prescaler
+* [#2647](https://github.com/apache/nuttx/pull/2647) xtensa: esp32: Fix ESP32 serial UART tx ready check error
+* [#2666](https://github.com/apache/nuttx/pull/2666) xtensa: esp32: Fix ESP32 SPI3 slave ops data error
+* [#2676](https://github.com/apache/nuttx/pull/2676) arm: stm32412: Fixes pinmap CAN1
+* [#2689](https://github.com/apache/nuttx/pull/2689) arm: tiva: Fix lm3s_ethernet.c with DEBUGASSERT
+* [#2700](https://github.com/apache/nuttx/pull/2700) arm: nRF52 various minor fixes
+* [#2708](https://github.com/apache/nuttx/pull/2708) xtensa: esp32: Fix ESP32 I2C driver issues
+* [#2709](https://github.com/apache/nuttx/pull/2709) xtensa: esp32: Fix ESP32 SPI driver issues
+* [#2722](https://github.com/apache/nuttx/pull/2722) arm: stm32f412:Replaced Kludged pinmap with one for SoC.
+* [#2725](https://github.com/apache/nuttx/pull/2725) arm: nRF52: FIX wrong bitmask for DRIVE setting
+* [#2727](https://github.com/apache/nuttx/pull/2727) xtensa: esp32_free_cpuint: Fix an assertion
+* [#2728](https://github.com/apache/nuttx/pull/2728) xtensa: esp32_dma_init: Fix a dubious assertion
+* [#2731](https://github.com/apache/nuttx/pull/2731) xtensa: esp_allocateheap.c: Correct ROM memory boundaries in SMP case
+* [#2752](https://github.com/apache/nuttx/pull/2752) xtensa: esp32/esp32_spiflash.c: Fix the value of the page start address when invalidating the cache
+* [#2755](https://github.com/apache/nuttx/pull/2755) xtensa: esp32: Fix compile errors with CONFIG_SMP=y
+* [#2757](https://github.com/apache/nuttx/pull/2757) xtensa: esp32/esp32_wifi_adapter.c: Print debug output only when DEBUG_WIRLESS* are enabled
+* [#2758](https://github.com/apache/nuttx/pull/2758) xtensa: Kconfig: Reduce the default value of the internal memory
+* [#2759](https://github.com/apache/nuttx/pull/2759) xtensa: esp32/psram: Fix missing configs
+* [#2761](https://github.com/apache/nuttx/pull/2761) risc-v: Remove unused and undefined file section "Public Variables"
+* [#2763](https://github.com/apache/nuttx/pull/2763) arm: imx6: Apply the latest imxrt/imxrt_enet.c to imx6/imx_enet.c
+* [#2771](https://github.com/apache/nuttx/pull/2771) arm: imx6: Update imx6 enet
+* [#2772](https://github.com/apache/nuttx/pull/2771) arm: imx6 enet with TCP_WRITE_BUFFERS
+* [#2777](https://github.com/apache/nuttx/pull/2777) arm: imx6: Fix a compile error with CONFIG_DEBUG_ASSERTIONS=y
+* [#2779](https://github.com/apache/nuttx/pull/2779) arm: samv7/sam_mcan.c: fix some mismatches caused by renaming
+* [#2782](https://github.com/apache/nuttx/pull/2782) arm: nRF52 fixes
+* [#2788](https://github.com/apache/nuttx/pull/2788) risc-v: Don't declare riscv_addregion if CONFIG_MM_REGIONS is < 1.
+* [#2791](https://github.com/apache/nuttx/pull/2791) arm: stm32f7/stm32_qspi.c: Fix warning of format strings
+* [#2792](https://github.com/apache/nuttx/pull/2792) arm: [imxrt] Fix FlexCAN tx dropping frames
+* [#2793](https://github.com/apache/nuttx/pull/2316) risc-v: Remove nx_start prototype from riscv_internal.h
+* [#2795](https://github.com/apache/nuttx/pull/2795) arm: stm32f412:Corrected Pin count
+* [#2796](https://github.com/apache/nuttx/pull/2796) xtensa: esp32: Fix cache issue detected by DEBUG_ASSERTION
+* [#2799](https://github.com/apache/nuttx/pull/2799) RV64: handle relocation type R_RISCV_CALL_PLT in PIC build.
+* [#2805](https://github.com/apache/nuttx/pull/2805) arm: imxrt1060 iperf
+* [#2812](https://github.com/apache/nuttx/pull/2812) xtensa: esp32_spiflash.c: Fix preprocessor condition
+* [#2813](https://github.com/apache/nuttx/pull/2813) xtensa: esp32: Add extern modifier to ROM function declaration
+* [#2815](https://github.com/apache/nuttx/pull/2815) riscv: Fix files names in headers that were still using the old 'up_' prefix
+* [#2832](https://github.com/apache/nuttx/pull/2832) xtensa: esp32: Fix the issue of WiFi internal malloc from PSRAM
+* [#2844](https://github.com/apache/nuttx/pull/2844) risc-v: LiteX: Make Arty-A7 example work
+* [#2867](https://github.com/apache/nuttx/pull/2867) arm: lpc17xx_40xx/lpc17_40_i2c.c: Propagate I2C I/O errors
+* [#2886](https://github.com/apache/nuttx/pull/2886) arm: pic32mz: Chip does not have ANSEL register on port K
+* [#2889](https://github.com/apache/nuttx/pull/2889) arm: pic32mx7 cannot perform context switch
+* [#2892](https://github.com/apache/nuttx/pull/2892) risc-v: esp32-c3: Don't reserve any vectors for any special use.
+* [#2893](https://github.com/apache/nuttx/pull/2893) risc-v: esp32-c3: Build serial driver only when selected
+* [#2903](https://github.com/apache/nuttx/pull/2903) xtensa: esp32: xtensa_user: Implement a few more instructions
+* [#2912](https://github.com/apache/nuttx/pull/2912) risc-v: esp32-c3: Fix CPU interrupts freeing on WDT driver
+* [#2917](https://github.com/apache/nuttx/pull/2917) arm: Add 'select ARM_HAVE_WFE_SEV' to ARCH_CHIP_RP2040
+* [#2920](https://github.com/apache/nuttx/pull/2920) risc-v: esp32-c3: Configure clock and call board initialize at startup
+* [#2923](https://github.com/apache/nuttx/pull/2923) ez80: fix several bugs in emac driver
+* [#2931](https://github.com/apache/nuttx/pull/2931) arm: kinetis: [FlexCAN] Fix TX drop #2792 and correctly set CAN timings to non-zero
+* [#2931](https://github.com/apache/nuttx/pull/2931) arm: s32k1xx: [FlexCAN] Fix TX drop #2792 and correctly set CAN timings to non-zero
+* [#2943](https://github.com/apache/nuttx/pull/2943) arm: stm32x7:lse ensure it is started
+* [#2951](https://github.com/apache/nuttx/pull/2951) arm: stm32_wwdg debug log formatting
+* [#2967](https://github.com/apache/nuttx/pull/2967) arm: STM32F7 lse static values directly from Kconfig
+* [#2968](https://github.com/apache/nuttx/pull/2968) xtensa: esp32: Change I2C SCL default pin to a valid one
+* [#2972](https://github.com/apache/nuttx/pull/2972) risc-v: esp32-c3: Fix GPIO pin function configuration
+* [#2976](https://github.com/apache/nuttx/pull/2976) xtensa: ESP32: Fix I2C Kconfig bringing the character driver as a dependency
+* [#2977](https://github.com/apache/nuttx/pull/2977) xtensa: ESP32: Fix GPIO pin function configuration
+* [#2996](https://github.com/apache/nuttx/pull/2996) arm: stm32h747xi: Fix missing IO_CONFIG setting
+* [#3008](https://github.com/apache/nuttx/pull/3008) risc-v: esp32-c3: free cpu in case it was preallocated in wdt driver
+* [#3013](https://github.com/apache/nuttx/pull/3013) risc-v: bl602:fix bl602_flash_erase to erase the wrong block
+* [#3034](https://github.com/apache/nuttx/pull/3034) arm: imx6: Fix an error message in imx_enet.c
+* [#3051](https://github.com/apache/nuttx/pull/3051) risc-v: Internal functions should be prefixed with riscv_ not up
+* [#3075](https://github.com/apache/nuttx/pull/3075) arm: Fix syscall number out of swi range in thumb mode
+* [#3079](https://github.com/apache/nuttx/pull/3079) arm: kinetis: [FlexCAN] Correct reset state for CTRL1 register
+* [#3079](https://github.com/apache/nuttx/pull/3079) arm: s32k1xx: [FlexCAN] Correct reset state for CTRL1 register
+* [#3088](https://github.com/apache/nuttx/pull/3088) arm: samv7: Fix sam_putreg() parameter type
+* [#3092](https://github.com/apache/nuttx/pull/3092) xtensa: xtensa: esp32_allocateheap.c: Don't allocate ROM regions when running in QEMU.
+* [#3116](https://github.com/apache/nuttx/pull/3116) arm: stm32l5: Enable SPI support and license clearing
+* [#3119](https://github.com/apache/nuttx/pull/2976) xtensa: sp32: Fix buffer size word-alignment for DMA transfers
+* [#3125](https://github.com/apache/nuttx/pull/3125) risc-v: Internal functions should be prefixed with "riscv_"
+* [#3130](https://github.com/apache/nuttx/pull/3145) xtensa: esp32: Fix SPI polling mode when DMA is also enabled.
+* [#3135](https://github.com/apache/nuttx/pull/3135) rv64:c906:colorize the idle stack area;minor fixes.
+* [#3145](https://github.com/apache/nuttx/pull/3145) xtensa: esp32_part_ioctl: Return -ENOTTY for unknown commands
+* [#3162](https://github.com/apache/nuttx/pull/3162) arm: STM32 USB OTGFSDEV: Fix handling of SETUP OUT longer than 64 bytes
+* [#3167](https://github.com/apache/nuttx/pull/3167) arm: stm32h7:SPI Fix 16 bit SPI mode
+* [#3174](https://github.com/apache/nuttx/pull/3174) arm: Use macro defined swi range in dispatch_syscall
+* [#3178](https://github.com/apache/nuttx/pull/3178) arm: tiva:cc13x0_adi3_refsys fix typo
+* [#3198](https://github.com/apache/nuttx/pull/3198) arm: Stm32h7 fix heap clobber
+* [#3199](https://github.com/apache/nuttx/pull/3199) xtensa: ESP32: Fix math for DMA buffer length rounding
+* [#3200](https://github.com/apache/nuttx/pull/3200) xtensa: esp32: Fix DMA burst mode being unintendedly disabled
+* [#3219](https://github.com/apache/nuttx/pull/3219) risc-v: bl602: fix _heap_start not word aligned
+* [#3220](https://github.com/apache/nuttx/pull/3220) arm: Fix indexing for stm32h7 usbhost tracing
+* [#3248](https://github.com/apache/nuttx/pull/3248) xtensa: esp32: remove extra initial newline on syslog call
+* [#3283](https://github.com/apache/nuttx/pull/3283) rv64:add memory clobber to inline asm for syscall.
+* [#3285](https://github.com/apache/nuttx/pull/3285) arm: Remove .cpu directive from assemble file
+* [#3293](https://github.com/apache/nuttx/pull/3293) arm: armv6-m: Remove cpsid and cpsie from exception_common
+* [#3307](https://github.com/apache/nuttx/pull/3307) arm: Replace the hardcode syscall number with macro
+* [#3310](https://github.com/apache/nuttx/pull/3310) arm: armv8-m: Merge ite instruction to the previous one
+* [#3311](https://github.com/apache/nuttx/pull/3311) arm: fix the potential corruption in initialization
+* [#3313](https://github.com/apache/nuttx/pull/3313) arm: Replace "b lr" or "mov pc, lr" with "bx lr"
+* [#3315](https://github.com/apache/nuttx/pull/3315) arm: Move setjmp/longjmp to libc/machine
+* [#3326](https://github.com/apache/nuttx/pull/3326) arm: Update the old arm architecture with the recent fix
+* [#3440](https://github.com/apache/nuttx/pull/3440) arm: Change all spsr_cxsf to spsr
+* [#3448](https://github.com/apache/nuttx/pull/3448) arm: armv7-a: Remove the special process of the nest level
+* [#3451](https://github.com/apache/nuttx/pull/3451) arm: Remove g_irqtmp, g_undeftmp and g_aborttmp
+* [#3452](https://github.com/apache/nuttx/pull/3452) risc-v: esp32-c3: Refactors and fixes issues on serial driver.
+* [#3457](https://github.com/apache/nuttx/pull/3457) arm: stm32h7: Actually use the AXI SRAM as the main heap as the documentation describes in PROTECTED mode.
+* [#3459](https://github.com/apache/nuttx/pull/3459) arm: stm32h7: Fixes build error in stm32_sdmmc.c without DCACHE
+* [#3473](https://github.com/apache/nuttx/pull/3473) xtensa: esp32: move common XTAL and RUN_IRAM configs to ESP32 KConfig
+* [#3486](https://github.com/apache/nuttx/pull/3486) xtensa: esp32: Improve SPI polling to use the entire HW buffer
+* [#3492](https://github.com/apache/nuttx/pull/3492) risc-v: riscv_initialize.c: Add telnet_initialize to riscv's up_initialize
+* [#2868](https://github.com/apache/nuttx/pull/2868) xtensa: Fix xtensa stack coloring
 
 ## Simulator
 
 ### New Features
-* [#2129](https://github.com/apache/incubator-nuttx/pull/2129) add "nimble" config, to test nimBLE on top of bthcisock
-* [#2130](https://github.com/apache/incubator-nuttx/pull/2130) rpproxy/rpserver: force use 'CONFIG_SIM_M32' for 64bit system.
-* [#2158](https://github.com/apache/incubator-nuttx/pull/2158) linux I2C bus support in sim
-* [#2164](https://github.com/apache/incubator-nuttx/pull/2164) add LVGL configuration which uses the X11 framebuffer and mouse
-* [#2198](https://github.com/apache/incubator-nuttx/pull/2198) support LCD emulation over X11; correctly decouple LCD/FB from X11/NX
-* [#2579](https://github.com/apache/incubator-nuttx/pull/2579) make it conditional with FS_FAT
-* [#2599](https://github.com/apache/incubator-nuttx/pull/2599) names: add writev/readv into name list
-* [#2619](https://github.com/apache/incubator-nuttx/pull/2619) hci: reuse the reserved fields of hci buffer
-* [#2690](https://github.com/apache/incubator-nuttx/pull/2690) support sim vfork
-* [#2696](https://github.com/apache/incubator-nuttx/pull/2696) hcitty: add hcitty adapter
-* [#2720](https://github.com/apache/incubator-nuttx/pull/2720) board/sim: Support NuttX BLE stack through uart shim driver
-* [#3093](https://github.com/apache/incubator-nuttx/pull/3093) add heap policy and asan logic to support mm debug on sim platform
-* [#3152](https://github.com/apache/incubator-nuttx/pull/3152) add dlsym to [nuttx-names.in](http://nuttx-names.in)
-* [#3224](https://github.com/apache/incubator-nuttx/pull/3224) boards/sim: remove dsptest configuration
-* [#3231](https://github.com/apache/incubator-nuttx/pull/3231) add the simulated lower-half FOC device
-* [#3478](https://github.com/apache/incubator-nuttx/pull/3478) refactor signal handling
+* [#2129](https://github.com/apache/nuttx/pull/2129) add "nimble" config, to test nimBLE on top of bthcisock
+* [#2130](https://github.com/apache/nuttx/pull/2130) rpproxy/rpserver: force use 'CONFIG_SIM_M32' for 64bit system.
+* [#2158](https://github.com/apache/nuttx/pull/2158) linux I2C bus support in sim
+* [#2164](https://github.com/apache/nuttx/pull/2164) add LVGL configuration which uses the X11 framebuffer and mouse
+* [#2198](https://github.com/apache/nuttx/pull/2198) support LCD emulation over X11; correctly decouple LCD/FB from X11/NX
+* [#2579](https://github.com/apache/nuttx/pull/2579) make it conditional with FS_FAT
+* [#2599](https://github.com/apache/nuttx/pull/2599) names: add writev/readv into name list
+* [#2619](https://github.com/apache/nuttx/pull/2619) hci: reuse the reserved fields of hci buffer
+* [#2690](https://github.com/apache/nuttx/pull/2690) support sim vfork
+* [#2696](https://github.com/apache/nuttx/pull/2696) hcitty: add hcitty adapter
+* [#2720](https://github.com/apache/nuttx/pull/2720) board/sim: Support NuttX BLE stack through uart shim driver
+* [#3093](https://github.com/apache/nuttx/pull/3093) add heap policy and asan logic to support mm debug on sim platform
+* [#3152](https://github.com/apache/nuttx/pull/3152) add dlsym to [nuttx-names.in](http://nuttx-names.in)
+* [#3224](https://github.com/apache/nuttx/pull/3224) boards/sim: remove dsptest configuration
+* [#3231](https://github.com/apache/nuttx/pull/3231) add the simulated lower-half FOC device
+* [#3478](https://github.com/apache/nuttx/pull/3478) refactor signal handling
 
 ### Bug Fixes
-* [#2109](https://github.com/apache/incubator-nuttx/pull/2109) Revert "arch/sim: Make the SIGUSR1 host signal use the NuttX irq logic"
-* [#2246](https://github.com/apache/incubator-nuttx/pull/2246) boards/sim/sim/sim/src/sim_touchscreen.c: add missing nx_disconnect
-* [#2259](https://github.com/apache/incubator-nuttx/pull/2259) boards/sim: add atexit(2) into naming list
-* [#2441](https://github.com/apache/incubator-nuttx/pull/2441) sim: fix input handling and add simulated buttons support from mouse
-* [#2597](https://github.com/apache/incubator-nuttx/pull/2597) Revert "board/sim: Remove the too strict warning"
-* [#3176](https://github.com/apache/incubator-nuttx/pull/3176) sim: fix signal deliver calling error on sim platform
-* [#3205](https://github.com/apache/incubator-nuttx/pull/3205) sim: do not exit simulator on up_assert (just let the task exit)
+* [#2109](https://github.com/apache/nuttx/pull/2109) Revert "arch/sim: Make the SIGUSR1 host signal use the NuttX irq logic"
+* [#2246](https://github.com/apache/nuttx/pull/2246) boards/sim/sim/sim/src/sim_touchscreen.c: add missing nx_disconnect
+* [#2259](https://github.com/apache/nuttx/pull/2259) boards/sim: add atexit(2) into naming list
+* [#2441](https://github.com/apache/nuttx/pull/2441) sim: fix input handling and add simulated buttons support from mouse
+* [#2597](https://github.com/apache/nuttx/pull/2597) Revert "board/sim: Remove the too strict warning"
+* [#3176](https://github.com/apache/nuttx/pull/3176) sim: fix signal deliver calling error on sim platform
+* [#3205](https://github.com/apache/nuttx/pull/3205) sim: do not exit simulator on up_assert (just let the task exit)
 
 ## Documentation
 
 ### New Features
-* [#1955](https://github.com/apache/incubator-nuttx/pull/1955) Add documentation for note filters and task trace guides
-* [#1959](https://github.com/apache/incubator-nuttx/pull/1959) Documentation for the Timer Driver
-* [#2268](https://github.com/apache/incubator-nuttx/pull/2268) Documentation for Watchdog Timer Driver
-* [#2334](https://github.com/apache/incubator-nuttx/pull/2334) [CONTRIBUTING.md](http://CONTRIBUTING.md): talk about preferred commit message format
-* [#2408](https://github.com/apache/incubator-nuttx/pull/2408) Documentation: support versioned docs
-* [#2543](https://github.com/apache/incubator-nuttx/pull/2543) Documentation: how to use auto monitor feature to keep the chip alive
-* [#2818](https://github.com/apache/incubator-nuttx/pull/2818) Documentation: introduce hardware platforms documentation
-* [#2819](https://github.com/apache/incubator-nuttx/pull/2819) Documentation: document nRF52832 Sparkfun board (improve MDK board a bit)
-* [#3022](https://github.com/apache/incubator-nuttx/pull/3022) hostfs: Document the backends and restrictions
-* [#3127](https://github.com/apache/incubator-nuttx/pull/3127) Documentation: add ESP32 and DevKitC docs
-* [#3138](https://github.com/apache/incubator-nuttx/pull/3138) Addind CMake based C++ project example in documentation
-* [#3490](https://github.com/apache/incubator-nuttx/pull/3490) Documentation/esp32: Add supported peripherals
+* [#1955](https://github.com/apache/nuttx/pull/1955) Add documentation for note filters and task trace guides
+* [#1959](https://github.com/apache/nuttx/pull/1959) Documentation for the Timer Driver
+* [#2268](https://github.com/apache/nuttx/pull/2268) Documentation for Watchdog Timer Driver
+* [#2334](https://github.com/apache/nuttx/pull/2334) [CONTRIBUTING.md](http://CONTRIBUTING.md): talk about preferred commit message format
+* [#2408](https://github.com/apache/nuttx/pull/2408) Documentation: support versioned docs
+* [#2543](https://github.com/apache/nuttx/pull/2543) Documentation: how to use auto monitor feature to keep the chip alive
+* [#2818](https://github.com/apache/nuttx/pull/2818) Documentation: introduce hardware platforms documentation
+* [#2819](https://github.com/apache/nuttx/pull/2819) Documentation: document nRF52832 Sparkfun board (improve MDK board a bit)
+* [#3022](https://github.com/apache/nuttx/pull/3022) hostfs: Document the backends and restrictions
+* [#3127](https://github.com/apache/nuttx/pull/3127) Documentation: add ESP32 and DevKitC docs
+* [#3138](https://github.com/apache/nuttx/pull/3138) Addind CMake based C++ project example in documentation
+* [#3490](https://github.com/apache/nuttx/pull/3490) Documentation/esp32: Add supported peripherals
 
 ### Improvements
-* [#2021](https://github.com/apache/incubator-nuttx/pull/2021) Correct the links in Documentation folder
-* [#2024](https://github.com/apache/incubator-nuttx/pull/2024) Fix broken documentation links
-* [#2026](https://github.com/apache/incubator-nuttx/pull/2026) Documentation: Remove all tail spaces from *.rst and *.html
-* [#2027](https://github.com/apache/incubator-nuttx/pull/2027) Documentation: Reorganize some section
-* [#2031](https://github.com/apache/incubator-nuttx/pull/2031) Documentation/quickstart/debugging.rst: rewrite JTAG/OpenOCD section
-* [#2045](https://github.com/apache/incubator-nuttx/pull/2045) Documentation: Misc fixups for broken links, errors, warnings
-* [#2051](https://github.com/apache/incubator-nuttx/pull/2051) Documentation/quickstart/debugging: rewrite SWD sentence
-* [#2106](https://github.com/apache/incubator-nuttx/pull/2106) documentation: change non-working URL
-* [#2329](https://github.com/apache/incubator-nuttx/pull/2329) Documentation/components/drivers/character/pwm: fix pwm.c location
-* [#2362](https://github.com/apache/incubator-nuttx/pull/2362) Documentation improvements
-* [#2390](https://github.com/apache/incubator-nuttx/pull/2390) Documentation: improve debugging section
-* [#2485](https://github.com/apache/incubator-nuttx/pull/2485) Documentaiton: merge quickstart to getting started
-* [#2563](https://github.com/apache/incubator-nuttx/pull/2563) update Documentation/components/drivers/character/watchdog.rst
-* [#3144](https://github.com/apache/incubator-nuttx/pull/3144) CI: remove linkcheck when building docs
-* [#3180](https://github.com/apache/incubator-nuttx/pull/3180) documentation: improve boardctl() docs
-* [#3194](https://github.com/apache/incubator-nuttx/pull/3194) Documentation: add syslog user API and other minor improvements
-* [#3271](https://github.com/apache/incubator-nuttx/pull/3271) docs and comments: Update stale references to COPYING
-* [#3470](https://github.com/apache/incubator-nuttx/pull/3470) Documentation: migrate ESP32 README to docs
+* [#2021](https://github.com/apache/nuttx/pull/2021) Correct the links in Documentation folder
+* [#2024](https://github.com/apache/nuttx/pull/2024) Fix broken documentation links
+* [#2026](https://github.com/apache/nuttx/pull/2026) Documentation: Remove all tail spaces from *.rst and *.html
+* [#2027](https://github.com/apache/nuttx/pull/2027) Documentation: Reorganize some section
+* [#2031](https://github.com/apache/nuttx/pull/2031) Documentation/quickstart/debugging.rst: rewrite JTAG/OpenOCD section
+* [#2045](https://github.com/apache/nuttx/pull/2045) Documentation: Misc fixups for broken links, errors, warnings
+* [#2051](https://github.com/apache/nuttx/pull/2051) Documentation/quickstart/debugging: rewrite SWD sentence
+* [#2106](https://github.com/apache/nuttx/pull/2106) documentation: change non-working URL
+* [#2329](https://github.com/apache/nuttx/pull/2329) Documentation/components/drivers/character/pwm: fix pwm.c location
+* [#2362](https://github.com/apache/nuttx/pull/2362) Documentation improvements
+* [#2390](https://github.com/apache/nuttx/pull/2390) Documentation: improve debugging section
+* [#2485](https://github.com/apache/nuttx/pull/2485) Documentaiton: merge quickstart to getting started
+* [#2563](https://github.com/apache/nuttx/pull/2563) update Documentation/components/drivers/character/watchdog.rst
+* [#3144](https://github.com/apache/nuttx/pull/3144) CI: remove linkcheck when building docs
+* [#3180](https://github.com/apache/nuttx/pull/3180) documentation: improve boardctl() docs
+* [#3194](https://github.com/apache/nuttx/pull/3194) Documentation: add syslog user API and other minor improvements
+* [#3271](https://github.com/apache/nuttx/pull/3271) docs and comments: Update stale references to COPYING
+* [#3470](https://github.com/apache/nuttx/pull/3470) Documentation: migrate ESP32 README to docs
 
 ## Driver Support
 
 ### New Driver Support
-* [#1936](https://github.com/apache/incubator-nuttx/pull/1936) note: Add task trace support
-* [#1989](https://github.com/apache/incubator-nuttx/pull/1989) sensors: Support fxos8700cq motion I2C sensor
-* [#2091](https://github.com/apache/incubator-nuttx/pull/2091) usbdev: add Android Debug Bridge driver
-* [#2166](https://github.com/apache/incubator-nuttx/pull/2166) lcd: Add LCD character driver: allows interacting with LCD directly from userspace
-* [#2216](https://github.com/apache/incubator-nuttx/pull/2216) rc: support infrared remote control
-* [#2282](https://github.com/apache/incubator-nuttx/pull/2282) audio: cxd56: add initial audio SRC implementation
-* [#2301](https://github.com/apache/incubator-nuttx/pull/2301) analog: support for MAX1161X family of I2C 12 bit ADC chips
-* [#2429](https://github.com/apache/incubator-nuttx/pull/2429) audio: add simple wm8994 codec driver
-* [#2628](https://github.com/apache/incubator-nuttx/pull/2628) efuse: Add generic efuse driver for NuttX
-* [#2736](https://github.com/apache/incubator-nuttx/pull/2736) console: Add generic support to LWL Console
-* [#2829](https://github.com/apache/incubator-nuttx/pull/2829) sensor: add fakesensor driver
-* [#3230](https://github.com/apache/incubator-nuttx/pull/3230) motor: add generic upper-half driver for Field Oriented Control (FOC)
-* [#3474](https://github.com/apache/incubator-nuttx/pull/3474) sensors: Adds driver for hyt271 sensore module
+* [#1936](https://github.com/apache/nuttx/pull/1936) note: Add task trace support
+* [#1989](https://github.com/apache/nuttx/pull/1989) sensors: Support fxos8700cq motion I2C sensor
+* [#2091](https://github.com/apache/nuttx/pull/2091) usbdev: add Android Debug Bridge driver
+* [#2166](https://github.com/apache/nuttx/pull/2166) lcd: Add LCD character driver: allows interacting with LCD directly from userspace
+* [#2216](https://github.com/apache/nuttx/pull/2216) rc: support infrared remote control
+* [#2282](https://github.com/apache/nuttx/pull/2282) audio: cxd56: add initial audio SRC implementation
+* [#2301](https://github.com/apache/nuttx/pull/2301) analog: support for MAX1161X family of I2C 12 bit ADC chips
+* [#2429](https://github.com/apache/nuttx/pull/2429) audio: add simple wm8994 codec driver
+* [#2628](https://github.com/apache/nuttx/pull/2628) efuse: Add generic efuse driver for NuttX
+* [#2736](https://github.com/apache/nuttx/pull/2736) console: Add generic support to LWL Console
+* [#2829](https://github.com/apache/nuttx/pull/2829) sensor: add fakesensor driver
+* [#3230](https://github.com/apache/nuttx/pull/3230) motor: add generic upper-half driver for Field Oriented Control (FOC)
+* [#3474](https://github.com/apache/nuttx/pull/3474) sensors: Adds driver for hyt271 sensore module
 
 ### Bug Fixes
-* [#2036](https://github.com/apache/incubator-nuttx/pull/2036) serial: break from read after closing
-* [#2039](https://github.com/apache/incubator-nuttx/pull/2039) sensors: add unified management for sensor
-* [#2070](https://github.com/apache/incubator-nuttx/pull/2070) bluetooth: support HCI/L2CAP sockets, support HCI RAW channel
-* [#2139](https://github.com/apache/incubator-nuttx/pull/2139) lcd: Ssd1306 cleanup
-* [#2142](https://github.com/apache/incubator-nuttx/pull/2776) note: Add task name record for task trace
-* [#2146](https://github.com/apache/incubator-nuttx/pull/2146) pipes: nx_pipe syscall takes three params, also use nx_close
-* [#2175](https://github.com/apache/incubator-nuttx/pull/2175) wireless: gs2200m: Check disassociation from AP and enable rejoin
-* [#2188](https://github.com/apache/incubator-nuttx/pull/2200) lcd_dev: put header in correct location; fix missing const
-* [#2200](https://github.com/apache/incubator-nuttx/pull/2200) lcd: Minor fixes to ssd1306 i2c driver
-* [#2201](https://github.com/apache/incubator-nuttx/pull/2512) wireless: gs2200m: Add function to get IWNWID / IWFREQ / IWSENS information
-* [#2208](https://github.com/apache/incubator-nuttx/pull/2208) lcd: add optional putarea()/getarea() operations
-* [#2215](https://github.com/apache/incubator-nuttx/pull/2215) sensors: add new feature about sensor driver model
-* [#2223](https://github.com/apache/incubator-nuttx/pull/2223) audio: cxd56: cleanup for the spresense audio implementation
-* [#2315](https://github.com/apache/incubator-nuttx/pull/2370) sensors: add common circular buffer management
-* [#2318](https://github.com/apache/incubator-nuttx/pull/2318) sensors: update l3gd20 sensor driver with new sensor driver model
-* [#2343](https://github.com/apache/incubator-nuttx/pull/2343) serial: Prevent RX stall
-* [#2345](https://github.com/apache/incubator-nuttx/pull/2345) mtd/mtd_progmem.c: fix progmem_log2 parameter type to match prototype
-* [#2369](https://github.com/apache/incubator-nuttx/pull/2369) sensors: support custom types of sensor
-* [#2370](https://github.com/apache/incubator-nuttx/pull/2370) rc: fix bug about lirc_read
-* [#2383](https://github.com/apache/incubator-nuttx/pull/2383) USB: Do not try to print NULL format strings for verbose trace messages when disabled
-* [#2398](https://github.com/apache/incubator-nuttx/pull/2398) rptun: fix rptun rpmsg_unregister_callback fault
-* [#2445](https://github.com/apache/incubator-nuttx/pull/2445) audio: Make audio_null play at real speed
-* [#2488](https://github.com/apache/incubator-nuttx/pull/2488) crypto/arc4random: rename getrandom to arc4random_buf
-* [#2490](https://github.com/apache/incubator-nuttx/pull/3482) leds: ws2812: make frequency selection more flexible
-* [#2497](https://github.com/apache/incubator-nuttx/pull/2497) crypto/random_pool.c: fix getrandom() when thread calling it gets can…
-* [#2508](https://github.com/apache/incubator-nuttx/pull/2508) leds/ws2812: optimize reset bytes
-* [#2512](https://github.com/apache/incubator-nuttx/pull/2488) wireless/bluetooth: change the tx thread stack size to DEFAULT_TASK_STACKSIZE
-* [#2564](https://github.com/apache/incubator-nuttx/pull/2564) audio: uninitialize usermq to NULL when the device has not
-* [#2571](https://github.com/apache/incubator-nuttx/pull/2571) bluetooth: Fix bt_buff lifecycle
-* [#2607](https://github.com/apache/incubator-nuttx/pull/2607) wireless: bluetooth: minor fix to bluetooth stack
-* [#2609](https://github.com/apache/incubator-nuttx/pull/2609) wireless: bluetooth: fix minor issue in bt uart driver
-* [#2611](https://github.com/apache/incubator-nuttx/pull/2611) wireless/bluetooth: Fix vairous issues found in bt uart shim driver
-* [#2617](https://github.com/apache/incubator-nuttx/pull/2617) serial: should include <signal.h> explicitly
-* [#2621](https://github.com/apache/incubator-nuttx/pull/2621) syslog: Added formatted timestamps in syslog.
-* [#2636](https://github.com/apache/incubator-nuttx/pull/2636) pipes: pty shouldn't call nx_pipe and then file_detach in kernel space
-* [#2664](https://github.com/apache/incubator-nuttx/pull/2664) can: fix RTR ioctl and support timeout
-* [#2691](https://github.com/apache/incubator-nuttx/pull/2383) wireless: bluetooth: add more hci event definitions
-* [#2692](https://github.com/apache/incubator-nuttx/pull/2692) syslog: Prepend Process ID to syslog message
-* [#2697](https://github.com/apache/incubator-nuttx/pull/2697) syslog: Added printing of log priority in syslog
-* [#2698](https://github.com/apache/incubator-nuttx/pull/2698) syslog: Added color output to syslog.
-* [#2704](https://github.com/apache/incubator-nuttx/pull/2704) wireless: bluetooth: minor fix for bluetooth driver
-* [#2707](https://github.com/apache/incubator-nuttx/pull/2707) drivers: wireless: Fix ASSERT() in _read_data_len() in gs2200m.c
-* [#2710](https://github.com/apache/incubator-nuttx/pull/2710) syslog: Re-arranged syslog fields.
-* [#2711](https://github.com/apache/incubator-nuttx/pull/2711) sensors: bmp280: minor fixes
-* [#2715](https://github.com/apache/incubator-nuttx/pull/2715) sensors: bmp280: convert to sensor interface (and minor sensor change)
-* [#2738](https://github.com/apache/incubator-nuttx/pull/2738) wireless: gs2200m: Print error massages with wlerr()
-* [#2747](https://github.com/apache/incubator-nuttx/pull/2747) wireless: gs2200m: Fix _read_data()
-* [#2775](https://github.com/apache/incubator-nuttx/pull/2775) mtd: w25qxxxjv.c : W25Q256's sector count is 8192
-* [#2776](https://github.com/apache/incubator-nuttx/pull/2776) net/encx24j600.c: Correct setting of ifstate
-* [#2798](https://github.com/apache/incubator-nuttx/pull/2798) wireless: gs2200m: Change retry condition in gs2200m_hal_write()
-* [#2801](https://github.com/apache/incubator-nuttx/pull/2801) mtd:w25qxxxjv.c: use different protect bits and address lengts
-* [#2850](https://github.com/apache/incubator-nuttx/pull/2850) audio: Introduce a driver-specific spinlock to cxd56.c
-* [#2907](https://github.com/apache/incubator-nuttx/pull/2711) sensors: driver model update
-* [#2950](https://github.com/apache/incubator-nuttx/pull/2950) audio: pcm_decode: add RAW format support
-* [#2961](https://github.com/apache/incubator-nuttx/pull/2961) syslog_rpmsg: fix system crash when open CONFIG_SCHED_HAVE_PARENT
-* [#2989](https://github.com/apache/incubator-nuttx/pull/2989) mmcsd: Fixes race condition in event wait logic of SDMMC driver
-* [#3000](https://github.com/apache/incubator-nuttx/pull/3000) sensors: fakesensor support batch
-* [#3020](https://github.com/apache/incubator-nuttx/pull/3020) syslog: add option to prefix process name
-* [#3047](https://github.com/apache/incubator-nuttx/pull/3047) mmcsd: Stuck in 1-bit mode, Removed CONFIG_ARCH_HAVE_SDIO_DELAYED_INVLDT
-* [#3050](https://github.com/apache/incubator-nuttx/pull/3050) syslog: Added support for multiple syslog channels.
-* [#3110](https://github.com/apache/incubator-nuttx/pull/3110) can: Add CAN FD flags to CAN header
-* [#3118](https://github.com/apache/incubator-nuttx/pull/3118) sensors: qencoder.c - Remove bad sninfo() format string
-* [#3163](https://github.com/apache/incubator-nuttx/pull/3163) USBDEV: RNDIS: Fix occasional disconnections due to race condition
-* [#3185](https://github.com/apache/incubator-nuttx/pull/3185) USBDEV RNDIS: Fix unaligned access caused by 4f66624
-* [#3195](https://github.com/apache/incubator-nuttx/pull/3195) serial: Don't comment out ws_[x|y]pixel field from winsize struct
-* [#3201](https://github.com/apache/incubator-nuttx/pull/3201) timers: rtc/rpmsg: support server and client to set time each other
-* [#3214](https://github.com/apache/incubator-nuttx/pull/3214) can: Fix TX ID bits 18-20 of mcp2515 can driver
-* [#3215](https://github.com/apache/incubator-nuttx/pull/3215) syslog: Drop extra carriage return from syslog calls
-* [#3226](https://github.com/apache/incubator-nuttx/pull/3226) syslog: Added multi device support in syslog_device.
-* [#3269](https://github.com/apache/incubator-nuttx/pull/3269) motor: Add support for motor debug messages
-* [#3453](https://github.com/apache/incubator-nuttx/pull/3453) syslog: Fix in syslog_intbuffer flushing
-* [#3454](https://github.com/apache/incubator-nuttx/pull/3454) syslog: Proper uninit of syslog_device.
-* [#3475](https://github.com/apache/incubator-nuttx/pull/3214) input: Add INPUT_TOUCHSCREEN config
-* [#3482](https://github.com/apache/incubator-nuttx/pull/3482) input: Rename config from INPUT classes
+* [#2036](https://github.com/apache/nuttx/pull/2036) serial: break from read after closing
+* [#2039](https://github.com/apache/nuttx/pull/2039) sensors: add unified management for sensor
+* [#2070](https://github.com/apache/nuttx/pull/2070) bluetooth: support HCI/L2CAP sockets, support HCI RAW channel
+* [#2139](https://github.com/apache/nuttx/pull/2139) lcd: Ssd1306 cleanup
+* [#2142](https://github.com/apache/nuttx/pull/2776) note: Add task name record for task trace
+* [#2146](https://github.com/apache/nuttx/pull/2146) pipes: nx_pipe syscall takes three params, also use nx_close
+* [#2175](https://github.com/apache/nuttx/pull/2175) wireless: gs2200m: Check disassociation from AP and enable rejoin
+* [#2188](https://github.com/apache/nuttx/pull/2200) lcd_dev: put header in correct location; fix missing const
+* [#2200](https://github.com/apache/nuttx/pull/2200) lcd: Minor fixes to ssd1306 i2c driver
+* [#2201](https://github.com/apache/nuttx/pull/2512) wireless: gs2200m: Add function to get IWNWID / IWFREQ / IWSENS information
+* [#2208](https://github.com/apache/nuttx/pull/2208) lcd: add optional putarea()/getarea() operations
+* [#2215](https://github.com/apache/nuttx/pull/2215) sensors: add new feature about sensor driver model
+* [#2223](https://github.com/apache/nuttx/pull/2223) audio: cxd56: cleanup for the spresense audio implementation
+* [#2315](https://github.com/apache/nuttx/pull/2370) sensors: add common circular buffer management
+* [#2318](https://github.com/apache/nuttx/pull/2318) sensors: update l3gd20 sensor driver with new sensor driver model
+* [#2343](https://github.com/apache/nuttx/pull/2343) serial: Prevent RX stall
+* [#2345](https://github.com/apache/nuttx/pull/2345) mtd/mtd_progmem.c: fix progmem_log2 parameter type to match prototype
+* [#2369](https://github.com/apache/nuttx/pull/2369) sensors: support custom types of sensor
+* [#2370](https://github.com/apache/nuttx/pull/2370) rc: fix bug about lirc_read
+* [#2383](https://github.com/apache/nuttx/pull/2383) USB: Do not try to print NULL format strings for verbose trace messages when disabled
+* [#2398](https://github.com/apache/nuttx/pull/2398) rptun: fix rptun rpmsg_unregister_callback fault
+* [#2445](https://github.com/apache/nuttx/pull/2445) audio: Make audio_null play at real speed
+* [#2488](https://github.com/apache/nuttx/pull/2488) crypto/arc4random: rename getrandom to arc4random_buf
+* [#2490](https://github.com/apache/nuttx/pull/3482) leds: ws2812: make frequency selection more flexible
+* [#2497](https://github.com/apache/nuttx/pull/2497) crypto/random_pool.c: fix getrandom() when thread calling it gets can…
+* [#2508](https://github.com/apache/nuttx/pull/2508) leds/ws2812: optimize reset bytes
+* [#2512](https://github.com/apache/nuttx/pull/2488) wireless/bluetooth: change the tx thread stack size to DEFAULT_TASK_STACKSIZE
+* [#2564](https://github.com/apache/nuttx/pull/2564) audio: uninitialize usermq to NULL when the device has not
+* [#2571](https://github.com/apache/nuttx/pull/2571) bluetooth: Fix bt_buff lifecycle
+* [#2607](https://github.com/apache/nuttx/pull/2607) wireless: bluetooth: minor fix to bluetooth stack
+* [#2609](https://github.com/apache/nuttx/pull/2609) wireless: bluetooth: fix minor issue in bt uart driver
+* [#2611](https://github.com/apache/nuttx/pull/2611) wireless/bluetooth: Fix vairous issues found in bt uart shim driver
+* [#2617](https://github.com/apache/nuttx/pull/2617) serial: should include <signal.h> explicitly
+* [#2621](https://github.com/apache/nuttx/pull/2621) syslog: Added formatted timestamps in syslog.
+* [#2636](https://github.com/apache/nuttx/pull/2636) pipes: pty shouldn't call nx_pipe and then file_detach in kernel space
+* [#2664](https://github.com/apache/nuttx/pull/2664) can: fix RTR ioctl and support timeout
+* [#2691](https://github.com/apache/nuttx/pull/2383) wireless: bluetooth: add more hci event definitions
+* [#2692](https://github.com/apache/nuttx/pull/2692) syslog: Prepend Process ID to syslog message
+* [#2697](https://github.com/apache/nuttx/pull/2697) syslog: Added printing of log priority in syslog
+* [#2698](https://github.com/apache/nuttx/pull/2698) syslog: Added color output to syslog.
+* [#2704](https://github.com/apache/nuttx/pull/2704) wireless: bluetooth: minor fix for bluetooth driver
+* [#2707](https://github.com/apache/nuttx/pull/2707) drivers: wireless: Fix ASSERT() in _read_data_len() in gs2200m.c
+* [#2710](https://github.com/apache/nuttx/pull/2710) syslog: Re-arranged syslog fields.
+* [#2711](https://github.com/apache/nuttx/pull/2711) sensors: bmp280: minor fixes
+* [#2715](https://github.com/apache/nuttx/pull/2715) sensors: bmp280: convert to sensor interface (and minor sensor change)
+* [#2738](https://github.com/apache/nuttx/pull/2738) wireless: gs2200m: Print error massages with wlerr()
+* [#2747](https://github.com/apache/nuttx/pull/2747) wireless: gs2200m: Fix _read_data()
+* [#2775](https://github.com/apache/nuttx/pull/2775) mtd: w25qxxxjv.c : W25Q256's sector count is 8192
+* [#2776](https://github.com/apache/nuttx/pull/2776) net/encx24j600.c: Correct setting of ifstate
+* [#2798](https://github.com/apache/nuttx/pull/2798) wireless: gs2200m: Change retry condition in gs2200m_hal_write()
+* [#2801](https://github.com/apache/nuttx/pull/2801) mtd:w25qxxxjv.c: use different protect bits and address lengts
+* [#2850](https://github.com/apache/nuttx/pull/2850) audio: Introduce a driver-specific spinlock to cxd56.c
+* [#2907](https://github.com/apache/nuttx/pull/2711) sensors: driver model update
+* [#2950](https://github.com/apache/nuttx/pull/2950) audio: pcm_decode: add RAW format support
+* [#2961](https://github.com/apache/nuttx/pull/2961) syslog_rpmsg: fix system crash when open CONFIG_SCHED_HAVE_PARENT
+* [#2989](https://github.com/apache/nuttx/pull/2989) mmcsd: Fixes race condition in event wait logic of SDMMC driver
+* [#3000](https://github.com/apache/nuttx/pull/3000) sensors: fakesensor support batch
+* [#3020](https://github.com/apache/nuttx/pull/3020) syslog: add option to prefix process name
+* [#3047](https://github.com/apache/nuttx/pull/3047) mmcsd: Stuck in 1-bit mode, Removed CONFIG_ARCH_HAVE_SDIO_DELAYED_INVLDT
+* [#3050](https://github.com/apache/nuttx/pull/3050) syslog: Added support for multiple syslog channels.
+* [#3110](https://github.com/apache/nuttx/pull/3110) can: Add CAN FD flags to CAN header
+* [#3118](https://github.com/apache/nuttx/pull/3118) sensors: qencoder.c - Remove bad sninfo() format string
+* [#3163](https://github.com/apache/nuttx/pull/3163) USBDEV: RNDIS: Fix occasional disconnections due to race condition
+* [#3185](https://github.com/apache/nuttx/pull/3185) USBDEV RNDIS: Fix unaligned access caused by 4f66624
+* [#3195](https://github.com/apache/nuttx/pull/3195) serial: Don't comment out ws_[x|y]pixel field from winsize struct
+* [#3201](https://github.com/apache/nuttx/pull/3201) timers: rtc/rpmsg: support server and client to set time each other
+* [#3214](https://github.com/apache/nuttx/pull/3214) can: Fix TX ID bits 18-20 of mcp2515 can driver
+* [#3215](https://github.com/apache/nuttx/pull/3215) syslog: Drop extra carriage return from syslog calls
+* [#3226](https://github.com/apache/nuttx/pull/3226) syslog: Added multi device support in syslog_device.
+* [#3269](https://github.com/apache/nuttx/pull/3269) motor: Add support for motor debug messages
+* [#3453](https://github.com/apache/nuttx/pull/3453) syslog: Fix in syslog_intbuffer flushing
+* [#3454](https://github.com/apache/nuttx/pull/3454) syslog: Proper uninit of syslog_device.
+* [#3475](https://github.com/apache/nuttx/pull/3214) input: Add INPUT_TOUCHSCREEN config
+* [#3482](https://github.com/apache/nuttx/pull/3482) input: Rename config from INPUT classes
 
 ## Board Support
 
 ### New Board Support
-* [#2054](https://github.com/apache/incubator-nuttx/pull/2054) configure.sh: update custom board config build support
-* [#2463](https://github.com/apache/incubator-nuttx/pull/2463) boards: Added Teensy-4.x BSP
-* [#2503](https://github.com/apache/incubator-nuttx/pull/2503) Re-organise ESP32 boards and introduce two more(ESP-WROVER-KIT and the ESP32-Ethernet-Kit)
-* [#2506](https://github.com/apache/incubator-nuttx/pull/2506) stm32: add stm32g43x support and nucleo-g431rb board
-* [#2838](https://github.com/apache/incubator-nuttx/pull/2838) Add initial support for ESP32-C3 and ESP32-C3 DevKit board
-* [#2877](https://github.com/apache/incubator-nuttx/pull/2877) Support for Raspberry Pi Pico
-* [#3129](https://github.com/apache/incubator-nuttx/pull/3129) boards/stm32: add initial support for b-g431b-esc1 board
-* [#3217](https://github.com/apache/incubator-nuttx/pull/3217) board: Add support for nucleo-h743i2
-* [#3234](https://github.com/apache/incubator-nuttx/pull/3234) boards/stm32/common: add support for IHM07M1 and IHM08M1 boards
+* [#2054](https://github.com/apache/nuttx/pull/2054) configure.sh: update custom board config build support
+* [#2463](https://github.com/apache/nuttx/pull/2463) boards: Added Teensy-4.x BSP
+* [#2503](https://github.com/apache/nuttx/pull/2503) Re-organise ESP32 boards and introduce two more(ESP-WROVER-KIT and the ESP32-Ethernet-Kit)
+* [#2506](https://github.com/apache/nuttx/pull/2506) stm32: add stm32g43x support and nucleo-g431rb board
+* [#2838](https://github.com/apache/nuttx/pull/2838) Add initial support for ESP32-C3 and ESP32-C3 DevKit board
+* [#2877](https://github.com/apache/nuttx/pull/2877) Support for Raspberry Pi Pico
+* [#3129](https://github.com/apache/nuttx/pull/3129) boards/stm32: add initial support for b-g431b-esc1 board
+* [#3217](https://github.com/apache/nuttx/pull/3217) board: Add support for nucleo-h743i2
+* [#3234](https://github.com/apache/nuttx/pull/3234) boards/stm32/common: add support for IHM07M1 and IHM08M1 boards
 
 ### Boards With Significant Improvements
 
 #### ARM
 
 #### BL602
-* [#2764](https://github.com/apache/incubator-nuttx/pull/2764) boards: bl602evb flash and debug notes
+* [#2764](https://github.com/apache/nuttx/pull/2764) boards: bl602evb flash and debug notes
 
 #### C906
-* [#3027](https://github.com/apache/incubator-nuttx/pull/3027) board:rv64:c906:support the ELF apps
+* [#3027](https://github.com/apache/nuttx/pull/3027) board:rv64:c906:support the ELF apps
 
 #### CXD56
-* [#1939](https://github.com/apache/incubator-nuttx/pull/1939) Add cxd56xx intstack for SMP
-* [#3016](https://github.com/apache/incubator-nuttx/pull/3016) spresense:rndis_smp
-* [#3024](https://github.com/apache/incubator-nuttx/pull/3024) Spesense CPU activity LED support
-* [#3084](https://github.com/apache/incubator-nuttx/pull/3084) cxd56_gnss: Add missing include header for cxd56_gnss.c
-* [#3085](https://github.com/apache/incubator-nuttx/pull/3085) cxd56_cpu1signal: Fix an issue that gnss does not work
+* [#1939](https://github.com/apache/nuttx/pull/1939) Add cxd56xx intstack for SMP
+* [#3016](https://github.com/apache/nuttx/pull/3016) spresense:rndis_smp
+* [#3024](https://github.com/apache/nuttx/pull/3024) Spesense CPU activity LED support
+* [#3084](https://github.com/apache/nuttx/pull/3084) cxd56_gnss: Add missing include header for cxd56_gnss.c
+* [#3085](https://github.com/apache/nuttx/pull/3085) cxd56_cpu1signal: Fix an issue that gnss does not work
 
 #### ESP32
-* [#2507](https://github.com/apache/incubator-nuttx/pull/2507) boards/arm/stm32: add common and stm32f103-minimum support for WS2812
-* [#2753](https://github.com/apache/incubator-nuttx/pull/2753) esp32: Enable renew for "wapi" configs
-* [#2864](https://github.com/apache/incubator-nuttx/pull/2864) Add wapi_smp to test Wi-Fi in SMP mode
-* [#2883](https://github.com/apache/incubator-nuttx/pull/2883) This commit implements I2C support for ESP32 (wrover kit)
-* [#2888](https://github.com/apache/incubator-nuttx/pull/2888) This commit enables BMP180 suport for ESP32
-* [#2971](https://github.com/apache/incubator-nuttx/pull/2971) esp32: Add board config to support MCP2515
-* [#3071](https://github.com/apache/incubator-nuttx/pull/3071) ESP32: Mount TMPFS on board bring up
-* [#3095](https://github.com/apache/incubator-nuttx/pull/3095) ESP32: Allow a BSS section to reside in external memory
-* [#3117](https://github.com/apache/incubator-nuttx/pull/3117) xtensa/esp32: Use Polling instead of DMA for transfers below threshold
-* [#3139](https://github.com/apache/incubator-nuttx/pull/3139) xtensa/esp32: Support esp32 wireless ioctl cmd
-* [#3154](https://github.com/apache/incubator-nuttx/pull/3154) ESP32: Add Button support via BOOT button on GPIO0
-* [#3164](https://github.com/apache/incubator-nuttx/pull/3164) xtensa/esp32: Adds oneshot timer driver.
-* [#3190](https://github.com/apache/incubator-nuttx/pull/3190) risc-v/esp32c3: Support ESP32-C3 wireless ioctl cmd
-* [#3192](https://github.com/apache/incubator-nuttx/pull/3192) esp32-devkitc: Make nsh the entry-point of the ostest config
-* [#3211](https://github.com/apache/incubator-nuttx/pull/3211) esp32-devkitc: Add GPIO board support
-* [#3270](https://github.com/apache/incubator-nuttx/pull/3270) xtensa/esp32: Refactor register access functions on SPI driver
-* [#3303](https://github.com/apache/incubator-nuttx/pull/3303) esp32-devkitc: Add BMP180 sensor support
+* [#2507](https://github.com/apache/nuttx/pull/2507) boards/arm/stm32: add common and stm32f103-minimum support for WS2812
+* [#2753](https://github.com/apache/nuttx/pull/2753) esp32: Enable renew for "wapi" configs
+* [#2864](https://github.com/apache/nuttx/pull/2864) Add wapi_smp to test Wi-Fi in SMP mode
+* [#2883](https://github.com/apache/nuttx/pull/2883) This commit implements I2C support for ESP32 (wrover kit)
+* [#2888](https://github.com/apache/nuttx/pull/2888) This commit enables BMP180 suport for ESP32
+* [#2971](https://github.com/apache/nuttx/pull/2971) esp32: Add board config to support MCP2515
+* [#3071](https://github.com/apache/nuttx/pull/3071) ESP32: Mount TMPFS on board bring up
+* [#3095](https://github.com/apache/nuttx/pull/3095) ESP32: Allow a BSS section to reside in external memory
+* [#3117](https://github.com/apache/nuttx/pull/3117) xtensa/esp32: Use Polling instead of DMA for transfers below threshold
+* [#3139](https://github.com/apache/nuttx/pull/3139) xtensa/esp32: Support esp32 wireless ioctl cmd
+* [#3154](https://github.com/apache/nuttx/pull/3154) ESP32: Add Button support via BOOT button on GPIO0
+* [#3164](https://github.com/apache/nuttx/pull/3164) xtensa/esp32: Adds oneshot timer driver.
+* [#3190](https://github.com/apache/nuttx/pull/3190) risc-v/esp32c3: Support ESP32-C3 wireless ioctl cmd
+* [#3192](https://github.com/apache/nuttx/pull/3192) esp32-devkitc: Make nsh the entry-point of the ostest config
+* [#3211](https://github.com/apache/nuttx/pull/3211) esp32-devkitc: Add GPIO board support
+* [#3270](https://github.com/apache/nuttx/pull/3270) xtensa/esp32: Refactor register access functions on SPI driver
+* [#3303](https://github.com/apache/nuttx/pull/3303) esp32-devkitc: Add BMP180 sensor support
 
 #### ESP32C3
-* [#2879](https://github.com/apache/incubator-nuttx/pull/2879) risc-v/esp32c3: Enable stdio buffering for esp32c3-devkit NSH config
-* [#2897](https://github.com/apache/incubator-nuttx/pull/2897) boards/esp32c3: Add tmpfs mounting when bringing up
-* [#3074](https://github.com/apache/incubator-nuttx/pull/3074) esp32c3-devkit: Use nx_mount to avoid overriding errno
-* [#3261](https://github.com/apache/incubator-nuttx/pull/3261) esp32-c3: Add support to RNG peripheral
+* [#2879](https://github.com/apache/nuttx/pull/2879) risc-v/esp32c3: Enable stdio buffering for esp32c3-devkit NSH config
+* [#2897](https://github.com/apache/nuttx/pull/2897) boards/esp32c3: Add tmpfs mounting when bringing up
+* [#3074](https://github.com/apache/nuttx/pull/3074) esp32c3-devkit: Use nx_mount to avoid overriding errno
+* [#3261](https://github.com/apache/nuttx/pull/3261) esp32-c3: Add support to RNG peripheral
 
 #### IMX6
-* [#2997](https://github.com/apache/incubator-nuttx/pull/2997) boards: sabre-6quad: Add netnsh_smp configuration
+* [#2997](https://github.com/apache/nuttx/pull/2997) boards: sabre-6quad: Add netnsh_smp configuration
 
 #### IMXRT
-* [#2004](https://github.com/apache/incubator-nuttx/pull/2004) FlexCAN driver for i.MX RT1060 MCU
-* [#2526](https://github.com/apache/incubator-nuttx/pull/2526) boards/arm/imxrt/teensy-4.x: CDC-ACM console support
-* [#2588](https://github.com/apache/incubator-nuttx/pull/2588) teensy-4.x Support for ST7789 controller
+* [#2004](https://github.com/apache/nuttx/pull/2004) FlexCAN driver for i.MX RT1060 MCU
+* [#2526](https://github.com/apache/nuttx/pull/2526) boards/arm/imxrt/teensy-4.x: CDC-ACM console support
+* [#2588](https://github.com/apache/nuttx/pull/2588) teensy-4.x Support for ST7789 controller
 
 #### KINETIS
-* [#1969](https://github.com/apache/incubator-nuttx/pull/1969) freedom-k64f: Init PWM only if enabled
-* [#1977](https://github.com/apache/incubator-nuttx/pull/1977) freedom-k64f: Support raw binary firmware format
-* [#1980](https://github.com/apache/incubator-nuttx/pull/1980) freedom-k64f: Add renew DHCP client for netnsh
-* [#1982](https://github.com/apache/incubator-nuttx/pull/1982) freedom-k64f: Add I2C initial support
-* [#1999](https://github.com/apache/incubator-nuttx/pull/1999) freedom-k64f: Register on board sensor driver
-* [#2020](https://github.com/apache/incubator-nuttx/pull/2020) freedom-k64f: Declare k64_i2cdev_initialize function
-* [#2030](https://github.com/apache/incubator-nuttx/pull/2030) freedom-k64f: Fix k64_buttons.c
-* [#2037](https://github.com/apache/incubator-nuttx/pull/2037) freedom-k64f: Add demo configuration
-* [#2047](https://github.com/apache/incubator-nuttx/pull/2047) freedom-k64f: Add I2C to demo image
-* [#2847](https://github.com/apache/incubator-nuttx/pull/2847) board/freedom-k64f: Add usbdev support with cdcacm example
+* [#1969](https://github.com/apache/nuttx/pull/1969) freedom-k64f: Init PWM only if enabled
+* [#1977](https://github.com/apache/nuttx/pull/1977) freedom-k64f: Support raw binary firmware format
+* [#1980](https://github.com/apache/nuttx/pull/1980) freedom-k64f: Add renew DHCP client for netnsh
+* [#1982](https://github.com/apache/nuttx/pull/1982) freedom-k64f: Add I2C initial support
+* [#1999](https://github.com/apache/nuttx/pull/1999) freedom-k64f: Register on board sensor driver
+* [#2020](https://github.com/apache/nuttx/pull/2020) freedom-k64f: Declare k64_i2cdev_initialize function
+* [#2030](https://github.com/apache/nuttx/pull/2030) freedom-k64f: Fix k64_buttons.c
+* [#2037](https://github.com/apache/nuttx/pull/2037) freedom-k64f: Add demo configuration
+* [#2047](https://github.com/apache/nuttx/pull/2047) freedom-k64f: Add I2C to demo image
+* [#2847](https://github.com/apache/nuttx/pull/2847) board/freedom-k64f: Add usbdev support with cdcacm example
 
 #### LPC17XX_40XX
-* [#3239](https://github.com/apache/incubator-nuttx/pull/3239) board/arm/lpc17xx_40xx/mbed: Add userleds driver support
+* [#3239](https://github.com/apache/nuttx/pull/3239) board/arm/lpc17xx_40xx/mbed: Add userleds driver support
 
 #### NRF52
-* [#2706](https://github.com/apache/incubator-nuttx/pull/2706) board/nrf52-feather: Add simple i2c test configuration
+* [#2706](https://github.com/apache/nuttx/pull/2706) board/nrf52-feather: Add simple i2c test configuration
 
 #### RP2040
-* [#2884](https://github.com/apache/incubator-nuttx/pull/2884) Update raspi-pico
-* [#2894](https://github.com/apache/incubator-nuttx/pull/2894) boards: raspberrypi-pico: Add nshsram defconfig for SRAM build
-* [#3014](https://github.com/apache/incubator-nuttx/pull/3014) BMP180 sensor support to RP2040
-* [#3021](https://github.com/apache/incubator-nuttx/pull/3021) add INA219 support
-* [#3030](https://github.com/apache/incubator-nuttx/pull/3030) boards/raspberrypi-pico: Support ENC28J60 SPI ethernet board
-* [#3067](https://github.com/apache/incubator-nuttx/pull/3067) boards/raspberrypi-pico: Pico Display Pack (ST7789 LCD) support
+* [#2884](https://github.com/apache/nuttx/pull/2884) Update raspi-pico
+* [#2894](https://github.com/apache/nuttx/pull/2894) boards: raspberrypi-pico: Add nshsram defconfig for SRAM build
+* [#3014](https://github.com/apache/nuttx/pull/3014) BMP180 sensor support to RP2040
+* [#3021](https://github.com/apache/nuttx/pull/3021) add INA219 support
+* [#3030](https://github.com/apache/nuttx/pull/3030) boards/raspberrypi-pico: Support ENC28J60 SPI ethernet board
+* [#3067](https://github.com/apache/nuttx/pull/3067) boards/raspberrypi-pico: Pico Display Pack (ST7789 LCD) support
 
 #### SAM34
-* [#2464](https://github.com/apache/incubator-nuttx/pull/2464) Added: MT29F2G Nand Flash block driver for sam4s-xplained-pro
+* [#2464](https://github.com/apache/nuttx/pull/2464) Added: MT29F2G Nand Flash block driver for sam4s-xplained-pro
 
 #### STM32
-* [#2433](https://github.com/apache/incubator-nuttx/pull/2433) Add 2.4 Inch TFT LCD Shield ILI9341 for nucleo-l152re, 8080 MCU 8-bit
-* [#2505](https://github.com/apache/incubator-nuttx/pull/2505) boards/arm/stm32/stm32f103-minimum: cleanup
-* [#3053](https://github.com/apache/incubator-nuttx/pull/3053) Nucleo-F446RE: added support for CAN driver
-* [#3064](https://github.com/apache/incubator-nuttx/pull/3064) boards: refactor for nucleo-f446re and nucleo-f302r8 boards
-* [#3097](https://github.com/apache/incubator-nuttx/pull/3097) Add configuration for testing the Sporadic Scheduler.
-* [#3222](https://github.com/apache/incubator-nuttx/pull/3222) stm32/stm32_serial: add support for TX DMA and some improvements
-* [#3223](https://github.com/apache/incubator-nuttx/pull/3223) stm32/stm32_pwm: add interfaces to access RCR register and TRGO
-* [#3225](https://github.com/apache/incubator-nuttx/pull/3225) stm32/stm32_adc: various improvements for ADC
-* [#3232](https://github.com/apache/incubator-nuttx/pull/3232) stm32/stm32_foc.c: add the lower-half FOC device support
+* [#2433](https://github.com/apache/nuttx/pull/2433) Add 2.4 Inch TFT LCD Shield ILI9341 for nucleo-l152re, 8080 MCU 8-bit
+* [#2505](https://github.com/apache/nuttx/pull/2505) boards/arm/stm32/stm32f103-minimum: cleanup
+* [#3053](https://github.com/apache/nuttx/pull/3053) Nucleo-F446RE: added support for CAN driver
+* [#3064](https://github.com/apache/nuttx/pull/3064) boards: refactor for nucleo-f446re and nucleo-f302r8 boards
+* [#3097](https://github.com/apache/nuttx/pull/3097) Add configuration for testing the Sporadic Scheduler.
+* [#3222](https://github.com/apache/nuttx/pull/3222) stm32/stm32_serial: add support for TX DMA and some improvements
+* [#3223](https://github.com/apache/nuttx/pull/3223) stm32/stm32_pwm: add interfaces to access RCR register and TRGO
+* [#3225](https://github.com/apache/nuttx/pull/3225) stm32/stm32_adc: various improvements for ADC
+* [#3232](https://github.com/apache/nuttx/pull/3232) stm32/stm32_foc.c: add the lower-half FOC device support
 
 #### STM32F4
-* [#2553](https://github.com/apache/incubator-nuttx/pull/2553) boards: stm32f4discovery: Add adb configuration
-* [#2699](https://github.com/apache/incubator-nuttx/pull/2699) boards/stm32f4discovery: Add a LWL board profile and improve the README.txt
-* [#3052](https://github.com/apache/incubator-nuttx/pull/3052) Add support to LCD ST7789 on STM32F4Discovery
-* [#3056](https://github.com/apache/incubator-nuttx/pull/3056) Add LCD1602 Backpack to common board
+* [#2553](https://github.com/apache/nuttx/pull/2553) boards: stm32f4discovery: Add adb configuration
+* [#2699](https://github.com/apache/nuttx/pull/2699) boards/stm32f4discovery: Add a LWL board profile and improve the README.txt
+* [#3052](https://github.com/apache/nuttx/pull/3052) Add support to LCD ST7789 on STM32F4Discovery
+* [#3056](https://github.com/apache/nuttx/pull/3056) Add LCD1602 Backpack to common board
 
 #### STM32F7
-* [#3218](https://github.com/apache/incubator-nuttx/pull/3218) Integration of pysimCoder with NUTTX
+* [#3218](https://github.com/apache/nuttx/pull/3218) Integration of pysimCoder with NUTTX
 
 #### STM32H7
-* [#2353](https://github.com/apache/incubator-nuttx/pull/2353) Fix of the OTG FS HOST for nucleo-h743zi
+* [#2353](https://github.com/apache/nuttx/pull/2353) Fix of the OTG FS HOST for nucleo-h743zi
 
 #### STM32L4
-* [#2009](https://github.com/apache/incubator-nuttx/pull/2842) Added STM32L432KC DAC support
-* [#2837](https://github.com/apache/incubator-nuttx/pull/2837) Add missing I2C3 support on nucleo-l432kc board
-* [#2842](https://github.com/apache/incubator-nuttx/pull/2842) board: nucleo-l432kc: Add missing i2c_master_s definition
+* [#2009](https://github.com/apache/nuttx/pull/2842) Added STM32L432KC DAC support
+* [#2837](https://github.com/apache/nuttx/pull/2837) Add missing I2C3 support on nucleo-l432kc board
+* [#2842](https://github.com/apache/nuttx/pull/2842) board: nucleo-l432kc: Add missing i2c_master_s definition
 
 #### TIVA
-* [#2684](https://github.com/apache/incubator-nuttx/pull/2684) boards: lm3s6965-ek: Add iperf to discover/defconfig
+* [#2684](https://github.com/apache/nuttx/pull/2684) boards: lm3s6965-ek: Add iperf to discover/defconfig
 
 #### XTENSA
 
 ### **Minor Board Changes**
-* [#2558](https://github.com/apache/incubator-nuttx/pull/2558) boards: Remove CINCPATH and CXXINCPATH
+* [#2558](https://github.com/apache/nuttx/pull/2558) boards: Remove CINCPATH and CXXINCPATH
 
 #### ARM
-* [#2079](https://github.com/apache/incubator-nuttx/pull/2079) Stm32 oled fixes pr
-* [#2360](https://github.com/apache/incubator-nuttx/pull/2360) stm32/stm32ldiscovery: modernize board init little bit
-* [#2500](https://github.com/apache/incubator-nuttx/pull/2500) stm32/common: devpath not long enough for apa102 and veml6070
+* [#2079](https://github.com/apache/nuttx/pull/2079) Stm32 oled fixes pr
+* [#2360](https://github.com/apache/nuttx/pull/2360) stm32/stm32ldiscovery: modernize board init little bit
+* [#2500](https://github.com/apache/nuttx/pull/2500) stm32/common: devpath not long enough for apa102 and veml6070
 
 #### CXD56
-* [#2193](https://github.com/apache/incubator-nuttx/pull/2193) cxd56xx: Remove HOSTCC and HOSTCFLAGS from Make.defs
+* [#2193](https://github.com/apache/nuttx/pull/2193) cxd56xx: Remove HOSTCC and HOSTCFLAGS from Make.defs
 
 #### Xtensa
-* [#2127](https://github.com/apache/incubator-nuttx/pull/2127) esp32: Added Userled support
-* [#2802](https://github.com/apache/incubator-nuttx/pull/2802) ESP32: Refactor of POSTBUILD action
-* [#3263](https://github.com/apache/incubator-nuttx/pull/3263) esp32: Move the WLAN initialisation to the common directory.
-* [#3288](https://github.com/apache/incubator-nuttx/pull/3288) esp32-wrover-kit: Don't use User GPIO Subsystem to control LED
-* [#3442](https://github.com/apache/incubator-nuttx/pull/3442) esp32 boards: BUTTON_BOOT should use PULLUP instead PULLDOWN
+* [#2127](https://github.com/apache/nuttx/pull/2127) esp32: Added Userled support
+* [#2802](https://github.com/apache/nuttx/pull/2802) ESP32: Refactor of POSTBUILD action
+* [#3263](https://github.com/apache/nuttx/pull/3263) esp32: Move the WLAN initialisation to the common directory.
+* [#3288](https://github.com/apache/nuttx/pull/3288) esp32-wrover-kit: Don't use User GPIO Subsystem to control LED
+* [#3442](https://github.com/apache/nuttx/pull/3442) esp32 boards: BUTTON_BOOT should use PULLUP instead PULLDOWN
 
 ## File System
 
 ### Significant Improvements
-* [#2598](https://github.com/apache/incubator-nuttx/pull/2598) fs/epoll: add asynchronous epoll control support
-* [#2841](https://github.com/apache/incubator-nuttx/pull/2841) fs: procfs meminfo improvements
-* [#2957](https://github.com/apache/incubator-nuttx/pull/2957) fs: mqueue: add poll support
-* [#3045](https://github.com/apache/incubator-nuttx/pull/3045) fs: Allocate file/socket dynamically
-* [#3212](https://github.com/apache/incubator-nuttx/pull/3212) fs/lfs: Update version to 2.4.0
+* [#2598](https://github.com/apache/nuttx/pull/2598) fs/epoll: add asynchronous epoll control support
+* [#2841](https://github.com/apache/nuttx/pull/2841) fs: procfs meminfo improvements
+* [#2957](https://github.com/apache/nuttx/pull/2957) fs: mqueue: add poll support
+* [#3045](https://github.com/apache/nuttx/pull/3045) fs: Allocate file/socket dynamically
+* [#3212](https://github.com/apache/nuttx/pull/3212) fs/lfs: Update version to 2.4.0
 
 ### Bug Fixes
-* [#2073](https://github.com/apache/incubator-nuttx/pull/2073) fs: epoll_create: modify return value for epoll_create1
-* [#2260](https://github.com/apache/incubator-nuttx/pull/2260) fs: eventfd: remove the unique minor limit
-* [#2317](https://github.com/apache/incubator-nuttx/pull/2317) fs: flashback to release all file descriptors in group to increase debugging time.
-* [#2339](https://github.com/apache/incubator-nuttx/pull/2339) Revert "fs/nxffs: Fix scan good block slowly and scan an invalid block"
-* [#2532](https://github.com/apache/incubator-nuttx/pull/2532) fs/unionfs: remove excessive protection to avoid deadlock
-* [#2540](https://github.com/apache/incubator-nuttx/pull/2540) fs: Skip call fs_checkfd if fd < 3 in fs_fdopen
-* [#2572](https://github.com/apache/incubator-nuttx/pull/2572) fs: spiffs fixes
-* [#2606](https://github.com/apache/incubator-nuttx/pull/2606) fs: Fix inode lock at umount2
-* [#2618](https://github.com/apache/incubator-nuttx/pull/2618) fs: remove INODE_IS_SPECIAL() use INODE_IS_PSEUDODIR instead
-* [#2638](https://github.com/apache/incubator-nuttx/pull/2618) fs: fs_dupfd2 should return OK if fd1 equals fd2
-* [#2639](https://github.com/apache/incubator-nuttx/pull/2639) fs: Let files_allocate return -EMFILE instead ERROR
-* [#2640](https://github.com/apache/incubator-nuttx/pull/2640) fs: Remove _files_close and reuse file_close
-* [#2643](https://github.com/apache/incubator-nuttx/pull/2643) fs: Fix the race condition in file_dup
-* [#2648](https://github.com/apache/incubator-nuttx/pull/2648) fs: Remove the special hack for pty in nx_vopen
-* [#2660](https://github.com/apache/incubator-nuttx/pull/2660) fs: Reimplement file_open to not depend on nx_open
-* [#2661](https://github.com/apache/incubator-nuttx/pull/2661) fs: file_dup2 shouldn't hold the file list lock
-* [#2662](https://github.com/apache/incubator-nuttx/pull/2662) fs/inode/fs_files.c: fix DEBUGASSERT in romfs
-* [#2667](https://github.com/apache/incubator-nuttx/pull/2667) fs: Make nx_vxxx and file_vxxx as internal functions
-* [#2724](https://github.com/apache/incubator-nuttx/pull/2724) fs/tmpfs: Iterate the entry reversely in readdir
-* [#2739](https://github.com/apache/incubator-nuttx/pull/2739) fs/readdir: Must reserve a byte for the NUL terminator
-* [#2810](https://github.com/apache/incubator-nuttx/pull/2810) fs: eventfd: Convert the indent under EVENT_FD_VFS_PATH option to tab
-* [#2852](https://github.com/apache/incubator-nuttx/pull/2852) fs: Merge fs_poll into poll_fdsetup
-* [#2854](https://github.com/apache/incubator-nuttx/pull/2854) fs: Don't call _NX_SETERRNO in fopen and fdopen
-* [#2861](https://github.com/apache/incubator-nuttx/pull/2861) fs: change geometry sizes from size_t to uint32_t
-* [#2913](https://github.com/apache/incubator-nuttx/pull/2913) fs/lfs: lfs_file_sync() when littlefs_open
-* [#2956](https://github.com/apache/incubator-nuttx/pull/2956) fs/mount: fix mount cmd break out when meet stat error
-* [#3042](https://github.com/apache/incubator-nuttx/pull/3042) fs: vfs : Do some adjustments for epoll
-* [#3060](https://github.com/apache/incubator-nuttx/pull/3060) fs: find_blockdriver: Don't ferr() on MTDs
-* [#3069](https://github.com/apache/incubator-nuttx/pull/3069) fs/mmap: Clarify MAP_PRIVATE dependency on CONFIG_FS_RAMMAP
-* [#3070](https://github.com/apache/incubator-nuttx/pull/3070) fs/mmap: Return EACCES for incompatible file descriptors
-* [#3105](https://github.com/apache/incubator-nuttx/pull/3105) fs/epoll: correct the return value of epoll_ctl(2)
-* [#3137](https://github.com/apache/incubator-nuttx/pull/3137) fs/littlefs: Suppport the duplication function
-* [#3444](https://github.com/apache/incubator-nuttx/pull/3444) fs/romfs: fix open zero-byte file fail issue
-* [#3491](https://github.com/apache/incubator-nuttx/pull/3491) fs: vfs: adjust the error code of write to be consistent with read
+* [#2073](https://github.com/apache/nuttx/pull/2073) fs: epoll_create: modify return value for epoll_create1
+* [#2260](https://github.com/apache/nuttx/pull/2260) fs: eventfd: remove the unique minor limit
+* [#2317](https://github.com/apache/nuttx/pull/2317) fs: flashback to release all file descriptors in group to increase debugging time.
+* [#2339](https://github.com/apache/nuttx/pull/2339) Revert "fs/nxffs: Fix scan good block slowly and scan an invalid block"
+* [#2532](https://github.com/apache/nuttx/pull/2532) fs/unionfs: remove excessive protection to avoid deadlock
+* [#2540](https://github.com/apache/nuttx/pull/2540) fs: Skip call fs_checkfd if fd < 3 in fs_fdopen
+* [#2572](https://github.com/apache/nuttx/pull/2572) fs: spiffs fixes
+* [#2606](https://github.com/apache/nuttx/pull/2606) fs: Fix inode lock at umount2
+* [#2618](https://github.com/apache/nuttx/pull/2618) fs: remove INODE_IS_SPECIAL() use INODE_IS_PSEUDODIR instead
+* [#2638](https://github.com/apache/nuttx/pull/2618) fs: fs_dupfd2 should return OK if fd1 equals fd2
+* [#2639](https://github.com/apache/nuttx/pull/2639) fs: Let files_allocate return -EMFILE instead ERROR
+* [#2640](https://github.com/apache/nuttx/pull/2640) fs: Remove _files_close and reuse file_close
+* [#2643](https://github.com/apache/nuttx/pull/2643) fs: Fix the race condition in file_dup
+* [#2648](https://github.com/apache/nuttx/pull/2648) fs: Remove the special hack for pty in nx_vopen
+* [#2660](https://github.com/apache/nuttx/pull/2660) fs: Reimplement file_open to not depend on nx_open
+* [#2661](https://github.com/apache/nuttx/pull/2661) fs: file_dup2 shouldn't hold the file list lock
+* [#2662](https://github.com/apache/nuttx/pull/2662) fs/inode/fs_files.c: fix DEBUGASSERT in romfs
+* [#2667](https://github.com/apache/nuttx/pull/2667) fs: Make nx_vxxx and file_vxxx as internal functions
+* [#2724](https://github.com/apache/nuttx/pull/2724) fs/tmpfs: Iterate the entry reversely in readdir
+* [#2739](https://github.com/apache/nuttx/pull/2739) fs/readdir: Must reserve a byte for the NUL terminator
+* [#2810](https://github.com/apache/nuttx/pull/2810) fs: eventfd: Convert the indent under EVENT_FD_VFS_PATH option to tab
+* [#2852](https://github.com/apache/nuttx/pull/2852) fs: Merge fs_poll into poll_fdsetup
+* [#2854](https://github.com/apache/nuttx/pull/2854) fs: Don't call _NX_SETERRNO in fopen and fdopen
+* [#2861](https://github.com/apache/nuttx/pull/2861) fs: change geometry sizes from size_t to uint32_t
+* [#2913](https://github.com/apache/nuttx/pull/2913) fs/lfs: lfs_file_sync() when littlefs_open
+* [#2956](https://github.com/apache/nuttx/pull/2956) fs/mount: fix mount cmd break out when meet stat error
+* [#3042](https://github.com/apache/nuttx/pull/3042) fs: vfs : Do some adjustments for epoll
+* [#3060](https://github.com/apache/nuttx/pull/3060) fs: find_blockdriver: Don't ferr() on MTDs
+* [#3069](https://github.com/apache/nuttx/pull/3069) fs/mmap: Clarify MAP_PRIVATE dependency on CONFIG_FS_RAMMAP
+* [#3070](https://github.com/apache/nuttx/pull/3070) fs/mmap: Return EACCES for incompatible file descriptors
+* [#3105](https://github.com/apache/nuttx/pull/3105) fs/epoll: correct the return value of epoll_ctl(2)
+* [#3137](https://github.com/apache/nuttx/pull/3137) fs/littlefs: Suppport the duplication function
+* [#3444](https://github.com/apache/nuttx/pull/3444) fs/romfs: fix open zero-byte file fail issue
+* [#3491](https://github.com/apache/nuttx/pull/3491) fs: vfs: adjust the error code of write to be consistent with read
 
 ## Networking
 
 ### Significant Improvements
-* [#2414](https://github.com/apache/incubator-nuttx/pull/2414) net: tcp: implement the fast retransmit
-* [#2415](https://github.com/apache/incubator-nuttx/pull/2415) net: gmp: add MULTICAST_TTL support
-* [#2417](https://github.com/apache/incubator-nuttx/pull/2417) net: wireless: add country code control support
-* [#2548](https://github.com/apache/incubator-nuttx/pull/2548) net: tcp: optimize TCP handshake performance
-* [#2695](https://github.com/apache/incubator-nuttx/pull/2695) netpacket: if_addr: add interface address header
-* [#2899](https://github.com/apache/incubator-nuttx/pull/2899) net: socket: Unify socket into file system to avoid the code duplication
-* [#2964](https://github.com/apache/incubator-nuttx/pull/2964) net: socket_rpmsg: add socket rpmsg support
-* [#3025](https://github.com/apache/incubator-nuttx/pull/3025) net: Add sendmsg and recvmsg to syscall list
-* [#3081](https://github.com/apache/incubator-nuttx/pull/3081) tcp_send_buffered.c: improve tcp write buffering
-* [#3113](https://github.com/apache/incubator-nuttx/pull/3113) net: usrsock: add send multi-elements support
-* [#3257](https://github.com/apache/incubator-nuttx/pull/3257) net: tcp: support bind the same port with different domain
+* [#2414](https://github.com/apache/nuttx/pull/2414) net: tcp: implement the fast retransmit
+* [#2415](https://github.com/apache/nuttx/pull/2415) net: gmp: add MULTICAST_TTL support
+* [#2417](https://github.com/apache/nuttx/pull/2417) net: wireless: add country code control support
+* [#2548](https://github.com/apache/nuttx/pull/2548) net: tcp: optimize TCP handshake performance
+* [#2695](https://github.com/apache/nuttx/pull/2695) netpacket: if_addr: add interface address header
+* [#2899](https://github.com/apache/nuttx/pull/2899) net: socket: Unify socket into file system to avoid the code duplication
+* [#2964](https://github.com/apache/nuttx/pull/2964) net: socket_rpmsg: add socket rpmsg support
+* [#3025](https://github.com/apache/nuttx/pull/3025) net: Add sendmsg and recvmsg to syscall list
+* [#3081](https://github.com/apache/nuttx/pull/3081) tcp_send_buffered.c: improve tcp write buffering
+* [#3113](https://github.com/apache/nuttx/pull/3113) net: usrsock: add send multi-elements support
+* [#3257](https://github.com/apache/nuttx/pull/3257) net: tcp: support bind the same port with different domain
 
 ### Bug Fixes
-* [#1589](https://github.com/apache/incubator-nuttx/pull/1589) net: tcp: fix tcp socket close timeout if loss wireless connection
-* [#2075](https://github.com/apache/incubator-nuttx/pull/2075) net: TCP-stack fix for stalled tcp sockets due to broken keepalive
-* [#2121](https://github.com/apache/incubator-nuttx/pull/2121) net: devif: devif_callback.c: remove harmful debug check
-* [#2257](https://github.com/apache/incubator-nuttx/pull/2257) net: callback: remove the assert check of conn instance
-* [#2332](https://github.com/apache/incubator-nuttx/pull/2332) net/tcp: Rectified keepalive fix
-* [#2412](https://github.com/apache/incubator-nuttx/pull/2413) net/icmp: add sanity check to avoid wild data length
-* [#2413](https://github.com/apache/incubator-nuttx/pull/2413) net/tcp: correct the available iobs count if throttle is enabled
-* [#2416](https://github.com/apache/incubator-nuttx/pull/2416) net/tcp: fallback to unthrottle pool to avoid deadlock
-* [#2421](https://github.com/apache/incubator-nuttx/pull/2421) net/neighbor/neighbor_ethernet_out.c: fix build error without ICMPv6
-* [#2465](https://github.com/apache/incubator-nuttx/pull/2465) net/procfs: handle opendir("/proc/net/") correctly
-* [#2466](https://github.com/apache/incubator-nuttx/pull/2466) net/igmp: add sanity check to handle allocate fail
-* [#2467](https://github.com/apache/incubator-nuttx/pull/2467) net/sockopt: Try usrsock further if the protocol not available
-* [#2489](https://github.com/apache/incubator-nuttx/pull/2489) net: tcp: send the ACK in time after obtain ahead buffer from iobs
-* [#2688](https://github.com/apache/incubator-nuttx/pull/2688) net: Remove duplicate forward references
-* [#2774](https://github.com/apache/incubator-nuttx/pull/2774) net/ip: do not drop the udp packet from IP layer
-* [#2811](https://github.com/apache/incubator-nuttx/pull/2811) net/local: Add an option to specify the prefix of named pipe
-* [#2869](https://github.com/apache/incubator-nuttx/pull/2869) netdb.h: Add NI_MAXHOST and NI_MAXSERV
-* [#2911](https://github.com/apache/incubator-nuttx/pull/2911) net: fix a few DP83848C and DP83825I constants
-* [#2959](https://github.com/apache/incubator-nuttx/pull/2959) net: socket: move si_send/recv into sendmsg/recvmsg
-* [#2978](https://github.com/apache/incubator-nuttx/pull/2978) telnet: fix crash about telnet client connect
-* [#3037](https://github.com/apache/incubator-nuttx/pull/3037) Revert "net: tcp: Add DEBUGASSERT() in psock_tcp_send()"
-* [#3043](https://github.com/apache/incubator-nuttx/pull/3043) net: local: Remove local_send.c since nobody use it now
-* [#3044](https://github.com/apache/incubator-nuttx/pull/3044) net: fix local_sendmsg return length
-* [#3062](https://github.com/apache/incubator-nuttx/pull/3062) net: tcp_sendfile.c: Remove an unused copy of CONFIG_NET_TCP_SPLIT_SIZE
-* [#3099](https://github.com/apache/incubator-nuttx/pull/3099) net: tcp: dup: do not start the tcp monitor if unestablished
-* [#3100](https://github.com/apache/incubator-nuttx/pull/3100) net: tcp: correct the port byte order
-* [#3101](https://github.com/apache/incubator-nuttx/pull/3101) net: arp: add timeout to avoid infinite send wait
-* [#3103](https://github.com/apache/incubator-nuttx/pull/3103) net: tcp: reset the connection ref count before tcp_free()
-* [#3104](https://github.com/apache/incubator-nuttx/pull/3104) net: dev: check the available address further
-* [#3106](https://github.com/apache/incubator-nuttx/pull/3106) net: if: remove the macro expansion of the public structure
-* [#3221](https://github.com/apache/incubator-nuttx/pull/3221) net: tcp: tcp_send_buffered.c: Fix non-blocking I/O
-* [#3254](https://github.com/apache/incubator-nuttx/pull/3254) net: arp: Fix arp
-* [#3319](https://github.com/apache/incubator-nuttx/pull/3319) tcp_netpoll.c: Fix a performance issue with CONFIG_NET_TCP_WRITE_BUFFERS
+* [#1589](https://github.com/apache/nuttx/pull/1589) net: tcp: fix tcp socket close timeout if loss wireless connection
+* [#2075](https://github.com/apache/nuttx/pull/2075) net: TCP-stack fix for stalled tcp sockets due to broken keepalive
+* [#2121](https://github.com/apache/nuttx/pull/2121) net: devif: devif_callback.c: remove harmful debug check
+* [#2257](https://github.com/apache/nuttx/pull/2257) net: callback: remove the assert check of conn instance
+* [#2332](https://github.com/apache/nuttx/pull/2332) net/tcp: Rectified keepalive fix
+* [#2412](https://github.com/apache/nuttx/pull/2413) net/icmp: add sanity check to avoid wild data length
+* [#2413](https://github.com/apache/nuttx/pull/2413) net/tcp: correct the available iobs count if throttle is enabled
+* [#2416](https://github.com/apache/nuttx/pull/2416) net/tcp: fallback to unthrottle pool to avoid deadlock
+* [#2421](https://github.com/apache/nuttx/pull/2421) net/neighbor/neighbor_ethernet_out.c: fix build error without ICMPv6
+* [#2465](https://github.com/apache/nuttx/pull/2465) net/procfs: handle opendir("/proc/net/") correctly
+* [#2466](https://github.com/apache/nuttx/pull/2466) net/igmp: add sanity check to handle allocate fail
+* [#2467](https://github.com/apache/nuttx/pull/2467) net/sockopt: Try usrsock further if the protocol not available
+* [#2489](https://github.com/apache/nuttx/pull/2489) net: tcp: send the ACK in time after obtain ahead buffer from iobs
+* [#2688](https://github.com/apache/nuttx/pull/2688) net: Remove duplicate forward references
+* [#2774](https://github.com/apache/nuttx/pull/2774) net/ip: do not drop the udp packet from IP layer
+* [#2811](https://github.com/apache/nuttx/pull/2811) net/local: Add an option to specify the prefix of named pipe
+* [#2869](https://github.com/apache/nuttx/pull/2869) netdb.h: Add NI_MAXHOST and NI_MAXSERV
+* [#2911](https://github.com/apache/nuttx/pull/2911) net: fix a few DP83848C and DP83825I constants
+* [#2959](https://github.com/apache/nuttx/pull/2959) net: socket: move si_send/recv into sendmsg/recvmsg
+* [#2978](https://github.com/apache/nuttx/pull/2978) telnet: fix crash about telnet client connect
+* [#3037](https://github.com/apache/nuttx/pull/3037) Revert "net: tcp: Add DEBUGASSERT() in psock_tcp_send()"
+* [#3043](https://github.com/apache/nuttx/pull/3043) net: local: Remove local_send.c since nobody use it now
+* [#3044](https://github.com/apache/nuttx/pull/3044) net: fix local_sendmsg return length
+* [#3062](https://github.com/apache/nuttx/pull/3062) net: tcp_sendfile.c: Remove an unused copy of CONFIG_NET_TCP_SPLIT_SIZE
+* [#3099](https://github.com/apache/nuttx/pull/3099) net: tcp: dup: do not start the tcp monitor if unestablished
+* [#3100](https://github.com/apache/nuttx/pull/3100) net: tcp: correct the port byte order
+* [#3101](https://github.com/apache/nuttx/pull/3101) net: arp: add timeout to avoid infinite send wait
+* [#3103](https://github.com/apache/nuttx/pull/3103) net: tcp: reset the connection ref count before tcp_free()
+* [#3104](https://github.com/apache/nuttx/pull/3104) net: dev: check the available address further
+* [#3106](https://github.com/apache/nuttx/pull/3106) net: if: remove the macro expansion of the public structure
+* [#3221](https://github.com/apache/nuttx/pull/3221) net: tcp: tcp_send_buffered.c: Fix non-blocking I/O
+* [#3254](https://github.com/apache/nuttx/pull/3254) net: arp: Fix arp
+* [#3319](https://github.com/apache/nuttx/pull/3319) tcp_netpoll.c: Fix a performance issue with CONFIG_NET_TCP_WRITE_BUFFERS
 
 # Security Issues Fixed In This Release
 
@@ -947,8 +947,8 @@ limitations under the License.
 
 ### Change CFLAGS, CPPFLAGS, CXXFLAGS, and AFLAGS from Recursive to Simple Assignment
 
-[PR-1890](https://github.com/apache/incubator-nuttx/pull/1890)
-(commit [2caf3a69e3d60ec550980f7ba897c732e7a39df7](https://github.com/apache/incubator-nuttx/pull/1890/commits/2caf3a69e3d60ec550980f7ba897c732e7a39df7))
+[PR-1890](https://github.com/apache/nuttx/pull/1890)
+(commit [2caf3a69e3d60ec550980f7ba897c732e7a39df7](https://github.com/apache/nuttx/pull/1890/commits/2caf3a69e3d60ec550980f7ba897c732e7a39df7))
 attempts to speed up compilation time for concurrent builds by changing
 assignment to makefile variables `*CFLAGS*`, `*CPPFLAGS*`, `*CXXFLAGS*`, and
 `*AFLAGS*` from recursive `=` to simple `:=`. This causes these compile
@@ -976,8 +976,8 @@ AFLAGS := $(CFLAGS) -D__ASSEMBLY__
 
 ### Not Necessary to Define `__NuttX__` in Make.defs
 
-[PR-2192](https://github.com/apache/incubator-nuttx/pull/2192)
-(commit [9208176f600d0d04446531909bf05710716a5ee4](https://github.com/apache/incubator-nuttx/commit/9208176f600d0d04446531909bf05710716a5ee4))
+[PR-2192](https://github.com/apache/nuttx/pull/2192)
+(commit [9208176f600d0d04446531909bf05710716a5ee4](https://github.com/apache/nuttx/commit/9208176f600d0d04446531909bf05710716a5ee4))
 refactors definition of the `__NuttX__` preprocessor symbol to
 `tools/Config.mk`, so it is no longer necessary to define it in each board's
 `Make.defs` file.

--- a/_releases/10.2.0.md
+++ b/_releases/10.2.0.md
@@ -49,136 +49,136 @@ limitations under the License.
 ## Major Changes to Core OS
 
 ### New Features
-* [#3708](https://github.com/apache/incubator-nuttx/pull/3708) openamp: Update to 2020.10.0 official release
-* [#3709](https://github.com/apache/incubator-nuttx/pull/3709) Update libcxx to 12.0.0 release
-* [#3674](https://github.com/apache/incubator-nuttx/pull/3674) libc/termios: Implement TCSADRAIN and TCSAFLUSH for tcsetattr
-* [#4595](https://github.com/apache/incubator-nuttx/pull/4595) libc/misc: add lib_glob
-* [#4594](https://github.com/apache/incubator-nuttx/pull/4594) libc/string: add lib_strchrnul
-* [#3672](https://github.com/apache/incubator-nuttx/pull/3672) include/spawn.h: Add POSIX_SPAWN_SETSID definition
-* [#4265](https://github.com/apache/incubator-nuttx/pull/4265) libc: Support message catalog function
-* [#3102](https://github.com/apache/incubator-nuttx/pull/3102) mm/iob: add iob_free_queue() interface
-* [#3893](https://github.com/apache/incubator-nuttx/pull/3893) libs/libc/netdb: add dns clear interface
-* [#3959](https://github.com/apache/incubator-nuttx/pull/3959) libc/time: Implement timegm function
-* [#3963](https://github.com/apache/incubator-nuttx/pull/3963) libc/sched: Implement nice API
-* [#3977](https://github.com/apache/incubator-nuttx/pull/3977) sched: Add kthread_create_with_stack
-* [#4016](https://github.com/apache/incubator-nuttx/pull/4016) Add heap & stack check to idle thread
-* [#4114](https://github.com/apache/incubator-nuttx/pull/4114) libc/math: Add fmax and fmin functions
-* [#4130](https://github.com/apache/incubator-nuttx/pull/4130) sys/poll: add POLLRDHUP definition
-* [#4262](https://github.com/apache/incubator-nuttx/pull/4262) libc: Add the empty nl_langinfo implementation
-* [#4272](https://github.com/apache/incubator-nuttx/pull/4272) libc: Implement gettext function
-* [#4432](https://github.com/apache/incubator-nuttx/pull/4432) libc:machine: add atomic_load/store/exchange API
-* [#4438](https://github.com/apache/incubator-nuttx/pull/4438) uClibcxx: add weak attribute for new/del ops
-* [#3681](https://github.com/apache/incubator-nuttx/pull/3681) libc: Implement openpty function
-* [#4363](https://github.com/apache/incubator-nuttx/pull/4363) sched/backtrace: add sched_backtrace support
-* [#4374](https://github.com/apache/incubator-nuttx/pull/4374) libxx: add new low level c++ standard library support
-* [#4425](https://github.com/apache/incubator-nuttx/pull/4425) libc: add common machine atomic operation
-* [#3687](https://github.com/apache/incubator-nuttx/pull/3687) libc/pwd: Add NSS_BUFLEN_PASSWD macro
-* [#3970](https://github.com/apache/incubator-nuttx/pull/3970) libc: Implement fesetround & fegetround for arm
-* [#4104](https://github.com/apache/incubator-nuttx/pull/4104) sched/clock: add nsec range check in clock_settime
-* [#4518](https://github.com/apache/incubator-nuttx/pull/4518) getaddrinfo: support AF_LOCAL and AF_RPMSG
-* [#4595](https://github.com/apache/incubator-nuttx/pull/4595) libc/misc: add lib_glob
-* [#3985](https://github.com/apache/incubator-nuttx/pull/3985) mmap: Implement the minial but reasonable mlock/munlock/mprotect
-* [#4065](https://github.com/apache/incubator-nuttx/pull/4065) mm: Add kmm_malloc_size and mm_malloc_size
-* [#4096](https://github.com/apache/incubator-nuttx/pull/4096) mm: Simplify the semaphore handling
-* [#4100](https://github.com/apache/incubator-nuttx/pull/4100) Implement utime and futimes
+* [#3708](https://github.com/apache/nuttx/pull/3708) openamp: Update to 2020.10.0 official release
+* [#3709](https://github.com/apache/nuttx/pull/3709) Update libcxx to 12.0.0 release
+* [#3674](https://github.com/apache/nuttx/pull/3674) libc/termios: Implement TCSADRAIN and TCSAFLUSH for tcsetattr
+* [#4595](https://github.com/apache/nuttx/pull/4595) libc/misc: add lib_glob
+* [#4594](https://github.com/apache/nuttx/pull/4594) libc/string: add lib_strchrnul
+* [#3672](https://github.com/apache/nuttx/pull/3672) include/spawn.h: Add POSIX_SPAWN_SETSID definition
+* [#4265](https://github.com/apache/nuttx/pull/4265) libc: Support message catalog function
+* [#3102](https://github.com/apache/nuttx/pull/3102) mm/iob: add iob_free_queue() interface
+* [#3893](https://github.com/apache/nuttx/pull/3893) libs/libc/netdb: add dns clear interface
+* [#3959](https://github.com/apache/nuttx/pull/3959) libc/time: Implement timegm function
+* [#3963](https://github.com/apache/nuttx/pull/3963) libc/sched: Implement nice API
+* [#3977](https://github.com/apache/nuttx/pull/3977) sched: Add kthread_create_with_stack
+* [#4016](https://github.com/apache/nuttx/pull/4016) Add heap & stack check to idle thread
+* [#4114](https://github.com/apache/nuttx/pull/4114) libc/math: Add fmax and fmin functions
+* [#4130](https://github.com/apache/nuttx/pull/4130) sys/poll: add POLLRDHUP definition
+* [#4262](https://github.com/apache/nuttx/pull/4262) libc: Add the empty nl_langinfo implementation
+* [#4272](https://github.com/apache/nuttx/pull/4272) libc: Implement gettext function
+* [#4432](https://github.com/apache/nuttx/pull/4432) libc:machine: add atomic_load/store/exchange API
+* [#4438](https://github.com/apache/nuttx/pull/4438) uClibcxx: add weak attribute for new/del ops
+* [#3681](https://github.com/apache/nuttx/pull/3681) libc: Implement openpty function
+* [#4363](https://github.com/apache/nuttx/pull/4363) sched/backtrace: add sched_backtrace support
+* [#4374](https://github.com/apache/nuttx/pull/4374) libxx: add new low level c++ standard library support
+* [#4425](https://github.com/apache/nuttx/pull/4425) libc: add common machine atomic operation
+* [#3687](https://github.com/apache/nuttx/pull/3687) libc/pwd: Add NSS_BUFLEN_PASSWD macro
+* [#3970](https://github.com/apache/nuttx/pull/3970) libc: Implement fesetround & fegetround for arm
+* [#4104](https://github.com/apache/nuttx/pull/4104) sched/clock: add nsec range check in clock_settime
+* [#4518](https://github.com/apache/nuttx/pull/4518) getaddrinfo: support AF_LOCAL and AF_RPMSG
+* [#4595](https://github.com/apache/nuttx/pull/4595) libc/misc: add lib_glob
+* [#3985](https://github.com/apache/nuttx/pull/3985) mmap: Implement the minial but reasonable mlock/munlock/mprotect
+* [#4065](https://github.com/apache/nuttx/pull/4065) mm: Add kmm_malloc_size and mm_malloc_size
+* [#4096](https://github.com/apache/nuttx/pull/4096) mm: Simplify the semaphore handling
+* [#4100](https://github.com/apache/nuttx/pull/4100) Implement utime and futimes
 
 ### Bug Fixes
-* [#4615](https://github.com/apache/incubator-nuttx/pull/4615) sched/signal: Correct kill with cancellation
-* [#4619](https://github.com/apache/incubator-nuttx/pull/4619) sched: Fix CPU affinity issues in SMP
-* [#3626](https://github.com/apache/incubator-nuttx/pull/3626) libc: Move pthread stuff to userspace
-* [#3673](https://github.com/apache/incubator-nuttx/pull/3673) libc/pty: Make ptsname[_r] support PSEUDOTERM_BSD config too
-* [#4599](https://github.com/apache/incubator-nuttx/pull/4599) sched:tcb_s:rearrange sched_priority/int_priority to word align
-* [#3747](https://github.com/apache/incubator-nuttx/pull/3747) mm:initialize ensure alignment.
-* [#3962](https://github.com/apache/incubator-nuttx/pull/3962) sched/task/task_spawn.c: initialize variables explicitly
-* [#3916](https://github.com/apache/incubator-nuttx/pull/3916) sched/posix_spawn: Don't insert name at the begin of argv
-* [#3858](https://github.com/apache/incubator-nuttx/pull/3858) tls: Move pthread key destructor to libc
-* [#3719](https://github.com/apache/incubator-nuttx/pull/3719) group/group_signal: cancel dispatch signal when child process doesn't exist
-* [#4453](https://github.com/apache/incubator-nuttx/pull/4453) libs/libxx: Enforce RTTI for building libcxxabi
-* [#4450](https://github.com/apache/incubator-nuttx/pull/4450) libxx:uClibc++: disable new_handler.cpp when use libsupc++
-* [#4456](https://github.com/apache/incubator-nuttx/pull/4456) libc/gettext: Initialize path field when creating mofile struct.
-* [#4466](https://github.com/apache/incubator-nuttx/pull/4466) sched/wdog/wd_start.c: prevent accessing watch-dog lag if head is NULL
-* [#4499](https://github.com/apache/incubator-nuttx/pull/4499) uClibc++:remove typeinfo.cpp that confict with libsupc++
-* [#3698](https://github.com/apache/incubator-nuttx/pull/3698) sched/task: Simplify the syscall handling of task_spawn
-* [#3813](https://github.com/apache/incubator-nuttx/pull/3813) syscall/syscall.csv: Correct ordering of entries
-* [#4020](https://github.com/apache/incubator-nuttx/pull/4020) SMP should depends on ARCH_INTERRUPTSTACK
-* [#3957](https://github.com/apache/incubator-nuttx/pull/3957) sched/wdog: Remove flags field from wdog_s to save memory
-* [#3967](https://github.com/apache/incubator-nuttx/pull/3967) libc/dirname: Handle the consecutive '/' correctly
-* [#4018](https://github.com/apache/incubator-nuttx/pull/4018) libs/libc/spawn: fix posix_spawn_file_actions_adddup2 alloc size error
-* [#4009](https://github.com/apache/incubator-nuttx/pull/4009) Move aligned_alloc, posix_memalign and valloc from mm/umm to libs/libc/stdlib
-* [#4021](https://github.com/apache/incubator-nuttx/pull/4021) sched/waitpid: handle waitpid waitting tcb->group is NULL
-* [#4026](https://github.com/apache/incubator-nuttx/pull/4026) sched/idle: disable sched when idle call nx_bringup
-* [#4035](https://github.com/apache/incubator-nuttx/pull/4035) work_queue: schedule the work queue using the timer mechanism
-* [#4048](https://github.com/apache/incubator-nuttx/pull/4048) libc: Move pthread_key_destructor to task_info_s
-* [#4057](https://github.com/apache/incubator-nuttx/pull/4057) libs: libnx: nxfonts: Fix prefix of generated fonts data
-* [#4109](https://github.com/apache/incubator-nuttx/pull/4109) libc: Implement ttyname and ttyname_r
-* [#4115](https://github.com/apache/incubator-nuttx/pull/4115) libc/math: Fix calculation error of log function
-* [#4124](https://github.com/apache/incubator-nuttx/pull/4124) add #undef for some libc function
-* [#4125](https://github.com/apache/incubator-nuttx/pull/4125) libc/sysconf: Add MONOTONIC_CLOCK for consistency
-* [#4127](https://github.com/apache/incubator-nuttx/pull/4127) libc: Increase the function of crc8 to use custom polynomials
-* [#4160](https://github.com/apache/incubator-nuttx/pull/4160) group/child_status: Dynamically expand group child_status
-* [#4183](https://github.com/apache/incubator-nuttx/pull/4183) sched/task: Fix wrong return value from nxspawn_open()
-* [#4226](https://github.com/apache/incubator-nuttx/pull/4226) syslog: reslove crash because vmov.i32 instruction is not ready
-* [#4246](https://github.com/apache/incubator-nuttx/pull/4246) libc/pthread_barrierattr_destory.c: Destroy shouldn't reinitialize the attributes
-* [#4270](https://github.com/apache/incubator-nuttx/pull/4270) tzset: avoid taking semaphore in interrupt for non-kernel mode
-* [#4413](https://github.com/apache/incubator-nuttx/pull/4413) sched/wdog: fix switch_context caused error in wd_start()
-* [#3703](https://github.com/apache/incubator-nuttx/pull/3703) sched/spawn: Support the stack address argument
-* [#4287](https://github.com/apache/incubator-nuttx/pull/4287) signal: Allow SIG_EVTHREAD selectable in protected mode
-* [#4296](https://github.com/apache/incubator-nuttx/pull/4296) sched: Fix crash on early syslog message with prepended process name
-* [#4368](https://github.com/apache/incubator-nuttx/pull/4368) libs/libxx/uClibc++.defs: Download the correct file type.
-* [#4369](https://github.com/apache/incubator-nuttx/pull/4369) libs/libxx: Download C++ libraries during context.
-* [#4382](https://github.com/apache/incubator-nuttx/pull/4382) sched/backtrace: simplify the assign of tcb in case of negative pid
-* [#4377](https://github.com/apache/incubator-nuttx/pull/4377) task_spawn: release g_spawn_parmsem and sched_unlock at the ending
-* [#4068](https://github.com/apache/incubator-nuttx/pull/4068) mm: Remove mm_heap_impl_s struct
-* [#4247](https://github.com/apache/incubator-nuttx/pull/4247) Redirect _l function to non-locale version
-* [#4380](https://github.com/apache/incubator-nuttx/pull/4380) som byteorder modification
-* [#4283](https://github.com/apache/incubator-nuttx/pull/4283) libc/gettext: Change g_domain to array
-* [#4512](https://github.com/apache/incubator-nuttx/pull/4512) lib_vsprintf: Add %pV format support
-* [#4513](https://github.com/apache/incubator-nuttx/pull/4513) libc/rexec/rexec_af: support remote command execution
-* [#4516](https://github.com/apache/incubator-nuttx/pull/4516) lib_fread: return the number of bytes actually read when error occurs.
-* [#4520](https://github.com/apache/incubator-nuttx/pull/4520) debug: allow customize EXTRA_FMT
-* [#3978](https://github.com/apache/incubator-nuttx/pull/3978) Decouple the initialization of the separate heaps from the TEXT_HEAP option.
-* [#4029](https://github.com/apache/incubator-nuttx/pull/4029) mm: fix memory corruption when loop create/exit thread in SMP mode
-* [#4055](https://github.com/apache/incubator-nuttx/pull/4055) mm: Move the real implementation of mm_sbrk to sbrk
-* [#4030](https://github.com/apache/incubator-nuttx/pull/4030) Fix procfs memory corruption when meet long string, add thread run time to procfs
-* [#4043](https://github.com/apache/incubator-nuttx/pull/4043) select: fix asan report error
-* [#4519](https://github.com/apache/incubator-nuttx/pull/4519) errno: use staic errno to replace tl_errno before tls initialization
-* [#3992](https://github.com/apache/incubator-nuttx/pull/3992) Refine tls_info_s and task_info_s
-* [#4019](https://github.com/apache/incubator-nuttx/pull/4019) Fix asan report error
-* [#4053](https://github.com/apache/incubator-nuttx/pull/4053) mm: Move procfs_register_meminfo into common place
-* [#4054](https://github.com/apache/incubator-nuttx/pull/4054) mm: Call memalign in malloc if ARCH_ADDRENV and BUILD_KERNEL are defined
-* [#4454](https://github.com/apache/incubator-nuttx/pull/4454) user/trap: Set MQ_MAXMSGSIZE to 64 to get NX working
-* [#3725](https://github.com/apache/incubator-nuttx/pull/3725) cmd/free: add nused/nfree field in command free
-* [#3753](https://github.com/apache/incubator-nuttx/pull/3753) libelf: fix "nsh: nsh_session: readline failed: 13" error
-* [#3767](https://github.com/apache/incubator-nuttx/pull/3767) binfmt: Move argv copy into exec_module
-* [#3764](https://github.com/apache/incubator-nuttx/pull/3764) binfmt: Rename dump_module to binfmt_dumpmodule
-* [#4064](https://github.com/apache/incubator-nuttx/pull/4064) binfmt: Replace all nx_ API with file_ API
-* [#3928](https://github.com/apache/incubator-nuttx/pull/3928) binfmt: Handle argv/argv[0] == NULL correctly in exec_module
-* [#3867](https://github.com/apache/incubator-nuttx/pull/3867) TLS: Correct handling of returned error values.
-* [#4185](https://github.com/apache/incubator-nuttx/pull/4185) iob_trimhead: fix an integer truncation
-* [#4117](https://github.com/apache/incubator-nuttx/pull/4117) Dynamically extend Pidhash table
-* [#4186](https://github.com/apache/incubator-nuttx/pull/4186) libc: Implement times function
-* [#3908](https://github.com/apache/incubator-nuttx/pull/3908) crypto/random_pool.c: Correct indexing on void pointer
-* [#3817](https://github.com/apache/incubator-nuttx/pull/3817) audio: various fixes
+* [#4615](https://github.com/apache/nuttx/pull/4615) sched/signal: Correct kill with cancellation
+* [#4619](https://github.com/apache/nuttx/pull/4619) sched: Fix CPU affinity issues in SMP
+* [#3626](https://github.com/apache/nuttx/pull/3626) libc: Move pthread stuff to userspace
+* [#3673](https://github.com/apache/nuttx/pull/3673) libc/pty: Make ptsname[_r] support PSEUDOTERM_BSD config too
+* [#4599](https://github.com/apache/nuttx/pull/4599) sched:tcb_s:rearrange sched_priority/int_priority to word align
+* [#3747](https://github.com/apache/nuttx/pull/3747) mm:initialize ensure alignment.
+* [#3962](https://github.com/apache/nuttx/pull/3962) sched/task/task_spawn.c: initialize variables explicitly
+* [#3916](https://github.com/apache/nuttx/pull/3916) sched/posix_spawn: Don't insert name at the begin of argv
+* [#3858](https://github.com/apache/nuttx/pull/3858) tls: Move pthread key destructor to libc
+* [#3719](https://github.com/apache/nuttx/pull/3719) group/group_signal: cancel dispatch signal when child process doesn't exist
+* [#4453](https://github.com/apache/nuttx/pull/4453) libs/libxx: Enforce RTTI for building libcxxabi
+* [#4450](https://github.com/apache/nuttx/pull/4450) libxx:uClibc++: disable new_handler.cpp when use libsupc++
+* [#4456](https://github.com/apache/nuttx/pull/4456) libc/gettext: Initialize path field when creating mofile struct.
+* [#4466](https://github.com/apache/nuttx/pull/4466) sched/wdog/wd_start.c: prevent accessing watch-dog lag if head is NULL
+* [#4499](https://github.com/apache/nuttx/pull/4499) uClibc++:remove typeinfo.cpp that confict with libsupc++
+* [#3698](https://github.com/apache/nuttx/pull/3698) sched/task: Simplify the syscall handling of task_spawn
+* [#3813](https://github.com/apache/nuttx/pull/3813) syscall/syscall.csv: Correct ordering of entries
+* [#4020](https://github.com/apache/nuttx/pull/4020) SMP should depends on ARCH_INTERRUPTSTACK
+* [#3957](https://github.com/apache/nuttx/pull/3957) sched/wdog: Remove flags field from wdog_s to save memory
+* [#3967](https://github.com/apache/nuttx/pull/3967) libc/dirname: Handle the consecutive '/' correctly
+* [#4018](https://github.com/apache/nuttx/pull/4018) libs/libc/spawn: fix posix_spawn_file_actions_adddup2 alloc size error
+* [#4009](https://github.com/apache/nuttx/pull/4009) Move aligned_alloc, posix_memalign and valloc from mm/umm to libs/libc/stdlib
+* [#4021](https://github.com/apache/nuttx/pull/4021) sched/waitpid: handle waitpid waitting tcb->group is NULL
+* [#4026](https://github.com/apache/nuttx/pull/4026) sched/idle: disable sched when idle call nx_bringup
+* [#4035](https://github.com/apache/nuttx/pull/4035) work_queue: schedule the work queue using the timer mechanism
+* [#4048](https://github.com/apache/nuttx/pull/4048) libc: Move pthread_key_destructor to task_info_s
+* [#4057](https://github.com/apache/nuttx/pull/4057) libs: libnx: nxfonts: Fix prefix of generated fonts data
+* [#4109](https://github.com/apache/nuttx/pull/4109) libc: Implement ttyname and ttyname_r
+* [#4115](https://github.com/apache/nuttx/pull/4115) libc/math: Fix calculation error of log function
+* [#4124](https://github.com/apache/nuttx/pull/4124) add #undef for some libc function
+* [#4125](https://github.com/apache/nuttx/pull/4125) libc/sysconf: Add MONOTONIC_CLOCK for consistency
+* [#4127](https://github.com/apache/nuttx/pull/4127) libc: Increase the function of crc8 to use custom polynomials
+* [#4160](https://github.com/apache/nuttx/pull/4160) group/child_status: Dynamically expand group child_status
+* [#4183](https://github.com/apache/nuttx/pull/4183) sched/task: Fix wrong return value from nxspawn_open()
+* [#4226](https://github.com/apache/nuttx/pull/4226) syslog: reslove crash because vmov.i32 instruction is not ready
+* [#4246](https://github.com/apache/nuttx/pull/4246) libc/pthread_barrierattr_destory.c: Destroy shouldn't reinitialize the attributes
+* [#4270](https://github.com/apache/nuttx/pull/4270) tzset: avoid taking semaphore in interrupt for non-kernel mode
+* [#4413](https://github.com/apache/nuttx/pull/4413) sched/wdog: fix switch_context caused error in wd_start()
+* [#3703](https://github.com/apache/nuttx/pull/3703) sched/spawn: Support the stack address argument
+* [#4287](https://github.com/apache/nuttx/pull/4287) signal: Allow SIG_EVTHREAD selectable in protected mode
+* [#4296](https://github.com/apache/nuttx/pull/4296) sched: Fix crash on early syslog message with prepended process name
+* [#4368](https://github.com/apache/nuttx/pull/4368) libs/libxx/uClibc++.defs: Download the correct file type.
+* [#4369](https://github.com/apache/nuttx/pull/4369) libs/libxx: Download C++ libraries during context.
+* [#4382](https://github.com/apache/nuttx/pull/4382) sched/backtrace: simplify the assign of tcb in case of negative pid
+* [#4377](https://github.com/apache/nuttx/pull/4377) task_spawn: release g_spawn_parmsem and sched_unlock at the ending
+* [#4068](https://github.com/apache/nuttx/pull/4068) mm: Remove mm_heap_impl_s struct
+* [#4247](https://github.com/apache/nuttx/pull/4247) Redirect _l function to non-locale version
+* [#4380](https://github.com/apache/nuttx/pull/4380) som byteorder modification
+* [#4283](https://github.com/apache/nuttx/pull/4283) libc/gettext: Change g_domain to array
+* [#4512](https://github.com/apache/nuttx/pull/4512) lib_vsprintf: Add %pV format support
+* [#4513](https://github.com/apache/nuttx/pull/4513) libc/rexec/rexec_af: support remote command execution
+* [#4516](https://github.com/apache/nuttx/pull/4516) lib_fread: return the number of bytes actually read when error occurs.
+* [#4520](https://github.com/apache/nuttx/pull/4520) debug: allow customize EXTRA_FMT
+* [#3978](https://github.com/apache/nuttx/pull/3978) Decouple the initialization of the separate heaps from the TEXT_HEAP option.
+* [#4029](https://github.com/apache/nuttx/pull/4029) mm: fix memory corruption when loop create/exit thread in SMP mode
+* [#4055](https://github.com/apache/nuttx/pull/4055) mm: Move the real implementation of mm_sbrk to sbrk
+* [#4030](https://github.com/apache/nuttx/pull/4030) Fix procfs memory corruption when meet long string, add thread run time to procfs
+* [#4043](https://github.com/apache/nuttx/pull/4043) select: fix asan report error
+* [#4519](https://github.com/apache/nuttx/pull/4519) errno: use staic errno to replace tl_errno before tls initialization
+* [#3992](https://github.com/apache/nuttx/pull/3992) Refine tls_info_s and task_info_s
+* [#4019](https://github.com/apache/nuttx/pull/4019) Fix asan report error
+* [#4053](https://github.com/apache/nuttx/pull/4053) mm: Move procfs_register_meminfo into common place
+* [#4054](https://github.com/apache/nuttx/pull/4054) mm: Call memalign in malloc if ARCH_ADDRENV and BUILD_KERNEL are defined
+* [#4454](https://github.com/apache/nuttx/pull/4454) user/trap: Set MQ_MAXMSGSIZE to 64 to get NX working
+* [#3725](https://github.com/apache/nuttx/pull/3725) cmd/free: add nused/nfree field in command free
+* [#3753](https://github.com/apache/nuttx/pull/3753) libelf: fix "nsh: nsh_session: readline failed: 13" error
+* [#3767](https://github.com/apache/nuttx/pull/3767) binfmt: Move argv copy into exec_module
+* [#3764](https://github.com/apache/nuttx/pull/3764) binfmt: Rename dump_module to binfmt_dumpmodule
+* [#4064](https://github.com/apache/nuttx/pull/4064) binfmt: Replace all nx_ API with file_ API
+* [#3928](https://github.com/apache/nuttx/pull/3928) binfmt: Handle argv/argv[0] == NULL correctly in exec_module
+* [#3867](https://github.com/apache/nuttx/pull/3867) TLS: Correct handling of returned error values.
+* [#4185](https://github.com/apache/nuttx/pull/4185) iob_trimhead: fix an integer truncation
+* [#4117](https://github.com/apache/nuttx/pull/4117) Dynamically extend Pidhash table
+* [#4186](https://github.com/apache/nuttx/pull/4186) libc: Implement times function
+* [#3908](https://github.com/apache/nuttx/pull/3908) crypto/random_pool.c: Correct indexing on void pointer
+* [#3817](https://github.com/apache/nuttx/pull/3817) audio: various fixes
 
 ## Major Changes to the Build System
 
 ### New Features
-* [#4525](https://github.com/apache/incubator-nuttx/pull/4525) mkromfsimg: Add optional rcS file path
-* [#4491](https://github.com/apache/incubator-nuttx/pull/4491) checkpatch.sh: add check gerrit Change-Id support
-* [#3716](https://github.com/apache/incubator-nuttx/pull/3716) tools: Add a bash completion script for the configure tool    
-* [#3819](https://github.com/apache/incubator-nuttx/pull/3819) docker/linux: Add ESP32-S2 toolchain and binaries.
-* [#4203](https://github.com/apache/incubator-nuttx/pull/4203) tools: Add armv7-a support to nuttx-gdbinit
-* [#3705](https://github.com/apache/incubator-nuttx/pull/3705) docker: add ninja-build
+* [#4525](https://github.com/apache/nuttx/pull/4525) mkromfsimg: Add optional rcS file path
+* [#4491](https://github.com/apache/nuttx/pull/4491) checkpatch.sh: add check gerrit Change-Id support
+* [#3716](https://github.com/apache/nuttx/pull/3716) tools: Add a bash completion script for the configure tool    
+* [#3819](https://github.com/apache/nuttx/pull/3819) docker/linux: Add ESP32-S2 toolchain and binaries.
+* [#4203](https://github.com/apache/nuttx/pull/4203) tools: Add armv7-a support to nuttx-gdbinit
+* [#3705](https://github.com/apache/nuttx/pull/3705) docker: add ninja-build
 
 ### Bug Fixes
-* [#4418](https://github.com/apache/incubator-nuttx/pull/4418) compiler.h: add __builtin_offsetof instead of offsetof
-* [#3815](https://github.com/apache/incubator-nuttx/pull/3815) tools/mksyscall: Fix build break of syscall instrumentation wrapper
-* [#4461](https://github.com/apache/incubator-nuttx/pull/4461) tools/ci: Minor improvements to CI build script
-* [#4492](https://github.com/apache/incubator-nuttx/pull/4492) tools/nxstyle: Fix the check tool incorrectly reported no alignment.
-* [#3710](https://github.com/apache/incubator-nuttx/pull/3710) tools/ci: Rename sim0x.dat to sim-0x.dat to align with arm-xx.dat
-* [#4455](https://github.com/apache/incubator-nuttx/pull/4455) makefile: let clean_context in distclean command
-* [#4423](https://github.com/apache/incubator-nuttx/pull/4423) board: Enable CONFIG_LIBCXXABI when CONFIG_LIBCXX is enabled
-* [#4196](https://github.com/apache/incubator-nuttx/pull/4196) tools: Fix nuttx-gdbinit
+* [#4418](https://github.com/apache/nuttx/pull/4418) compiler.h: add __builtin_offsetof instead of offsetof
+* [#3815](https://github.com/apache/nuttx/pull/3815) tools/mksyscall: Fix build break of syscall instrumentation wrapper
+* [#4461](https://github.com/apache/nuttx/pull/4461) tools/ci: Minor improvements to CI build script
+* [#4492](https://github.com/apache/nuttx/pull/4492) tools/nxstyle: Fix the check tool incorrectly reported no alignment.
+* [#3710](https://github.com/apache/nuttx/pull/3710) tools/ci: Rename sim0x.dat to sim-0x.dat to align with arm-xx.dat
+* [#4455](https://github.com/apache/nuttx/pull/4455) makefile: let clean_context in distclean command
+* [#4423](https://github.com/apache/nuttx/pull/4423) board: Enable CONFIG_LIBCXXABI when CONFIG_LIBCXX is enabled
+* [#4196](https://github.com/apache/nuttx/pull/4196) tools: Fix nuttx-gdbinit
 
 ## Architectural Support
 
@@ -187,275 +187,275 @@ limitations under the License.
 #### MIPS
 
 ##### PIC32
-* [#4252](https://github.com/apache/incubator-nuttx/pull/4252) pic32mz: added support for PIC32MZ2048EFG MCU
+* [#4252](https://github.com/apache/nuttx/pull/4252) pic32mz: added support for PIC32MZ2048EFG MCU
 
 ### Architectures with significant improvements
 
 #### ARM
-* [#4522](https://github.com/apache/incubator-nuttx/pull/4522) arch/arm: Add ARCH_CORTEXM55 Kconfig for cortex-m55
-* [#3759](https://github.com/apache/incubator-nuttx/pull/3759) arm/v7-a/fpu: add VFP-v3 D32 support  
-* [#4536](https://github.com/apache/incubator-nuttx/pull/4536) arch/arm: correct the function name from arm_getsp() to up_getsp()
-* [#4410](https://github.com/apache/incubator-nuttx/pull/4410) arch/arm/assert: enhance the assert dump
-* [#4409](https://github.com/apache/incubator-nuttx/pull/4409) arch/arm/cortex-m: add up_backtrace support
-* [#4405](https://github.com/apache/incubator-nuttx/pull/4405) arch/armv7: add up_backtrace support based on frame pointer
-* [#4385](https://github.com/apache/incubator-nuttx/pull/4385) arch/armv8-m: Update per the latest architecture reference manual
-* [#4354](https://github.com/apache/incubator-nuttx/pull/4354) arch/arm: correct the frame pointer register declare
-* [#4205](https://github.com/apache/incubator-nuttx/pull/4205) arm: add up_secure_irq support
-* [#4176](https://github.com/apache/incubator-nuttx/pull/4176) ARM: fix CPSR corruption after exception handling
-* [#4094](https://github.com/apache/incubator-nuttx/pull/4094) arch/armv7-a: Remove the special SMP SGI process
-* [#4451](https://github.com/apache/incubator-nuttx/pull/4451) arch: Replace ar, nm and ld with gcc-ar, gcc-nm and gcc
-* [#4343](https://github.com/apache/incubator-nuttx/pull/4343) arch/armv8-m: Add SAU support
-* [#4341](https://github.com/apache/incubator-nuttx/pull/4341) arch/arm: Add NVIC_FPCCR_XXX macro to avoid the hard code value
-* [#4279](https://github.com/apache/incubator-nuttx/pull/4279) arch/cortex-m: replace arm_switchcontext to c-style
-* [#4106](https://github.com/apache/incubator-nuttx/pull/4106) arm/setjmp.h:add c++ support
-* [#4013](https://github.com/apache/incubator-nuttx/pull/4013) arm: fix enable interrupt too earlier caused system crash
-* [#4483](https://github.com/apache/incubator-nuttx/pull/4483) Fix compilation of arm protected build
-* [#3879](https://github.com/apache/incubator-nuttx/pull/3879) arch: Rename xxx_getsp to up_getsp
-* [#4227](https://github.com/apache/incubator-nuttx/pull/4227) pwm: add option to break the loops when using multiple PWM channels
-* [#4261](https://github.com/apache/incubator-nuttx/pull/4261) EXC_SECURE and SECURE_STACK just can clear at TRUSTZONE_NONSECURE
+* [#4522](https://github.com/apache/nuttx/pull/4522) arch/arm: Add ARCH_CORTEXM55 Kconfig for cortex-m55
+* [#3759](https://github.com/apache/nuttx/pull/3759) arm/v7-a/fpu: add VFP-v3 D32 support  
+* [#4536](https://github.com/apache/nuttx/pull/4536) arch/arm: correct the function name from arm_getsp() to up_getsp()
+* [#4410](https://github.com/apache/nuttx/pull/4410) arch/arm/assert: enhance the assert dump
+* [#4409](https://github.com/apache/nuttx/pull/4409) arch/arm/cortex-m: add up_backtrace support
+* [#4405](https://github.com/apache/nuttx/pull/4405) arch/armv7: add up_backtrace support based on frame pointer
+* [#4385](https://github.com/apache/nuttx/pull/4385) arch/armv8-m: Update per the latest architecture reference manual
+* [#4354](https://github.com/apache/nuttx/pull/4354) arch/arm: correct the frame pointer register declare
+* [#4205](https://github.com/apache/nuttx/pull/4205) arm: add up_secure_irq support
+* [#4176](https://github.com/apache/nuttx/pull/4176) ARM: fix CPSR corruption after exception handling
+* [#4094](https://github.com/apache/nuttx/pull/4094) arch/armv7-a: Remove the special SMP SGI process
+* [#4451](https://github.com/apache/nuttx/pull/4451) arch: Replace ar, nm and ld with gcc-ar, gcc-nm and gcc
+* [#4343](https://github.com/apache/nuttx/pull/4343) arch/armv8-m: Add SAU support
+* [#4341](https://github.com/apache/nuttx/pull/4341) arch/arm: Add NVIC_FPCCR_XXX macro to avoid the hard code value
+* [#4279](https://github.com/apache/nuttx/pull/4279) arch/cortex-m: replace arm_switchcontext to c-style
+* [#4106](https://github.com/apache/nuttx/pull/4106) arm/setjmp.h:add c++ support
+* [#4013](https://github.com/apache/nuttx/pull/4013) arm: fix enable interrupt too earlier caused system crash
+* [#4483](https://github.com/apache/nuttx/pull/4483) Fix compilation of arm protected build
+* [#3879](https://github.com/apache/nuttx/pull/3879) arch: Rename xxx_getsp to up_getsp
+* [#4227](https://github.com/apache/nuttx/pull/4227) pwm: add option to break the loops when using multiple PWM channels
+* [#4261](https://github.com/apache/nuttx/pull/4261) EXC_SECURE and SECURE_STACK just can clear at TRUSTZONE_NONSECURE
 
 #### CXD56XX
-* [#4557](https://github.com/apache/incubator-nuttx/pull/4557) arch: cxd56xx: Replace the critical section with spinlock in cxd56_serial.c
-* [#3743](https://github.com/apache/incubator-nuttx/pull/3743) arch: arm: cxd56xx: Update cxd56xx drivers
-* [#3845](https://github.com/apache/incubator-nuttx/pull/3845) Fix spresense with elf
+* [#4557](https://github.com/apache/nuttx/pull/4557) arch: cxd56xx: Replace the critical section with spinlock in cxd56_serial.c
+* [#3743](https://github.com/apache/nuttx/pull/3743) arch: arm: cxd56xx: Update cxd56xx drivers
+* [#3845](https://github.com/apache/nuttx/pull/3845) Fix spresense with elf
 
 #### LPC17XX_40XX
-* [#4072](https://github.com/apache/incubator-nuttx/pull/4072) lpc17xx: Added WDT driver.
-* [#4316](https://github.com/apache/incubator-nuttx/pull/4316) lpc17_40: Fixed I2C port sanity check.
-* [#4148](https://github.com/apache/incubator-nuttx/pull/4148) lpc17_40: style fix in WDT definitions.
-* [#4107](https://github.com/apache/incubator-nuttx/pull/4107) lpc17_40: Fixed progmem driver.
+* [#4072](https://github.com/apache/nuttx/pull/4072) lpc17xx: Added WDT driver.
+* [#4316](https://github.com/apache/nuttx/pull/4316) lpc17_40: Fixed I2C port sanity check.
+* [#4148](https://github.com/apache/nuttx/pull/4148) lpc17_40: style fix in WDT definitions.
+* [#4107](https://github.com/apache/nuttx/pull/4107) lpc17_40: Fixed progmem driver.
 
 #### STM32
-* [#3761](https://github.com/apache/incubator-nuttx/pull/3761) ET-STM32 Stamp: An STM32F103RET6 target for NuttX
-* [#4350](https://github.com/apache/incubator-nuttx/pull/4350) arch/arm/src/stm32l4/Kconfig: add new STM32L4+ chip types
-* [#4310](https://github.com/apache/incubator-nuttx/pull/4310) arch/stm32: improvements for qencoder
-* [#3752](https://github.com/apache/incubator-nuttx/pull/3752) Use inttypes stm32fx i2c
-* [#4090](https://github.com/apache/incubator-nuttx/pull/4090) STM32G43XX Analog Comparator
-* [#3942](https://github.com/apache/incubator-nuttx/pull/3942) Changed the STM32 Analog Comparator driver.
-* [#3729](https://github.com/apache/incubator-nuttx/pull/3729) stm32 timers: Prefer GTIM macros and make this use more uniform.
-* [#4163](https://github.com/apache/incubator-nuttx/pull/4163) Files for pysimCoder
-* [#4151](https://github.com/apache/incubator-nuttx/pull/4151) Change DAC driver to support STM32G4 DAC
+* [#3761](https://github.com/apache/nuttx/pull/3761) ET-STM32 Stamp: An STM32F103RET6 target for NuttX
+* [#4350](https://github.com/apache/nuttx/pull/4350) arch/arm/src/stm32l4/Kconfig: add new STM32L4+ chip types
+* [#4310](https://github.com/apache/nuttx/pull/4310) arch/stm32: improvements for qencoder
+* [#3752](https://github.com/apache/nuttx/pull/3752) Use inttypes stm32fx i2c
+* [#4090](https://github.com/apache/nuttx/pull/4090) STM32G43XX Analog Comparator
+* [#3942](https://github.com/apache/nuttx/pull/3942) Changed the STM32 Analog Comparator driver.
+* [#3729](https://github.com/apache/nuttx/pull/3729) stm32 timers: Prefer GTIM macros and make this use more uniform.
+* [#4163](https://github.com/apache/nuttx/pull/4163) Files for pysimCoder
+* [#4151](https://github.com/apache/nuttx/pull/4151) Change DAC driver to support STM32G4 DAC
 
 #### STM32L4
-* [#3668](https://github.com/apache/incubator-nuttx/pull/3668) arch/arm/src/stm32l4/hardware/stm32l4xrxx: pinmap alternative function for SPI2  
-* [#4468](https://github.com/apache/incubator-nuttx/pull/4468) arch/arm/src/stm32l4: fix STM32L4+ option bytes memory address
-* [#4501](https://github.com/apache/incubator-nuttx/pull/4501) arch/arm/src/stm32l4: add control for Vddio2 independent I/Os supply valid
-* [#4469](https://github.com/apache/incubator-nuttx/pull/4469) arch/arm/src/stm32l4/stm32l4_flash.c: fix FLASH_CONFIG_I to use dual-bank access
+* [#3668](https://github.com/apache/nuttx/pull/3668) arch/arm/src/stm32l4/hardware/stm32l4xrxx: pinmap alternative function for SPI2  
+* [#4468](https://github.com/apache/nuttx/pull/4468) arch/arm/src/stm32l4: fix STM32L4+ option bytes memory address
+* [#4501](https://github.com/apache/nuttx/pull/4501) arch/arm/src/stm32l4: add control for Vddio2 independent I/Os supply valid
+* [#4469](https://github.com/apache/nuttx/pull/4469) arch/arm/src/stm32l4/stm32l4_flash.c: fix FLASH_CONFIG_I to use dual-bank access
 
 #### STM32L5
 
 #### S32K1XX
-* [#3850](https://github.com/apache/incubator-nuttx/pull/3850) UCANS32K146 add support for B revision
-* [#4493](https://github.com/apache/incubator-nuttx/pull/4493) Fix error in s32k118_pinmux.h
-* [#3795](https://github.com/apache/incubator-nuttx/pull/3795) S32K1XX LSPI Double word up to 64 bits support
+* [#3850](https://github.com/apache/nuttx/pull/3850) UCANS32K146 add support for B revision
+* [#4493](https://github.com/apache/nuttx/pull/4493) Fix error in s32k118_pinmux.h
+* [#3795](https://github.com/apache/nuttx/pull/3795) S32K1XX LSPI Double word up to 64 bits support
 
 #### IMX6
-* [#3777](https://github.com/apache/incubator-nuttx/pull/3777) arch: imx6: Add termios support to imx6
+* [#3777](https://github.com/apache/nuttx/pull/3777) arch: imx6: Add termios support to imx6
 
 #### IMXRT
-* [#3988](https://github.com/apache/incubator-nuttx/pull/3988) arch/arm/src/imxrt/imxrt_flexpwm.c: fix mistake in submodules address offset
-* [#4431](https://github.com/apache/incubator-nuttx/pull/4431) i.MX RT: Changes to FlexCAN driver and Teensy 4.x CAN configuration
-* [#4285](https://github.com/apache/incubator-nuttx/pull/4285) arch/arm/src/imxrt/imxrt_flexpwm.c: Set LDOK bits after all channels are set
-* [#4138](https://github.com/apache/incubator-nuttx/pull/4138) i.MX RT: added support for Tickless OS
+* [#3988](https://github.com/apache/nuttx/pull/3988) arch/arm/src/imxrt/imxrt_flexpwm.c: fix mistake in submodules address offset
+* [#4431](https://github.com/apache/nuttx/pull/4431) i.MX RT: Changes to FlexCAN driver and Teensy 4.x CAN configuration
+* [#4285](https://github.com/apache/nuttx/pull/4285) arch/arm/src/imxrt/imxrt_flexpwm.c: Set LDOK bits after all channels are set
+* [#4138](https://github.com/apache/nuttx/pull/4138) i.MX RT: added support for Tickless OS
 
 #### RP2040
-* [#4049](https://github.com/apache/incubator-nuttx/pull/4049) Raspipico smp
-* [#4251](https://github.com/apache/incubator-nuttx/pull/4251) raspberrypi-pico: add support for lcd_dev
-* [#4002](https://github.com/apache/incubator-nuttx/pull/4002) Kinetis Replace DMA with a proper eDMA driver and use it on SPI and Serial
+* [#4049](https://github.com/apache/nuttx/pull/4049) Raspipico smp
+* [#4251](https://github.com/apache/nuttx/pull/4251) raspberrypi-pico: add support for lcd_dev
+* [#4002](https://github.com/apache/nuttx/pull/4002) Kinetis Replace DMA with a proper eDMA driver and use it on SPI and Serial
 
 #### RTL8720C
-* [#4076](https://github.com/apache/incubator-nuttx/pull/4076) AmebaZ2: Add soc src code
+* [#4076](https://github.com/apache/nuttx/pull/4076) AmebaZ2: Add soc src code
 
 #### NRF52
 
 #### STM32H7/STM32F7
-* [#4331](https://github.com/apache/incubator-nuttx/pull/4331) arch/arm/stm32h7: dma and serial: add TRBUFF flag.
-* [#4441](https://github.com/apache/incubator-nuttx/pull/4441) arch/arm/stm32f7/stm32_irq: Fix format strings
-* [#4098](https://github.com/apache/incubator-nuttx/pull/4098) stm32h7 Ethernet add yield and timeout to not hog CPU
-* [#3730](https://github.com/apache/incubator-nuttx/pull/3730) stm32h7 rcc: Sync h7x7xx and h7x3xx. Changes are relevant to both
-* [#3892](https://github.com/apache/incubator-nuttx/pull/3892) arch/arm/src/stm32h7: qspi use indirect write instead of indirect read
-* [#3728](https://github.com/apache/incubator-nuttx/pull/3728) stm32f7: Remove references to BOARD_ENABLE_USBOTG_HSULPI.
-* [#3731](https://github.com/apache/incubator-nuttx/pull/3731) stm32/stm32f7 tickless: Fix up_timer_getmask to be correct for the width of the timer.
-* [#3976](https://github.com/apache/incubator-nuttx/pull/3976) STM32F7 SDMMC fixes
-* [#3924](https://github.com/apache/incubator-nuttx/pull/3924) stm32h7 fix for adc to handle overrun and the DR's fifo
+* [#4331](https://github.com/apache/nuttx/pull/4331) arch/arm/stm32h7: dma and serial: add TRBUFF flag.
+* [#4441](https://github.com/apache/nuttx/pull/4441) arch/arm/stm32f7/stm32_irq: Fix format strings
+* [#4098](https://github.com/apache/nuttx/pull/4098) stm32h7 Ethernet add yield and timeout to not hog CPU
+* [#3730](https://github.com/apache/nuttx/pull/3730) stm32h7 rcc: Sync h7x7xx and h7x3xx. Changes are relevant to both
+* [#3892](https://github.com/apache/nuttx/pull/3892) arch/arm/src/stm32h7: qspi use indirect write instead of indirect read
+* [#3728](https://github.com/apache/nuttx/pull/3728) stm32f7: Remove references to BOARD_ENABLE_USBOTG_HSULPI.
+* [#3731](https://github.com/apache/nuttx/pull/3731) stm32/stm32f7 tickless: Fix up_timer_getmask to be correct for the width of the timer.
+* [#3976](https://github.com/apache/nuttx/pull/3976) STM32F7 SDMMC fixes
+* [#3924](https://github.com/apache/nuttx/pull/3924) stm32h7 fix for adc to handle overrun and the DR's fifo
 
 #### Renesas
-* [#4230](https://github.com/apache/incubator-nuttx/pull/4230) renesas/rx65n: add long type for all PRI*PTR
-* [#3989](https://github.com/apache/incubator-nuttx/pull/3989) Renesas/RX added setjmp and placeholder ioctl
+* [#4230](https://github.com/apache/nuttx/pull/4230) renesas/rx65n: add long type for all PRI*PTR
+* [#3989](https://github.com/apache/nuttx/pull/3989) Renesas/RX added setjmp and placeholder ioctl
 
 #### Risc-V
-* [#3770](https://github.com/apache/incubator-nuttx/pull/3770) Add support for PolarFire SoC and icicle board
-* [#3997](https://github.com/apache/incubator-nuttx/pull/3997) risc-v/bl602: update wifi firmware version
-* [#4381](https://github.com/apache/incubator-nuttx/pull/4381) arch/riscv/assert: enhance the assert dump
-* [#4367](https://github.com/apache/incubator-nuttx/pull/4367) riscv/backtrace: add up_backtrace support
-* [#4365](https://github.com/apache/incubator-nuttx/pull/4365) riscv/common: add CURRENT_REGS declare in RV32
-* [#4342](https://github.com/apache/incubator-nuttx/pull/4342) riscv/bl602: Fix that AP cannot be start when STA have been started.
-* [#4335](https://github.com/apache/incubator-nuttx/pull/4335) arch/bl602：Add bl602 os adapter layer
-* [#4145](https://github.com/apache/incubator-nuttx/pull/4145) risc-v/bl602: update wifi firmware and some fixup.
-* [#3849](https://github.com/apache/incubator-nuttx/pull/3849) risc-v/mpfs: irq fixes, more register defines and up_systemreset()
-* [#3984](https://github.com/apache/incubator-nuttx/pull/3984) risc-v/bl602: Support AP and STA as independent network interface device
-* [#3913](https://github.com/apache/incubator-nuttx/pull/3913) arch: k210: Fix stack coloring for the idle thread stack
-* [#3757](https://github.com/apache/incubator-nuttx/pull/3757) riscv: Add inline IRQ process functions
-* [#4041](https://github.com/apache/incubator-nuttx/pull/4041) risc-v/bl602: add efuse driver
-* [#4384](https://github.com/apache/incubator-nuttx/pull/4384) Mpfs core pwm
-* [#4507](https://github.com/apache/incubator-nuttx/pull/4507) various MPFS fixes
+* [#3770](https://github.com/apache/nuttx/pull/3770) Add support for PolarFire SoC and icicle board
+* [#3997](https://github.com/apache/nuttx/pull/3997) risc-v/bl602: update wifi firmware version
+* [#4381](https://github.com/apache/nuttx/pull/4381) arch/riscv/assert: enhance the assert dump
+* [#4367](https://github.com/apache/nuttx/pull/4367) riscv/backtrace: add up_backtrace support
+* [#4365](https://github.com/apache/nuttx/pull/4365) riscv/common: add CURRENT_REGS declare in RV32
+* [#4342](https://github.com/apache/nuttx/pull/4342) riscv/bl602: Fix that AP cannot be start when STA have been started.
+* [#4335](https://github.com/apache/nuttx/pull/4335) arch/bl602：Add bl602 os adapter layer
+* [#4145](https://github.com/apache/nuttx/pull/4145) risc-v/bl602: update wifi firmware and some fixup.
+* [#3849](https://github.com/apache/nuttx/pull/3849) risc-v/mpfs: irq fixes, more register defines and up_systemreset()
+* [#3984](https://github.com/apache/nuttx/pull/3984) risc-v/bl602: Support AP and STA as independent network interface device
+* [#3913](https://github.com/apache/nuttx/pull/3913) arch: k210: Fix stack coloring for the idle thread stack
+* [#3757](https://github.com/apache/nuttx/pull/3757) riscv: Add inline IRQ process functions
+* [#4041](https://github.com/apache/nuttx/pull/4041) risc-v/bl602: add efuse driver
+* [#4384](https://github.com/apache/nuttx/pull/4384) Mpfs core pwm
+* [#4507](https://github.com/apache/nuttx/pull/4507) various MPFS fixes
 
 #### ESP32-C3
-* [#3853](https://github.com/apache/incubator-nuttx/pull/3853) arch/risc-v/esp32c3: add esp32c3_modtext to allow ELF loading
+* [#3853](https://github.com/apache/nuttx/pull/3853) arch/risc-v/esp32c3: add esp32c3_modtext to allow ELF loading
 
 #### BL602
-* [#3784](https://github.com/apache/incubator-nuttx/pull/3784) risc-v/bl602: Add RTC driver
-* [#4607](https://github.com/apache/incubator-nuttx/pull/4607) Open ble controller adaptation code
+* [#3784](https://github.com/apache/nuttx/pull/3784) risc-v/bl602: Add RTC driver
+* [#4607](https://github.com/apache/nuttx/pull/4607) Open ble controller adaptation code
 
 #### Xtensa
-* [#4280](https://github.com/apache/incubator-nuttx/pull/4280) arch:xtensa: add new GNU toolchain for xtensa.
-* [#4478](https://github.com/apache/incubator-nuttx/pull/4478) arch: xtensa: add xtensa cache support
-* [#4547](https://github.com/apache/incubator-nuttx/pull/4547) arch:xtensa: add full bactrace support
-* [#4407](https://github.com/apache/incubator-nuttx/pull/4407) arch/xtensa/src/common: Use irq_spin APIs in modifyregXX
-* [#4403](https://github.com/apache/incubator-nuttx/pull/4403) Use driver-specific spinlock for ESP32 serial driver.
-* [#4458](https://github.com/apache/incubator-nuttx/pull/4458) arch:xtensa: add xtensa mpu support
-* [#3762](https://github.com/apache/incubator-nuttx/pull/3762) xtensa: #ifdef SYMBOL is always true if SYMBOL defined as 0
+* [#4280](https://github.com/apache/nuttx/pull/4280) arch:xtensa: add new GNU toolchain for xtensa.
+* [#4478](https://github.com/apache/nuttx/pull/4478) arch: xtensa: add xtensa cache support
+* [#4547](https://github.com/apache/nuttx/pull/4547) arch:xtensa: add full bactrace support
+* [#4407](https://github.com/apache/nuttx/pull/4407) arch/xtensa/src/common: Use irq_spin APIs in modifyregXX
+* [#4403](https://github.com/apache/nuttx/pull/4403) Use driver-specific spinlock for ESP32 serial driver.
+* [#4458](https://github.com/apache/nuttx/pull/4458) arch:xtensa: add xtensa mpu support
+* [#3762](https://github.com/apache/nuttx/pull/3762) xtensa: #ifdef SYMBOL is always true if SYMBOL defined as 0
 
 #### ESP32
-* [#4638](https://github.com/apache/incubator-nuttx/pull/4638) esp32xx_rom.ld: Strongly declare some of the libgcc.a functions that are ROM resident
-* [#4417](https://github.com/apache/incubator-nuttx/pull/4417) arch/esp32: Properly handle GPIO interrupt in SMP.
-* [#4234](https://github.com/apache/incubator-nuttx/pull/4234) espressif/esp32/esp32s2/esp32c3: Disable wdt on initialization.
+* [#4638](https://github.com/apache/nuttx/pull/4638) esp32xx_rom.ld: Strongly declare some of the libgcc.a functions that are ROM resident
+* [#4417](https://github.com/apache/nuttx/pull/4417) arch/esp32: Properly handle GPIO interrupt in SMP.
+* [#4234](https://github.com/apache/nuttx/pull/4234) espressif/esp32/esp32s2/esp32c3: Disable wdt on initialization.
 
 #### X86_64
-* [#4447](https://github.com/apache/incubator-nuttx/pull/4447) Fix x86_64
+* [#4447](https://github.com/apache/nuttx/pull/4447) Fix x86_64
 
 ### General changes
-* [#4233](https://github.com/apache/incubator-nuttx/pull/4233) board/ctrl: Add BOARDIOC_BOOT_IMAGE for booting a new application image
-* [#4191](https://github.com/apache/incubator-nuttx/pull/4191) Add BOARDCTL_SWITCH_BOOT to support switch boot system
-* [#4089](https://github.com/apache/incubator-nuttx/pull/4089) board/ctrl: add BOARDCTL_UNIQUEKEY support
+* [#4233](https://github.com/apache/nuttx/pull/4233) board/ctrl: Add BOARDIOC_BOOT_IMAGE for booting a new application image
+* [#4191](https://github.com/apache/nuttx/pull/4191) Add BOARDCTL_SWITCH_BOOT to support switch boot system
+* [#4089](https://github.com/apache/nuttx/pull/4089) board/ctrl: add BOARDCTL_UNIQUEKEY support
 
  ## Simulator
-* [#3921](https://github.com/apache/incubator-nuttx/pull/3921) sim: Use cc as linker, which usually aliases to either GCC or Clang
-* [#4108](https://github.com/apache/incubator-nuttx/pull/4108) boards/sim: enable nxlooper for alsa config
-* [#4222](https://github.com/apache/incubator-nuttx/pull/4222) sim/cmdline: save boot cmdline
-* [#4209](https://github.com/apache/incubator-nuttx/pull/4209) Fix sim smp
-* [#4207](https://github.com/apache/incubator-nuttx/pull/4207) arch: sim: Workaround to make the IPI work on macOS
-* [#4167](https://github.com/apache/incubator-nuttx/pull/4167) arch/sim: The second CPU shouldn't call up_irqinitialize
-* [#3904](https://github.com/apache/incubator-nuttx/pull/3904) boards/sim/sim/sim: correct LDLINKFLAGS after migrating from ld to gcc
-* [#4056](https://github.com/apache/incubator-nuttx/pull/4056) arch/sim: Fix bt and audio simulation stop work in SMP mode
-* [#4045](https://github.com/apache/incubator-nuttx/pull/4045) sim/smp: fix smp can't start, caused by signal too busy
-* [#4015](https://github.com/apache/incubator-nuttx/pull/4015) modify sim clock to PC abs time
-* [#3983](https://github.com/apache/incubator-nuttx/pull/3983) arch/sim: Implement mm_mallinfo and malloc_size for the custom heap
-* [#4459](https://github.com/apache/incubator-nuttx/pull/4459) sim: Inhibit stack protector on stack coloration function
-* [#3721](https://github.com/apache/incubator-nuttx/pull/3721) sim/rptun: support multi(>2) core interactive by share memory
-* [#4306](https://github.com/apache/incubator-nuttx/pull/4306) boards/sim: Add smartfs profile example
-* [#4258](https://github.com/apache/incubator-nuttx/pull/4258) Use exit func iml host_abort.
-* [#3689](https://github.com/apache/incubator-nuttx/pull/3689) Apps Issue #246: Replace romdisk_register() with boardctl(BOARDIOC_ROMDISK)
-* [#4465](https://github.com/apache/incubator-nuttx/pull/4465) feature: driver: Add a Linux SPI into simulator.
+* [#3921](https://github.com/apache/nuttx/pull/3921) sim: Use cc as linker, which usually aliases to either GCC or Clang
+* [#4108](https://github.com/apache/nuttx/pull/4108) boards/sim: enable nxlooper for alsa config
+* [#4222](https://github.com/apache/nuttx/pull/4222) sim/cmdline: save boot cmdline
+* [#4209](https://github.com/apache/nuttx/pull/4209) Fix sim smp
+* [#4207](https://github.com/apache/nuttx/pull/4207) arch: sim: Workaround to make the IPI work on macOS
+* [#4167](https://github.com/apache/nuttx/pull/4167) arch/sim: The second CPU shouldn't call up_irqinitialize
+* [#3904](https://github.com/apache/nuttx/pull/3904) boards/sim/sim/sim: correct LDLINKFLAGS after migrating from ld to gcc
+* [#4056](https://github.com/apache/nuttx/pull/4056) arch/sim: Fix bt and audio simulation stop work in SMP mode
+* [#4045](https://github.com/apache/nuttx/pull/4045) sim/smp: fix smp can't start, caused by signal too busy
+* [#4015](https://github.com/apache/nuttx/pull/4015) modify sim clock to PC abs time
+* [#3983](https://github.com/apache/nuttx/pull/3983) arch/sim: Implement mm_mallinfo and malloc_size for the custom heap
+* [#4459](https://github.com/apache/nuttx/pull/4459) sim: Inhibit stack protector on stack coloration function
+* [#3721](https://github.com/apache/nuttx/pull/3721) sim/rptun: support multi(>2) core interactive by share memory
+* [#4306](https://github.com/apache/nuttx/pull/4306) boards/sim: Add smartfs profile example
+* [#4258](https://github.com/apache/nuttx/pull/4258) Use exit func iml host_abort.
+* [#3689](https://github.com/apache/nuttx/pull/3689) Apps Issue #246: Replace romdisk_register() with boardctl(BOARDIOC_ROMDISK)
+* [#4465](https://github.com/apache/nuttx/pull/4465) feature: driver: Add a Linux SPI into simulator.
 
 ## Documentation
 
 ### New Features
-* [#3634](https://github.com/apache/incubator-nuttx/pull/3634) Documentation/platforms: added documentation for imxrt10xx boards
-* [#4470](https://github.com/apache/incubator-nuttx/pull/4470) Doc: Add initial documentation to the simulator
-* [#4419](https://github.com/apache/incubator-nuttx/pull/4419) doc/esp32: Add instructions to use softap
+* [#3634](https://github.com/apache/nuttx/pull/3634) Documentation/platforms: added documentation for imxrt10xx boards
+* [#4470](https://github.com/apache/nuttx/pull/4470) Doc: Add initial documentation to the simulator
+* [#4419](https://github.com/apache/nuttx/pull/4419) doc/esp32: Add instructions to use softap
 
  ### Improvements
-* [#3782](https://github.com/apache/incubator-nuttx/pull/3782) spi: Improve SPI Slave interface documentation
-* [#4390](https://github.com/apache/incubator-nuttx/pull/4390) Documentation: Update ESP32-C3 supported peripheral list.
-* [#3702](https://github.com/apache/incubator-nuttx/pull/3702) Documentation/esp32c3: Fix a couple of issues from #3700
-* [#4242](https://github.com/apache/incubator-nuttx/pull/4242) Documentation/bl602: Update some imformation
-* [#3662](https://github.com/apache/incubator-nuttx/pull/3662) Fix some issues on SPI documentation
-* [#4375](https://github.com/apache/incubator-nuttx/pull/4375) Documentation/esp32-wrover-kit: update the name of the GPIO interrupt device.
-* [#4298](https://github.com/apache/incubator-nuttx/pull/4298) Doc/FAQ: Add more entries about board initialization
-* [#3899](https://github.com/apache/incubator-nuttx/pull/3899) Documentation: Update kconfig-frontends install instructions
-* [#4235](https://github.com/apache/incubator-nuttx/pull/4235) Documentation/: Update ESP32 doc.
-* [#3802](https://github.com/apache/incubator-nuttx/pull/3802) Doc: Improve documentation to make clear about the priorities
-* [#4564](https://github.com/apache/incubator-nuttx/pull/4564) Doc: Update download version to 10.1 and fix tar command
-* [#3700](https://github.com/apache/incubator-nuttx/pull/3700) Convert ESP32-C3 README to the new Documentation
-* [#4298](https://github.com/apache/incubator-nuttx/pull/4298) Doc/FAQ: Add more entries about board initialization
-* [#4297](https://github.com/apache/incubator-nuttx/pull/4297) Documentation/FAQ: Why /dev/ttySx is not created
+* [#3782](https://github.com/apache/nuttx/pull/3782) spi: Improve SPI Slave interface documentation
+* [#4390](https://github.com/apache/nuttx/pull/4390) Documentation: Update ESP32-C3 supported peripheral list.
+* [#3702](https://github.com/apache/nuttx/pull/3702) Documentation/esp32c3: Fix a couple of issues from #3700
+* [#4242](https://github.com/apache/nuttx/pull/4242) Documentation/bl602: Update some imformation
+* [#3662](https://github.com/apache/nuttx/pull/3662) Fix some issues on SPI documentation
+* [#4375](https://github.com/apache/nuttx/pull/4375) Documentation/esp32-wrover-kit: update the name of the GPIO interrupt device.
+* [#4298](https://github.com/apache/nuttx/pull/4298) Doc/FAQ: Add more entries about board initialization
+* [#3899](https://github.com/apache/nuttx/pull/3899) Documentation: Update kconfig-frontends install instructions
+* [#4235](https://github.com/apache/nuttx/pull/4235) Documentation/: Update ESP32 doc.
+* [#3802](https://github.com/apache/nuttx/pull/3802) Doc: Improve documentation to make clear about the priorities
+* [#4564](https://github.com/apache/nuttx/pull/4564) Doc: Update download version to 10.1 and fix tar command
+* [#3700](https://github.com/apache/nuttx/pull/3700) Convert ESP32-C3 README to the new Documentation
+* [#4298](https://github.com/apache/nuttx/pull/4298) Doc/FAQ: Add more entries about board initialization
+* [#4297](https://github.com/apache/nuttx/pull/4297) Documentation/FAQ: Why /dev/ttySx is not created
 
 ### Driver Support
 
 ### Bug Fixes
-* [#3842](https://github.com/apache/incubator-nuttx/pull/3842) Added automatic log rotation, when log file is opened.
-* [#3837](https://github.com/apache/incubator-nuttx/pull/3837) SYSLOG channel add functions return handle to the channel.
-* [#3848](https://github.com/apache/incubator-nuttx/pull/3848) Syslog file rotations number is configurable.
-* [#3808](https://github.com/apache/incubator-nuttx/pull/3808) Ramlog: recover last crash log from ram buffer.
-* [#4614](https://github.com/apache/incubator-nuttx/pull/4614) input/touch: add io command for touch firmware version
-* [#4632](https://github.com/apache/incubator-nuttx/pull/4632) feat: driver: support double buffer for display
-* [#4650](https://github.com/apache/incubator-nuttx/pull/4650) driver/power: using upper-half structure directly in the lower-half structure.
-* [#4370](https://github.com/apache/incubator-nuttx/pull/4370) drivers/sensors/bmp280.c: Correct bmp280 driver
-* [#4243](https://github.com/apache/incubator-nuttx/pull/4243) drivers/mmcsd:Send cmd0 just once for Increased compatibility
-* [#4231](https://github.com/apache/incubator-nuttx/pull/4231) adc: add ioctl command to get the number of configured channels
-* [#4007](https://github.com/apache/incubator-nuttx/pull/4007) driver/fakesensor: fix bugs.
-* [#4177](https://github.com/apache/incubator-nuttx/pull/4177) serial: use Ctrl+? composite key to force panic"
-* [#3851](https://github.com/apache/incubator-nuttx/pull/3851) spi: Refactor SPI Slave interface prefix to sync with I2C Slave
-* [#4095](https://github.com/apache/incubator-nuttx/pull/4095) drivers/syslog: Avoid prepending process name when no TCB is available
-* [#3990](https://github.com/apache/incubator-nuttx/pull/3990) drivers: wireless: Fix error handling in gs2200m_ioctl_send()
-* [#3860](https://github.com/apache/incubator-nuttx/pull/3860) drivers: serial: Remove an unnecessary critical section (cs) for SMP
-* [#3910](https://github.com/apache/incubator-nuttx/pull/3910) serial/pty: Initialize the terminal setting as a console
-* [#4110](https://github.com/apache/incubator-nuttx/pull/4110) bcm43xxx: supported IW_AUTH_CIPHER_NONE mode
-* [#4131](https://github.com/apache/incubator-nuttx/pull/4131) drivers/rptun: replace the notification mech from signal to semaphore
-* [#4132](https://github.com/apache/incubator-nuttx/pull/4132) serial: add ctrl+@ to force crash system for debugging
-* [#4156](https://github.com/apache/incubator-nuttx/pull/4156) Fakesensor: support gps by read nema csv and delete fakesensor init.
-* [#4225](https://github.com/apache/incubator-nuttx/pull/4225) sensor: directly return -ENOTSUP without the set_interval or batch
-* [#4228](https://github.com/apache/incubator-nuttx/pull/4228) drivers: wireless: Fix to set the address family for recvfrom() in gs2200m
-* [#4288](https://github.com/apache/incubator-nuttx/pull/4288) adc: add IOCTL commands ANIOC_RESET_FIFO and ANIOC_SAMPLES_ON_READ
-* [#4312](https://github.com/apache/incubator-nuttx/pull/4312) drivers/qencoder: add command to set the maximum encoder position
-* [#4652](https://github.com/apache/incubator-nuttx/pull/4652) driver/sensor: support sensor_ops: selftest
-* [#3633](https://github.com/apache/incubator-nuttx/pull/3633) drivers/serial: fix Rx interrupt enable for cdcacm
-* [#4504](https://github.com/apache/incubator-nuttx/pull/4504) add new interface for fb driver and lcd dev driver
-* [#4554](https://github.com/apache/incubator-nuttx/pull/4554) drivers/lcd: Add GC9A01 driver and refine ST7735
-* [#3658](https://github.com/apache/incubator-nuttx/pull/3658) drivers: move the generic upper-half motor driver
-* [#4397](https://github.com/apache/incubator-nuttx/pull/4397) Update lm3s6965
-* [#4489](https://github.com/apache/incubator-nuttx/pull/4489) drivers/mmcsd: Pass the right buffer size to SDIO_DMAPREFLIGHT
-* [#4479](https://github.com/apache/incubator-nuttx/pull/4479) drivers/sdmmc: Remove rwbuffer to avoid panic
-* [#4476](https://github.com/apache/incubator-nuttx/pull/4476) drivers/mmcsd: Change up_udelay to nxsig_usleep if delay >= 1ms
-* [#4474](https://github.com/apache/incubator-nuttx/pull/4474) drivers/mmcsd: Handle the failure correctly in mmcsd_slotinitialize
-* [#4473](https://github.com/apache/incubator-nuttx/pull/4473) drivers/mmcsd: Fix the wrong format argument in mmcsd_dmpcsd
-* [#3720](https://github.com/apache/incubator-nuttx/pull/3720) driver/syslog: add CONFIG_SYSLOG_RPMSG_SERVER_NAME
-* [#3864](https://github.com/apache/incubator-nuttx/pull/3864) Fix ht16k33 driver to support multi-modules
-* [#3828](https://github.com/apache/incubator-nuttx/pull/3828) syslog/emerg: fix bug about printing LOG_EMERG log from iob buffer
-* [#3806](https://github.com/apache/incubator-nuttx/pull/3806) syslog: fix bug about syslog_default_write
-* [#3936](https://github.com/apache/incubator-nuttx/pull/3936) syslog/ramlog: Remove the duplication of \n->\r\n conversion
-* [#3907](https://github.com/apache/incubator-nuttx/pull/3907) serial/pty: Don't return -NOSYS if pollfd::events equals 0
-* [#3742](https://github.com/apache/incubator-nuttx/pull/3742) drivers/modem/altair: Fix behavior when a reset packet conflicts with a send packet
-* [#3741](https://github.com/apache/incubator-nuttx/pull/3741) drivers/mtd/smart.c: Recover the missing link of directory entry
-* [#3736](https://github.com/apache/incubator-nuttx/pull/3736) drivers/syslog: Remove emergstream implementation and caller
-* [#3726](https://github.com/apache/incubator-nuttx/pull/3726) rtc: add config RTC_RPMSG_SERVER, RTC_RPMSG_SERVER_NAME
-* [#4113](https://github.com/apache/incubator-nuttx/pull/4113) syslog/ramlog: optimize code and fix init issue
-* [#4111](https://github.com/apache/incubator-nuttx/pull/4111) syslog/intbuf: force output log when syslog interrupt buffer is full
-* [#4042](https://github.com/apache/incubator-nuttx/pull/4042) serial: add ioctl TIOCNOTTY
-* [#4034](https://github.com/apache/incubator-nuttx/pull/4034) syslog: add CPU id to system when open CONFIG_SMP
-* [#4032](https://github.com/apache/incubator-nuttx/pull/4032) syslog: fix crash when print localtime by syslog
-* [#3979](https://github.com/apache/incubator-nuttx/pull/3979) note: Move up_schednote.c to drivers/note folder
-* [#4475](https://github.com/apache/incubator-nuttx/pull/4475) drivers/mmcsd: Change mmsd_ prefix to mmcsd_ prefix
-* [#4415](https://github.com/apache/incubator-nuttx/pull/4415) Adds driver for msa301 sensore module
-* [#4420](https://github.com/apache/incubator-nuttx/pull/4420) sensor: fix the bug that lsm6dsl selftest is invalid in nuttx.
-* [#3787](https://github.com/apache/incubator-nuttx/pull/3787) drivers/spi: Add SPI Slave character device driver
-* [#4566](https://github.com/apache/incubator-nuttx/pull/4566) drivers/syslog: Call up_puts in syslog_default_write instad up_putc
-* [#4580](https://github.com/apache/incubator-nuttx/pull/4580) drivers/syslog: Ensure the buffer zero terminate
-* [#4302](https://github.com/apache/incubator-nuttx/pull/4302) Compile fixes in MCP23X17 driver.
-* [#4299](https://github.com/apache/incubator-nuttx/pull/4299) bchlib: Improve error handling
-* [#4345](https://github.com/apache/incubator-nuttx/pull/4345) mtd: Implement BIOC_PARTINFO for all drivers
-* [#4248](https://github.com/apache/incubator-nuttx/pull/4248) mtd: Return MTD Partition Information
-* [#4166](https://github.com/apache/incubator-nuttx/pull/4166) mtd: Add MTDIOC_ERASESTATE command for retrieving erase state value
-* [#3885](https://github.com/apache/incubator-nuttx/pull/3885) mtd: Add MTDIOC_FLUSH IOCTL like MTDIOC_XIPBASE
-* [#3722](https://github.com/apache/incubator-nuttx/pull/3722) lirc: fix bug about lirc_raw_event
-* [#4515](https://github.com/apache/incubator-nuttx/pull/4515) rptun: add CONFIG_RPTUN_LOADER to optimize code size
-* [#4223](https://github.com/apache/incubator-nuttx/pull/4223) rptun: optimize multi-core startup
-* [#4552](https://github.com/apache/incubator-nuttx/pull/4552) bcm43xxx: abrupt stall of receiving new credits from sdpcm header
-* [#4565](https://github.com/apache/incubator-nuttx/pull/4565) bcm43xxx: added SDPCM frame pool size parameter
-* [#4236](https://github.com/apache/incubator-nuttx/pull/4236) bcm43xxx: fixed issues with unaligned buffers for DMA transfers.
-* [#4567](https://github.com/apache/incubator-nuttx/pull/4567) lcd/st77xx: change 16 bit cmd send to 8 bit
-* [#4137](https://github.com/apache/incubator-nuttx/pull/4137) bluetooth: add more OGF definition
-* [#4039](https://github.com/apache/incubator-nuttx/pull/4039) Add putarea() method for st7789
-* [#3754](https://github.com/apache/incubator-nuttx/pull/3754) wireless/bluetooth: decoupling bt_driver_s and bt_buf_s
+* [#3842](https://github.com/apache/nuttx/pull/3842) Added automatic log rotation, when log file is opened.
+* [#3837](https://github.com/apache/nuttx/pull/3837) SYSLOG channel add functions return handle to the channel.
+* [#3848](https://github.com/apache/nuttx/pull/3848) Syslog file rotations number is configurable.
+* [#3808](https://github.com/apache/nuttx/pull/3808) Ramlog: recover last crash log from ram buffer.
+* [#4614](https://github.com/apache/nuttx/pull/4614) input/touch: add io command for touch firmware version
+* [#4632](https://github.com/apache/nuttx/pull/4632) feat: driver: support double buffer for display
+* [#4650](https://github.com/apache/nuttx/pull/4650) driver/power: using upper-half structure directly in the lower-half structure.
+* [#4370](https://github.com/apache/nuttx/pull/4370) drivers/sensors/bmp280.c: Correct bmp280 driver
+* [#4243](https://github.com/apache/nuttx/pull/4243) drivers/mmcsd:Send cmd0 just once for Increased compatibility
+* [#4231](https://github.com/apache/nuttx/pull/4231) adc: add ioctl command to get the number of configured channels
+* [#4007](https://github.com/apache/nuttx/pull/4007) driver/fakesensor: fix bugs.
+* [#4177](https://github.com/apache/nuttx/pull/4177) serial: use Ctrl+? composite key to force panic"
+* [#3851](https://github.com/apache/nuttx/pull/3851) spi: Refactor SPI Slave interface prefix to sync with I2C Slave
+* [#4095](https://github.com/apache/nuttx/pull/4095) drivers/syslog: Avoid prepending process name when no TCB is available
+* [#3990](https://github.com/apache/nuttx/pull/3990) drivers: wireless: Fix error handling in gs2200m_ioctl_send()
+* [#3860](https://github.com/apache/nuttx/pull/3860) drivers: serial: Remove an unnecessary critical section (cs) for SMP
+* [#3910](https://github.com/apache/nuttx/pull/3910) serial/pty: Initialize the terminal setting as a console
+* [#4110](https://github.com/apache/nuttx/pull/4110) bcm43xxx: supported IW_AUTH_CIPHER_NONE mode
+* [#4131](https://github.com/apache/nuttx/pull/4131) drivers/rptun: replace the notification mech from signal to semaphore
+* [#4132](https://github.com/apache/nuttx/pull/4132) serial: add ctrl+@ to force crash system for debugging
+* [#4156](https://github.com/apache/nuttx/pull/4156) Fakesensor: support gps by read nema csv and delete fakesensor init.
+* [#4225](https://github.com/apache/nuttx/pull/4225) sensor: directly return -ENOTSUP without the set_interval or batch
+* [#4228](https://github.com/apache/nuttx/pull/4228) drivers: wireless: Fix to set the address family for recvfrom() in gs2200m
+* [#4288](https://github.com/apache/nuttx/pull/4288) adc: add IOCTL commands ANIOC_RESET_FIFO and ANIOC_SAMPLES_ON_READ
+* [#4312](https://github.com/apache/nuttx/pull/4312) drivers/qencoder: add command to set the maximum encoder position
+* [#4652](https://github.com/apache/nuttx/pull/4652) driver/sensor: support sensor_ops: selftest
+* [#3633](https://github.com/apache/nuttx/pull/3633) drivers/serial: fix Rx interrupt enable for cdcacm
+* [#4504](https://github.com/apache/nuttx/pull/4504) add new interface for fb driver and lcd dev driver
+* [#4554](https://github.com/apache/nuttx/pull/4554) drivers/lcd: Add GC9A01 driver and refine ST7735
+* [#3658](https://github.com/apache/nuttx/pull/3658) drivers: move the generic upper-half motor driver
+* [#4397](https://github.com/apache/nuttx/pull/4397) Update lm3s6965
+* [#4489](https://github.com/apache/nuttx/pull/4489) drivers/mmcsd: Pass the right buffer size to SDIO_DMAPREFLIGHT
+* [#4479](https://github.com/apache/nuttx/pull/4479) drivers/sdmmc: Remove rwbuffer to avoid panic
+* [#4476](https://github.com/apache/nuttx/pull/4476) drivers/mmcsd: Change up_udelay to nxsig_usleep if delay >= 1ms
+* [#4474](https://github.com/apache/nuttx/pull/4474) drivers/mmcsd: Handle the failure correctly in mmcsd_slotinitialize
+* [#4473](https://github.com/apache/nuttx/pull/4473) drivers/mmcsd: Fix the wrong format argument in mmcsd_dmpcsd
+* [#3720](https://github.com/apache/nuttx/pull/3720) driver/syslog: add CONFIG_SYSLOG_RPMSG_SERVER_NAME
+* [#3864](https://github.com/apache/nuttx/pull/3864) Fix ht16k33 driver to support multi-modules
+* [#3828](https://github.com/apache/nuttx/pull/3828) syslog/emerg: fix bug about printing LOG_EMERG log from iob buffer
+* [#3806](https://github.com/apache/nuttx/pull/3806) syslog: fix bug about syslog_default_write
+* [#3936](https://github.com/apache/nuttx/pull/3936) syslog/ramlog: Remove the duplication of \n->\r\n conversion
+* [#3907](https://github.com/apache/nuttx/pull/3907) serial/pty: Don't return -NOSYS if pollfd::events equals 0
+* [#3742](https://github.com/apache/nuttx/pull/3742) drivers/modem/altair: Fix behavior when a reset packet conflicts with a send packet
+* [#3741](https://github.com/apache/nuttx/pull/3741) drivers/mtd/smart.c: Recover the missing link of directory entry
+* [#3736](https://github.com/apache/nuttx/pull/3736) drivers/syslog: Remove emergstream implementation and caller
+* [#3726](https://github.com/apache/nuttx/pull/3726) rtc: add config RTC_RPMSG_SERVER, RTC_RPMSG_SERVER_NAME
+* [#4113](https://github.com/apache/nuttx/pull/4113) syslog/ramlog: optimize code and fix init issue
+* [#4111](https://github.com/apache/nuttx/pull/4111) syslog/intbuf: force output log when syslog interrupt buffer is full
+* [#4042](https://github.com/apache/nuttx/pull/4042) serial: add ioctl TIOCNOTTY
+* [#4034](https://github.com/apache/nuttx/pull/4034) syslog: add CPU id to system when open CONFIG_SMP
+* [#4032](https://github.com/apache/nuttx/pull/4032) syslog: fix crash when print localtime by syslog
+* [#3979](https://github.com/apache/nuttx/pull/3979) note: Move up_schednote.c to drivers/note folder
+* [#4475](https://github.com/apache/nuttx/pull/4475) drivers/mmcsd: Change mmsd_ prefix to mmcsd_ prefix
+* [#4415](https://github.com/apache/nuttx/pull/4415) Adds driver for msa301 sensore module
+* [#4420](https://github.com/apache/nuttx/pull/4420) sensor: fix the bug that lsm6dsl selftest is invalid in nuttx.
+* [#3787](https://github.com/apache/nuttx/pull/3787) drivers/spi: Add SPI Slave character device driver
+* [#4566](https://github.com/apache/nuttx/pull/4566) drivers/syslog: Call up_puts in syslog_default_write instad up_putc
+* [#4580](https://github.com/apache/nuttx/pull/4580) drivers/syslog: Ensure the buffer zero terminate
+* [#4302](https://github.com/apache/nuttx/pull/4302) Compile fixes in MCP23X17 driver.
+* [#4299](https://github.com/apache/nuttx/pull/4299) bchlib: Improve error handling
+* [#4345](https://github.com/apache/nuttx/pull/4345) mtd: Implement BIOC_PARTINFO for all drivers
+* [#4248](https://github.com/apache/nuttx/pull/4248) mtd: Return MTD Partition Information
+* [#4166](https://github.com/apache/nuttx/pull/4166) mtd: Add MTDIOC_ERASESTATE command for retrieving erase state value
+* [#3885](https://github.com/apache/nuttx/pull/3885) mtd: Add MTDIOC_FLUSH IOCTL like MTDIOC_XIPBASE
+* [#3722](https://github.com/apache/nuttx/pull/3722) lirc: fix bug about lirc_raw_event
+* [#4515](https://github.com/apache/nuttx/pull/4515) rptun: add CONFIG_RPTUN_LOADER to optimize code size
+* [#4223](https://github.com/apache/nuttx/pull/4223) rptun: optimize multi-core startup
+* [#4552](https://github.com/apache/nuttx/pull/4552) bcm43xxx: abrupt stall of receiving new credits from sdpcm header
+* [#4565](https://github.com/apache/nuttx/pull/4565) bcm43xxx: added SDPCM frame pool size parameter
+* [#4236](https://github.com/apache/nuttx/pull/4236) bcm43xxx: fixed issues with unaligned buffers for DMA transfers.
+* [#4567](https://github.com/apache/nuttx/pull/4567) lcd/st77xx: change 16 bit cmd send to 8 bit
+* [#4137](https://github.com/apache/nuttx/pull/4137) bluetooth: add more OGF definition
+* [#4039](https://github.com/apache/nuttx/pull/4039) Add putarea() method for st7789
+* [#3754](https://github.com/apache/nuttx/pull/3754) wireless/bluetooth: decoupling bt_driver_s and bt_buf_s
 
 ### New Driver Support
-* [#3727](https://github.com/apache/incubator-nuttx/pull/3727) Add basic support for MCP23017 I/O Expander
-* [#3859](https://github.com/apache/incubator-nuttx/pull/3859) Add Holtek HT16K33 14-segment display driver
-* [#4641](https://github.com/apache/incubator-nuttx/pull/4641) drivers/mtd/m25px.c: add support for MT25Q256 SPI NOR
-* [#4606](https://github.com/apache/incubator-nuttx/pull/4606) Add support for MT25Q1G SPI NOR
-* [#4373](https://github.com/apache/incubator-nuttx/pull/4373) Add support for 3-phase Hall effect sensor driver
-* [#4490](https://github.com/apache/incubator-nuttx/pull/4490) add support for power management ic axp202
+* [#3727](https://github.com/apache/nuttx/pull/3727) Add basic support for MCP23017 I/O Expander
+* [#3859](https://github.com/apache/nuttx/pull/3859) Add Holtek HT16K33 14-segment display driver
+* [#4641](https://github.com/apache/nuttx/pull/4641) drivers/mtd/m25px.c: add support for MT25Q256 SPI NOR
+* [#4606](https://github.com/apache/nuttx/pull/4606) Add support for MT25Q1G SPI NOR
+* [#4373](https://github.com/apache/nuttx/pull/4373) Add support for 3-phase Hall effect sensor driver
+* [#4490](https://github.com/apache/nuttx/pull/4490) add support for power management ic axp202
 
 ## Board Support
 
@@ -466,326 +466,326 @@ limitations under the License.
 #### ARM
 
 #### CXD56
-* [#3833](https://github.com/apache/incubator-nuttx/pull/3833) Spresense new memorymap
-* [#4526](https://github.com/apache/incubator-nuttx/pull/4526) Rearch video
-* [#3973](https://github.com/apache/incubator-nuttx/pull/3973) boards: spresense: Update rndis and rndis_smp for workaround
-* [#3744](https://github.com/apache/incubator-nuttx/pull/3744) boards: cxd56xx: Update drivers on spresense board
+* [#3833](https://github.com/apache/nuttx/pull/3833) Spresense new memorymap
+* [#4526](https://github.com/apache/nuttx/pull/4526) Rearch video
+* [#3973](https://github.com/apache/nuttx/pull/3973) boards: spresense: Update rndis and rndis_smp for workaround
+* [#3744](https://github.com/apache/nuttx/pull/3744) boards: cxd56xx: Update drivers on spresense board
 
 #### IMX6
-* [#3733](https://github.com/apache/incubator-nuttx/pull/3733) imx6 elf support
+* [#3733](https://github.com/apache/nuttx/pull/3733) imx6 elf support
 
 #### IMXRT
-* [#3982](https://github.com/apache/incubator-nuttx/pull/3982) boards/arm/imxrt/teensy-4.x: added board level support for GPIO driver
-* [#3929](https://github.com/apache/incubator-nuttx/pull/3929) Added encoder support for Teensy 4.x
-* [#3980](https://github.com/apache/incubator-nuttx/pull/3980) FlexPWM support for iMXRT MCU
-* [#4581](https://github.com/apache/incubator-nuttx/pull/4581) Fixed imxrt flexcan driver compilation error (incorrect variable scope)
+* [#3982](https://github.com/apache/nuttx/pull/3982) boards/arm/imxrt/teensy-4.x: added board level support for GPIO driver
+* [#3929](https://github.com/apache/nuttx/pull/3929) Added encoder support for Teensy 4.x
+* [#3980](https://github.com/apache/nuttx/pull/3980) FlexPWM support for iMXRT MCU
+* [#4581](https://github.com/apache/nuttx/pull/4581) Fixed imxrt flexcan driver compilation error (incorrect variable scope)
 
 #### LPC17XX_40XX
 
 #### NRF52
 
 #### RP2040
-* [#3917](https://github.com/apache/incubator-nuttx/pull/3917) arm/rp2040:USB device controller support
-* [#3857](https://github.com/apache/incubator-nuttx/pull/3857) boards: rp2040: Add user gpio driver
-* [#3996](https://github.com/apache/incubator-nuttx/pull/3996) Support for Waveshare Pico-LCD-1.x module
-* [#4086](https://github.com/apache/incubator-nuttx/pull/4086) Added PCF8574 backpack support to Raspberry Pi Pico
-* [#4204](https://github.com/apache/incubator-nuttx/pull/4204) added st7735 LCD based support
-* [#4289](https://github.com/apache/incubator-nuttx/pull/4289) Fixing BMP180 and INA219 in RP2040
+* [#3917](https://github.com/apache/nuttx/pull/3917) arm/rp2040:USB device controller support
+* [#3857](https://github.com/apache/nuttx/pull/3857) boards: rp2040: Add user gpio driver
+* [#3996](https://github.com/apache/nuttx/pull/3996) Support for Waveshare Pico-LCD-1.x module
+* [#4086](https://github.com/apache/nuttx/pull/4086) Added PCF8574 backpack support to Raspberry Pi Pico
+* [#4204](https://github.com/apache/nuttx/pull/4204) added st7735 LCD based support
+* [#4289](https://github.com/apache/nuttx/pull/4289) Fixing BMP180 and INA219 in RP2040
 
 #### S32K1XX
-* [#4643](https://github.com/apache/incubator-nuttx/pull/4643) S32K1xx arch: Add (optional) support for SPI native/hardware chip select
-* [#4634](https://github.com/apache/incubator-nuttx/pull/4634) S32K1XX arch: gpioread may also be used for output pins
-* [#4592](https://github.com/apache/incubator-nuttx/pull/4592) S32K1XX: Add LPI2C slave support
-* [#4541](https://github.com/apache/incubator-nuttx/pull/4541) S32K1XX EVB boards cleanup & update
-* [#4578](https://github.com/apache/incubator-nuttx/pull/4578) S32K1XXEVB boards: Fix RGB LED output and add comments
-* [#4533](https://github.com/apache/incubator-nuttx/pull/4533) S32k1xx: added PM support
-* [#4596](https://github.com/apache/incubator-nuttx/pull/4596) S32K1XX: Add FlexIO registers
-* [#4508](https://github.com/apache/incubator-nuttx/pull/4508) s32k1xx: added way to get the reset cause in a proc fs
-* [#4560](https://github.com/apache/incubator-nuttx/pull/4560) RDDRONE-UAVCAN / UCANS32K146 boards cleanup & update
+* [#4643](https://github.com/apache/nuttx/pull/4643) S32K1xx arch: Add (optional) support for SPI native/hardware chip select
+* [#4634](https://github.com/apache/nuttx/pull/4634) S32K1XX arch: gpioread may also be used for output pins
+* [#4592](https://github.com/apache/nuttx/pull/4592) S32K1XX: Add LPI2C slave support
+* [#4541](https://github.com/apache/nuttx/pull/4541) S32K1XX EVB boards cleanup & update
+* [#4578](https://github.com/apache/nuttx/pull/4578) S32K1XXEVB boards: Fix RGB LED output and add comments
+* [#4533](https://github.com/apache/nuttx/pull/4533) S32k1xx: added PM support
+* [#4596](https://github.com/apache/nuttx/pull/4596) S32K1XX: Add FlexIO registers
+* [#4508](https://github.com/apache/nuttx/pull/4508) s32k1xx: added way to get the reset cause in a proc fs
+* [#4560](https://github.com/apache/nuttx/pull/4560) RDDRONE-UAVCAN / UCANS32K146 boards cleanup & update
 
 #### SAM34
-* [#3732](https://github.com/apache/incubator-nuttx/pull/3732) board: Add support for Adafruit Circuit Express
-* [#3840](https://github.com/apache/incubator-nuttx/pull/3840) Add ST7789 LCD controller support for SAMV71 XPlained Ultra board
+* [#3732](https://github.com/apache/nuttx/pull/3732) board: Add support for Adafruit Circuit Express
+* [#3840](https://github.com/apache/nuttx/pull/3840) Add ST7789 LCD controller support for SAMV71 XPlained Ultra board
 
 #### STM32
-* [#3944](https://github.com/apache/incubator-nuttx/pull/3944) boards/arm/stm32/nucleo-f446re: added support for DAC driver
-* [#3880](https://github.com/apache/incubator-nuttx/pull/3880) boards/arm/stm32/nucleo-f446re: added support for GPIO driver
-* [#3909](https://github.com/apache/incubator-nuttx/pull/3909) Added basic support for nucleo-g431kb board.
-* [#3922](https://github.com/apache/incubator-nuttx/pull/3922) Adds PWM example to nucleo-g431kb board.
-* [#3914](https://github.com/apache/incubator-nuttx/pull/3914) boards: added support for EMW3162 Wi-Fi board
-* [#3878](https://github.com/apache/incubator-nuttx/pull/3878) Add FOC support for B-G431-ESC1 board
-* [#3637](https://github.com/apache/incubator-nuttx/pull/3637) boards/arm/stm32/nucleo-f446re: added support for PWM
-* [#3660](https://github.com/apache/incubator-nuttx/pull/3660) stm32_pwm: improvements for PULSECOUNT support
-* [#4505](https://github.com/apache/incubator-nuttx/pull/4505) STM32 F4, F7, H7 USB OTG Device Ensure EP initialized to proper state on usb reset and configure
-* [#4589](https://github.com/apache/incubator-nuttx/pull/4589) Fix stm32xx GPIO glitches from configuration bad order of operations
-* [#4085](https://github.com/apache/incubator-nuttx/pull/4085) stm32,stm32f7,stm32h7: supported ETH MAC promiscuous mode
-* [#4255](https://github.com/apache/incubator-nuttx/pull/4255) STM32 DAC Driver - Add support to DAC3
-* [#3796](https://github.com/apache/incubator-nuttx/pull/3796) boards/arm/stm32/nucleo-f412zg/scripts/Make.defs: Replace EXTRADEFINES by EXTRAFLAGS
-* [#4284](https://github.com/apache/incubator-nuttx/pull/4284) stm32_pmw: fix pwm_stop() function to enable multiple PWM start and stop
-* [#4353](https://github.com/apache/incubator-nuttx/pull/4353) stm32/stm32_serial.c fix issue
-* [#4244](https://github.com/apache/incubator-nuttx/pull/4244) STM32G4: add support for CORDIC math accelerator
-* [#4437](https://github.com/apache/incubator-nuttx/pull/4437) stm32_serial.c: Don't fake a TX interrupt when interrupts are not suppressed
-* [#3863](https://github.com/apache/incubator-nuttx/pull/3863) boards/arm/stm32/nucleo-f446re: fixed wrong qetimer config name
-* [#3952](https://github.com/apache/incubator-nuttx/pull/3952) SDIO IO_RW_EXTENDED command (CMD53) related fixes
-* [#4597](https://github.com/apache/incubator-nuttx/pull/4597) Add LCD backpack support for ESP32 (devkit-c).
+* [#3944](https://github.com/apache/nuttx/pull/3944) boards/arm/stm32/nucleo-f446re: added support for DAC driver
+* [#3880](https://github.com/apache/nuttx/pull/3880) boards/arm/stm32/nucleo-f446re: added support for GPIO driver
+* [#3909](https://github.com/apache/nuttx/pull/3909) Added basic support for nucleo-g431kb board.
+* [#3922](https://github.com/apache/nuttx/pull/3922) Adds PWM example to nucleo-g431kb board.
+* [#3914](https://github.com/apache/nuttx/pull/3914) boards: added support for EMW3162 Wi-Fi board
+* [#3878](https://github.com/apache/nuttx/pull/3878) Add FOC support for B-G431-ESC1 board
+* [#3637](https://github.com/apache/nuttx/pull/3637) boards/arm/stm32/nucleo-f446re: added support for PWM
+* [#3660](https://github.com/apache/nuttx/pull/3660) stm32_pwm: improvements for PULSECOUNT support
+* [#4505](https://github.com/apache/nuttx/pull/4505) STM32 F4, F7, H7 USB OTG Device Ensure EP initialized to proper state on usb reset and configure
+* [#4589](https://github.com/apache/nuttx/pull/4589) Fix stm32xx GPIO glitches from configuration bad order of operations
+* [#4085](https://github.com/apache/nuttx/pull/4085) stm32,stm32f7,stm32h7: supported ETH MAC promiscuous mode
+* [#4255](https://github.com/apache/nuttx/pull/4255) STM32 DAC Driver - Add support to DAC3
+* [#3796](https://github.com/apache/nuttx/pull/3796) boards/arm/stm32/nucleo-f412zg/scripts/Make.defs: Replace EXTRADEFINES by EXTRAFLAGS
+* [#4284](https://github.com/apache/nuttx/pull/4284) stm32_pmw: fix pwm_stop() function to enable multiple PWM start and stop
+* [#4353](https://github.com/apache/nuttx/pull/4353) stm32/stm32_serial.c fix issue
+* [#4244](https://github.com/apache/nuttx/pull/4244) STM32G4: add support for CORDIC math accelerator
+* [#4437](https://github.com/apache/nuttx/pull/4437) stm32_serial.c: Don't fake a TX interrupt when interrupts are not suppressed
+* [#3863](https://github.com/apache/nuttx/pull/3863) boards/arm/stm32/nucleo-f446re: fixed wrong qetimer config name
+* [#3952](https://github.com/apache/nuttx/pull/3952) SDIO IO_RW_EXTENDED command (CMD53) related fixes
+* [#4597](https://github.com/apache/nuttx/pull/4597) Add LCD backpack support for ESP32 (devkit-c).
 
 #### STM32L4
-* [#4534](https://github.com/apache/incubator-nuttx/pull/4534) STM32L4 LPUART support
+* [#4534](https://github.com/apache/nuttx/pull/4534) STM32L4 LPUART support
 
 #### STM32F4
 
 #### STM32F7 / STM32H7
- * [#3646](https://github.com/apache/incubator-nuttx/pull/3646) boards/stm32f7: Add i2c and mpu60x0 support to nucleo-144 and fix bitmask bug in mpu60x0
-* [#3650](https://github.com/apache/incubator-nuttx/pull/3650) stm32{H7|F7} Disables/Enabled the use of GPIO_OTG_ID pin
-* [#3669](https://github.com/apache/incubator-nuttx/pull/3669) STM32 {F7|H7} Use 250 Ms Data path timeout, regardless of Card Clock frequency
-* [#3651](https://github.com/apache/incubator-nuttx/pull/3651) Use inttypes in stm32{f7|h7}, Kinetis, s32k drivers.
-* [#4524](https://github.com/apache/incubator-nuttx/pull/4524) stm32*7/stm32_serial.c: Don't fake a TX interrupt when interrupts are not suppressed
-* [#4598](https://github.com/apache/incubator-nuttx/pull/4598) stm32h7:DMA_TRBUFF is DMA_SCR_TRBUFF
+ * [#3646](https://github.com/apache/nuttx/pull/3646) boards/stm32f7: Add i2c and mpu60x0 support to nucleo-144 and fix bitmask bug in mpu60x0
+* [#3650](https://github.com/apache/nuttx/pull/3650) stm32{H7|F7} Disables/Enabled the use of GPIO_OTG_ID pin
+* [#3669](https://github.com/apache/nuttx/pull/3669) STM32 {F7|H7} Use 250 Ms Data path timeout, regardless of Card Clock frequency
+* [#3651](https://github.com/apache/nuttx/pull/3651) Use inttypes in stm32{f7|h7}, Kinetis, s32k drivers.
+* [#4524](https://github.com/apache/nuttx/pull/4524) stm32*7/stm32_serial.c: Don't fake a TX interrupt when interrupts are not suppressed
+* [#4598](https://github.com/apache/nuttx/pull/4598) stm32h7:DMA_TRBUFF is DMA_SCR_TRBUFF
 
 #### KINETIS
-* [#4190](https://github.com/apache/incubator-nuttx/pull/4190) kinetis lpserial add RX DMA
+* [#4190](https://github.com/apache/nuttx/pull/4190) kinetis lpserial add RX DMA
 
 #### ARM
 #### AVR32
-* [#3684](https://github.com/apache/incubator-nuttx/pull/) avr32dev1: USART1 RX: Reassign pin
+* [#3684](https://github.com/apache/nuttx/pull/) avr32dev1: USART1 RX: Reassign pin
 
 #### MIPS
 #### PIC32
-* [#4264](https://github.com/apache/incubator-nuttx/pull/) boards: added a basic support for chipKIT Wi-FIRE board
+* [#4264](https://github.com/apache/nuttx/pull/) boards: added a basic support for chipKIT Wi-FIRE board
 
 #### RISC-V
-* [#3846](https://github.com/apache/incubator-nuttx/pull/3846) risc-v/rv32m1: Basic port to rv32m1 ri5cy
-* [#4146](https://github.com/apache/incubator-nuttx/pull/4146) risc-v/bl602: add boardctl support
-* [#3911](https://github.com/apache/incubator-nuttx/pull/3911) Add i2c driver to PolarFire SoC and Icicle board
-* [#3905](https://github.com/apache/incubator-nuttx/pull/3905) Add SPI driver to PolarFire SoC and Icicle board
-* [#3933](https://github.com/apache/incubator-nuttx/pull/3933) riscv/mpfs: add i2c reset handler
-* [#3920](https://github.com/apache/incubator-nuttx/pull/3920) add dma support for PolarFire SoC
-* [#4569](https://github.com/apache/incubator-nuttx/pull/4569) MPFS emmcsd
+* [#3846](https://github.com/apache/nuttx/pull/3846) risc-v/rv32m1: Basic port to rv32m1 ri5cy
+* [#4146](https://github.com/apache/nuttx/pull/4146) risc-v/bl602: add boardctl support
+* [#3911](https://github.com/apache/nuttx/pull/3911) Add i2c driver to PolarFire SoC and Icicle board
+* [#3905](https://github.com/apache/nuttx/pull/3905) Add SPI driver to PolarFire SoC and Icicle board
+* [#3933](https://github.com/apache/nuttx/pull/3933) riscv/mpfs: add i2c reset handler
+* [#3920](https://github.com/apache/nuttx/pull/3920) add dma support for PolarFire SoC
+* [#4569](https://github.com/apache/nuttx/pull/4569) MPFS emmcsd
 
 #### BL602
-* [#4010](https://github.com/apache/incubator-nuttx/pull/4010) boards/bl602: Fix uart_nx.c:419: undefined reference to `uart_bth4_register
+* [#4010](https://github.com/apache/nuttx/pull/4010) boards/bl602: Fix uart_nx.c:419: undefined reference to `uart_bth4_register
 
 #### C906
 
 #### ESP32-C3
-* [#3794](https://github.com/apache/incubator-nuttx/pull/3794) risc-v/esp32c3: Support ESP32-C3 RTC driver
-* [#3883](https://github.com/apache/incubator-nuttx/pull/3883) risc-v/esp32c3: Support ESP32-C3 RSA accelerator
-* [#3881](https://github.com/apache/incubator-nuttx/pull/3881) risc-v/esp32c3: Support ESP32-C3 efuse
-* [#3935](https://github.com/apache/incubator-nuttx/pull/3935) risc-v/esp32c3: Support ESP32-C3 SHA accelerator
-* [#3882](https://github.com/apache/incubator-nuttx/pull/3882) riscv/esp32c3: Use the RTC memory as another heap.
-* [#3945](https://github.com/apache/incubator-nuttx/pull/3945) boards/esp32c3: Add romfs configuration
-* [#3925](https://github.com/apache/incubator-nuttx/pull/3925) risc-v/esp32-c3: Adds I2C polled support
-* [#3823](https://github.com/apache/incubator-nuttx/pull/3823) risc-v/esp32-c3: Add support for HW flow control.
-* [#3822](https://github.com/apache/incubator-nuttx/pull/3822) ESP32-C3: Add DMA support for SPI Slave
-* [#3543](https://github.com/apache/incubator-nuttx/pull/3543) feat(esp32c3): Support esp32c3 ble function
-* [#3667](https://github.com/apache/incubator-nuttx/pull/3667) risc-v/esp32c3: Add ESP32-C3 (G)DMA driver and testing
-* [#4605](https://github.com/apache/incubator-nuttx/pull/4605) risc-v/esp32-c3: improvements and fix to esp32c3_rt_timer.c
-* [#4611](https://github.com/apache/incubator-nuttx/pull/4611) ESP32-C3: Add support for booting NuttX from MCUboot
-* [#3656](https://github.com/apache/incubator-nuttx/pull/3656) risc-v/esp32-c3: Adds freerun wrapper
-* [#4574](https://github.com/apache/incubator-nuttx/pull/4574) esp32c3-devkit: Add board profile to use LVGL on GC9A01 display
-* [#3810](https://github.com/apache/incubator-nuttx/pull/3810) risc-v/esp32c3: Fix overwriting of registered-but-disabled interrupts
-* [#3797](https://github.com/apache/incubator-nuttx/pull/3797) ESP32-C3: Add SPI Slave peripheral driver
-* [#4568](https://github.com/apache/incubator-nuttx/pull/4568) boards/esp32c3: add ESP32C3 LCD drivers
-* [#4553](https://github.com/apache/incubator-nuttx/pull/4553) risc-v/esp32c3: fix pwm driver bug
-* [#4500](https://github.com/apache/incubator-nuttx/pull/4500) risc-v/esp32-c3: refactor the Wi-Fi board logic.
-* [#3679](https://github.com/apache/incubator-nuttx/pull/3679) risc-v/esp32c3: Support ESP32-C3 PM standby and sleep
-* [#3766](https://github.com/apache/incubator-nuttx/pull/3766) riscv/esp32c3: Add ESP32-C3 AES driver
-* [#3750](https://github.com/apache/incubator-nuttx/pull/3750) riscv/esp32c3: Support SPI Flash encryption read/write
-* [#3735](https://github.com/apache/incubator-nuttx/pull/3735) riscv/esp32c3: Add ESP32-C3 ADC driver
-* [#3715](https://github.com/apache/incubator-nuttx/pull/3715) risc-v/esp32c3: Support ESP32-C3 auto-sleep
-* [#4239](https://github.com/apache/incubator-nuttx/pull/4239) risc-v/esp32-c3: Adds systimer support and make rt_timer rely on it
-* [#3694](https://github.com/apache/incubator-nuttx/pull/3694) risc-v/esp32c3: Add support for DMA transfers on SPI driver
-* [#3697](https://github.com/apache/incubator-nuttx/pull/3697) riscv/esp32c3: Fix RT timer issues
-* [#3906](https://github.com/apache/incubator-nuttx/pull/3906) risc-v/esp32c3_wifi_adapter.c: Remove a config that's only used in Xtensa chips.
-* [#3701](https://github.com/apache/incubator-nuttx/pull/3701) riscv/esp32c3: Add ESP32C3 LEDC(PWM) driver
-* [#3854](https://github.com/apache/incubator-nuttx/pull/3854) ESP32-C3: Small clean up on IRQ functions
-* [#4006](https://github.com/apache/incubator-nuttx/pull/4006) risc-v/esp32c3: Notifies networking layer whether the carrier is available
-* [#3788](https://github.com/apache/incubator-nuttx/pull/3788) ESP32-C3: Fix configuration of TX Burst support for GDMA
-* [#4040](https://github.com/apache/incubator-nuttx/pull/4040) risc-v/esp32c3: Fix some ESP32-C3 BLE driver issues
-* [#4082](https://github.com/apache/incubator-nuttx/pull/4082) boards/esp32c3-devkit: Support mounting SPI Flash MTD to littleFS
-* [#4075](https://github.com/apache/incubator-nuttx/pull/4075) risc-v/esp32c3: Add board_ioctl and board_uniqueid
-* [#4092](https://github.com/apache/incubator-nuttx/pull/4092) risc-v/esp32c3: Use onexit to free thread private semaphore
-* [#3971](https://github.com/apache/incubator-nuttx/pull/3971) boards/riscv/esp32c3: Rename the iram_0_2 segment to irom_0_0 to avoid confusions.
-* [#4141](https://github.com/apache/incubator-nuttx/pull/4141) risc-v/esp32-c3: Use systimer 0 to RTOS TICK
-* [#3793](https://github.com/apache/incubator-nuttx/pull/3793) esp32&esp32c3/wifi: Support specific channel and bssid scan
-* [#4162](https://github.com/apache/incubator-nuttx/pull/4162) risc-v/esp32c3: Fix some ESP32-C3 Wi-Fi driver issues
-* [#4169](https://github.com/apache/incubator-nuttx/pull/4169) risc-v/esp32-c3: Makes output readable and rmv unnecessary var.
-* [#4314](https://github.com/apache/incubator-nuttx/pull/4314) risc-v/esp32-c3: Complete the support for RWDT
+* [#3794](https://github.com/apache/nuttx/pull/3794) risc-v/esp32c3: Support ESP32-C3 RTC driver
+* [#3883](https://github.com/apache/nuttx/pull/3883) risc-v/esp32c3: Support ESP32-C3 RSA accelerator
+* [#3881](https://github.com/apache/nuttx/pull/3881) risc-v/esp32c3: Support ESP32-C3 efuse
+* [#3935](https://github.com/apache/nuttx/pull/3935) risc-v/esp32c3: Support ESP32-C3 SHA accelerator
+* [#3882](https://github.com/apache/nuttx/pull/3882) riscv/esp32c3: Use the RTC memory as another heap.
+* [#3945](https://github.com/apache/nuttx/pull/3945) boards/esp32c3: Add romfs configuration
+* [#3925](https://github.com/apache/nuttx/pull/3925) risc-v/esp32-c3: Adds I2C polled support
+* [#3823](https://github.com/apache/nuttx/pull/3823) risc-v/esp32-c3: Add support for HW flow control.
+* [#3822](https://github.com/apache/nuttx/pull/3822) ESP32-C3: Add DMA support for SPI Slave
+* [#3543](https://github.com/apache/nuttx/pull/3543) feat(esp32c3): Support esp32c3 ble function
+* [#3667](https://github.com/apache/nuttx/pull/3667) risc-v/esp32c3: Add ESP32-C3 (G)DMA driver and testing
+* [#4605](https://github.com/apache/nuttx/pull/4605) risc-v/esp32-c3: improvements and fix to esp32c3_rt_timer.c
+* [#4611](https://github.com/apache/nuttx/pull/4611) ESP32-C3: Add support for booting NuttX from MCUboot
+* [#3656](https://github.com/apache/nuttx/pull/3656) risc-v/esp32-c3: Adds freerun wrapper
+* [#4574](https://github.com/apache/nuttx/pull/4574) esp32c3-devkit: Add board profile to use LVGL on GC9A01 display
+* [#3810](https://github.com/apache/nuttx/pull/3810) risc-v/esp32c3: Fix overwriting of registered-but-disabled interrupts
+* [#3797](https://github.com/apache/nuttx/pull/3797) ESP32-C3: Add SPI Slave peripheral driver
+* [#4568](https://github.com/apache/nuttx/pull/4568) boards/esp32c3: add ESP32C3 LCD drivers
+* [#4553](https://github.com/apache/nuttx/pull/4553) risc-v/esp32c3: fix pwm driver bug
+* [#4500](https://github.com/apache/nuttx/pull/4500) risc-v/esp32-c3: refactor the Wi-Fi board logic.
+* [#3679](https://github.com/apache/nuttx/pull/3679) risc-v/esp32c3: Support ESP32-C3 PM standby and sleep
+* [#3766](https://github.com/apache/nuttx/pull/3766) riscv/esp32c3: Add ESP32-C3 AES driver
+* [#3750](https://github.com/apache/nuttx/pull/3750) riscv/esp32c3: Support SPI Flash encryption read/write
+* [#3735](https://github.com/apache/nuttx/pull/3735) riscv/esp32c3: Add ESP32-C3 ADC driver
+* [#3715](https://github.com/apache/nuttx/pull/3715) risc-v/esp32c3: Support ESP32-C3 auto-sleep
+* [#4239](https://github.com/apache/nuttx/pull/4239) risc-v/esp32-c3: Adds systimer support and make rt_timer rely on it
+* [#3694](https://github.com/apache/nuttx/pull/3694) risc-v/esp32c3: Add support for DMA transfers on SPI driver
+* [#3697](https://github.com/apache/nuttx/pull/3697) riscv/esp32c3: Fix RT timer issues
+* [#3906](https://github.com/apache/nuttx/pull/3906) risc-v/esp32c3_wifi_adapter.c: Remove a config that's only used in Xtensa chips.
+* [#3701](https://github.com/apache/nuttx/pull/3701) riscv/esp32c3: Add ESP32C3 LEDC(PWM) driver
+* [#3854](https://github.com/apache/nuttx/pull/3854) ESP32-C3: Small clean up on IRQ functions
+* [#4006](https://github.com/apache/nuttx/pull/4006) risc-v/esp32c3: Notifies networking layer whether the carrier is available
+* [#3788](https://github.com/apache/nuttx/pull/3788) ESP32-C3: Fix configuration of TX Burst support for GDMA
+* [#4040](https://github.com/apache/nuttx/pull/4040) risc-v/esp32c3: Fix some ESP32-C3 BLE driver issues
+* [#4082](https://github.com/apache/nuttx/pull/4082) boards/esp32c3-devkit: Support mounting SPI Flash MTD to littleFS
+* [#4075](https://github.com/apache/nuttx/pull/4075) risc-v/esp32c3: Add board_ioctl and board_uniqueid
+* [#4092](https://github.com/apache/nuttx/pull/4092) risc-v/esp32c3: Use onexit to free thread private semaphore
+* [#3971](https://github.com/apache/nuttx/pull/3971) boards/riscv/esp32c3: Rename the iram_0_2 segment to irom_0_0 to avoid confusions.
+* [#4141](https://github.com/apache/nuttx/pull/4141) risc-v/esp32-c3: Use systimer 0 to RTOS TICK
+* [#3793](https://github.com/apache/nuttx/pull/3793) esp32&esp32c3/wifi: Support specific channel and bssid scan
+* [#4162](https://github.com/apache/nuttx/pull/4162) risc-v/esp32c3: Fix some ESP32-C3 Wi-Fi driver issues
+* [#4169](https://github.com/apache/nuttx/pull/4169) risc-v/esp32-c3: Makes output readable and rmv unnecessary var.
+* [#4314](https://github.com/apache/nuttx/pull/4314) risc-v/esp32-c3: Complete the support for RWDT
 
 #### XTENSA
-* [#4590](https://github.com/apache/incubator-nuttx/pull/4590) [Xtensa/RISC-V] Remove FAR and CODE qualifiers from arch-specific files
-* [#4187](https://github.com/apache/incubator-nuttx/pull/4187) Fix xtensa_btdump() to look at the exception frame
-* [#4556](https://github.com/apache/incubator-nuttx/pull/4556) xtensa:backtrace: flush to stack when in interrupt
-* [#3939](https://github.com/apache/incubator-nuttx/pull/3939) Fix xtensa
-* [#4531](https://github.com/apache/incubator-nuttx/pull/4531) xtensa/irq.h: Fixes the routine that clears the processor interrupt
-* [#4278](https://github.com/apache/incubator-nuttx/pull/4278) xtensa/common: save sp before overwriting in level2/3/4 handler and typo fix
-* [#4311](https://github.com/apache/incubator-nuttx/pull/4311) xtensa:coproc: fix XTENSA_CP_ALLSET error in some case
-* [#3768](https://github.com/apache/incubator-nuttx/pull/3768) xtensa: Fixes names of architecture serial functions
+* [#4590](https://github.com/apache/nuttx/pull/4590) [Xtensa/RISC-V] Remove FAR and CODE qualifiers from arch-specific files
+* [#4187](https://github.com/apache/nuttx/pull/4187) Fix xtensa_btdump() to look at the exception frame
+* [#4556](https://github.com/apache/nuttx/pull/4556) xtensa:backtrace: flush to stack when in interrupt
+* [#3939](https://github.com/apache/nuttx/pull/3939) Fix xtensa
+* [#4531](https://github.com/apache/nuttx/pull/4531) xtensa/irq.h: Fixes the routine that clears the processor interrupt
+* [#4278](https://github.com/apache/nuttx/pull/4278) xtensa/common: save sp before overwriting in level2/3/4 handler and typo fix
+* [#4311](https://github.com/apache/nuttx/pull/4311) xtensa:coproc: fix XTENSA_CP_ALLSET error in some case
+* [#3768](https://github.com/apache/nuttx/pull/3768) xtensa: Fixes names of architecture serial functions
 
 #### ESP32
-* [#3940](https://github.com/apache/incubator-nuttx/pull/3940) xtensa/esp32: Support ESP32 RTC driver
-* [#4003](https://github.com/apache/incubator-nuttx/pull/4003) xtensa/esp32: Adds support for SERIAL_TXDMA.
-* [#3912](https://github.com/apache/incubator-nuttx/pull/3912) xtensa/esp32: Adds I2C polled support.
-* [#3803](https://github.com/apache/incubator-nuttx/pull/3803) Add support to ESP32-S2 and ESP32S2-SAOLA-1 Board
-* [#3824](https://github.com/apache/incubator-nuttx/pull/3824) xtensa/esp32-s2: Add support for serial HW flow control.
-* [#4604](https://github.com/apache/incubator-nuttx/pull/4604) xtensa/esp32: Enable build system to download or build binaries from source
-* [#3642](https://github.com/apache/incubator-nuttx/pull/3642) xtensa/esp32: several uart fixes
-* [#3648](https://github.com/apache/incubator-nuttx/pull/3648) tools/esp32/mk_qemu_img.sh: Refactor the dd commands.
-* [#4625](https://github.com/apache/incubator-nuttx/pull/4625) esp32-c3/esp32-s2: Fix the sequence of commands to set the alarm value on rt timer.
-* [#4610](https://github.com/apache/incubator-nuttx/pull/4610) ESP32-S2: Add support for booting NuttX from MCUboot
-* [#3678](https://github.com/apache/incubator-nuttx/pull/3678) xtensa/esp32: Support auto-sleep
-* [#4532](https://github.com/apache/incubator-nuttx/pull/4532) boards/esp32s2-saola-1: Add implementation for BOARDIOC_RESET interface
-* [#4275](https://github.com/apache/incubator-nuttx/pull/4275) xtensa/esp32: Keep track of the CPU where the interrupt was attached.
-* [#4295](https://github.com/apache/incubator-nuttx/pull/4295) xtensa/esp32: Enable boot from Espressif's port of MCUboot
-* [#4315](https://github.com/apache/incubator-nuttx/pull/4315) xtensa/esp32: Fix issues on RWDT
-* [#4366](https://github.com/apache/incubator-nuttx/pull/4366) xtensa/esp32: Use IRQ to enable/disable interrupts
-* [#4427](https://github.com/apache/incubator-nuttx/pull/4427) esp32/ttgo_lora_esp32: Add support to SSD1306 OLED display
-* [#4388](https://github.com/apache/incubator-nuttx/pull/4388) esp32: Re-organize the interrupt handling process to correctly handle the SMP case
-* [#4401](https://github.com/apache/incubator-nuttx/pull/4401) xtensa/esp32-s2: Adds support to the timer driver
-* [#4545](https://github.com/apache/incubator-nuttx/pull/4545) esp32-wrover: Add support to LCD1602 with I2C Backpack
-* [#4587](https://github.com/apache/incubator-nuttx/pull/4587) xtensa/esp32-s2: Adds freerun timer wrapper
-* [#4139](https://github.com/apache/incubator-nuttx/pull/4139) xtensa/esp32: Fixes termios issue.
-* [#4586](https://github.com/apache/incubator-nuttx/pull/4586) xtensa/esp32-s2: Adds oneshot device driver support
-* [#4570](https://github.com/apache/incubator-nuttx/pull/4570) esp32_spiflash.c: Correctly disable APP's CPU cache.
-* [#4509](https://github.com/apache/incubator-nuttx/pull/4509) esp32: Add initial support to Bluetooth Low Energy
-* [#4411](https://github.com/apache/incubator-nuttx/pull/4411) esp32/softap: Enable the WPA2 by default to ask user password
-* [#4412](https://github.com/apache/incubator-nuttx/pull/4412) boards/esp32: Add basic support to TTGO-LoRa-SX1276-ESP32
-* [#4585](https://github.com/apache/incubator-nuttx/pull/4585) xtensa/esp32-s2: Adds support to rt_timer and systimer to ESP32-S2.
-* [#4170](https://github.com/apache/incubator-nuttx/pull/4170) xtensa/esp32: Make output readable and rmv unnecessary var.
-* [#4195](https://github.com/apache/incubator-nuttx/pull/4195) esp32_allocateheap.c: Remove the amount reserved to himem from the heap.
-* [#4232](https://github.com/apache/incubator-nuttx/pull/4232) xtensa/esp32: Enable configuration of GPIO pad's drive strength
-* [#4240](https://github.com/apache/incubator-nuttx/pull/4240) xtensa/esp32: expose SPI2 as a char driver
-* [#4253](https://github.com/apache/incubator-nuttx/pull/4253) xtensa/esp32: Enable the allocation of multiple SPI Flash partitions
-* [#4338](https://github.com/apache/incubator-nuttx/pull/4338) tools/esp32/Config.mk: Allow ESPTOOL_BINDIR to be omitted when flashing the board
-* [#3938](https://github.com/apache/incubator-nuttx/pull/3938) esp32&esp32c3/wifi: Fix the issues of Wi-Fi configuration being overwritten
-* [#3969](https://github.com/apache/incubator-nuttx/pull/3969) boards/esp32: Refactor the different linker scripts and delete old OpenOCD config files.
-* [#3975](https://github.com/apache/incubator-nuttx/pull/3975) xtensa/esp32: Fix RTC WDT deinitialization on start routine
-* [#3987](https://github.com/apache/incubator-nuttx/pull/3987) tools/esp32/backtrace.gdbscript: don't modify registers
-* [#4001](https://github.com/apache/incubator-nuttx/pull/4001) xtensa/esp32: Support to select different clock source for RTC controller and close TODOs.
-* [#4073](https://github.com/apache/incubator-nuttx/pull/4073) xtensa/esp32: Fix uart 2 issue.
-* [#3800](https://github.com/apache/incubator-nuttx/pull/3800) arch/xtensa/esp32_emac.c: Call phy_enable_interrupt correctly.
-* [#4157](https://github.com/apache/incubator-nuttx/pull/4157) boards/esp32: Refactor the linker scripts into the common directory.
-* [#4249](https://github.com/apache/incubator-nuttx/pull/4249) xtensa/esp32-s2: Adds GPIO board logic to esp32s2-saola-1.
-* [#4471](https://github.com/apache/incubator-nuttx/pull/4471) xtensa/esp32: Wi-Fi board logic refactoring.
-* [#4497](https://github.com/apache/incubator-nuttx/pull/4497) esp32_serial.c: Don't fake an interrupt when interrupts are not suppressed.
-* [#3829](https://github.com/apache/incubator-nuttx/pull/3829) xtensa/esp32: Fixes support for UART HW flow control
-* [#3943](https://github.com/apache/incubator-nuttx/pull/3943) xtensa/esp32: Adds I2C Bit banging reset
-* [#3960](https://github.com/apache/incubator-nuttx/pull/3960) xtensa/esp32: Refactor the text heap and add RTC memory to it
-* [#4646](https://github.com/apache/incubator-nuttx/pull/4646) Add example to use BLE and WiFi at same time
+* [#3940](https://github.com/apache/nuttx/pull/3940) xtensa/esp32: Support ESP32 RTC driver
+* [#4003](https://github.com/apache/nuttx/pull/4003) xtensa/esp32: Adds support for SERIAL_TXDMA.
+* [#3912](https://github.com/apache/nuttx/pull/3912) xtensa/esp32: Adds I2C polled support.
+* [#3803](https://github.com/apache/nuttx/pull/3803) Add support to ESP32-S2 and ESP32S2-SAOLA-1 Board
+* [#3824](https://github.com/apache/nuttx/pull/3824) xtensa/esp32-s2: Add support for serial HW flow control.
+* [#4604](https://github.com/apache/nuttx/pull/4604) xtensa/esp32: Enable build system to download or build binaries from source
+* [#3642](https://github.com/apache/nuttx/pull/3642) xtensa/esp32: several uart fixes
+* [#3648](https://github.com/apache/nuttx/pull/3648) tools/esp32/mk_qemu_img.sh: Refactor the dd commands.
+* [#4625](https://github.com/apache/nuttx/pull/4625) esp32-c3/esp32-s2: Fix the sequence of commands to set the alarm value on rt timer.
+* [#4610](https://github.com/apache/nuttx/pull/4610) ESP32-S2: Add support for booting NuttX from MCUboot
+* [#3678](https://github.com/apache/nuttx/pull/3678) xtensa/esp32: Support auto-sleep
+* [#4532](https://github.com/apache/nuttx/pull/4532) boards/esp32s2-saola-1: Add implementation for BOARDIOC_RESET interface
+* [#4275](https://github.com/apache/nuttx/pull/4275) xtensa/esp32: Keep track of the CPU where the interrupt was attached.
+* [#4295](https://github.com/apache/nuttx/pull/4295) xtensa/esp32: Enable boot from Espressif's port of MCUboot
+* [#4315](https://github.com/apache/nuttx/pull/4315) xtensa/esp32: Fix issues on RWDT
+* [#4366](https://github.com/apache/nuttx/pull/4366) xtensa/esp32: Use IRQ to enable/disable interrupts
+* [#4427](https://github.com/apache/nuttx/pull/4427) esp32/ttgo_lora_esp32: Add support to SSD1306 OLED display
+* [#4388](https://github.com/apache/nuttx/pull/4388) esp32: Re-organize the interrupt handling process to correctly handle the SMP case
+* [#4401](https://github.com/apache/nuttx/pull/4401) xtensa/esp32-s2: Adds support to the timer driver
+* [#4545](https://github.com/apache/nuttx/pull/4545) esp32-wrover: Add support to LCD1602 with I2C Backpack
+* [#4587](https://github.com/apache/nuttx/pull/4587) xtensa/esp32-s2: Adds freerun timer wrapper
+* [#4139](https://github.com/apache/nuttx/pull/4139) xtensa/esp32: Fixes termios issue.
+* [#4586](https://github.com/apache/nuttx/pull/4586) xtensa/esp32-s2: Adds oneshot device driver support
+* [#4570](https://github.com/apache/nuttx/pull/4570) esp32_spiflash.c: Correctly disable APP's CPU cache.
+* [#4509](https://github.com/apache/nuttx/pull/4509) esp32: Add initial support to Bluetooth Low Energy
+* [#4411](https://github.com/apache/nuttx/pull/4411) esp32/softap: Enable the WPA2 by default to ask user password
+* [#4412](https://github.com/apache/nuttx/pull/4412) boards/esp32: Add basic support to TTGO-LoRa-SX1276-ESP32
+* [#4585](https://github.com/apache/nuttx/pull/4585) xtensa/esp32-s2: Adds support to rt_timer and systimer to ESP32-S2.
+* [#4170](https://github.com/apache/nuttx/pull/4170) xtensa/esp32: Make output readable and rmv unnecessary var.
+* [#4195](https://github.com/apache/nuttx/pull/4195) esp32_allocateheap.c: Remove the amount reserved to himem from the heap.
+* [#4232](https://github.com/apache/nuttx/pull/4232) xtensa/esp32: Enable configuration of GPIO pad's drive strength
+* [#4240](https://github.com/apache/nuttx/pull/4240) xtensa/esp32: expose SPI2 as a char driver
+* [#4253](https://github.com/apache/nuttx/pull/4253) xtensa/esp32: Enable the allocation of multiple SPI Flash partitions
+* [#4338](https://github.com/apache/nuttx/pull/4338) tools/esp32/Config.mk: Allow ESPTOOL_BINDIR to be omitted when flashing the board
+* [#3938](https://github.com/apache/nuttx/pull/3938) esp32&esp32c3/wifi: Fix the issues of Wi-Fi configuration being overwritten
+* [#3969](https://github.com/apache/nuttx/pull/3969) boards/esp32: Refactor the different linker scripts and delete old OpenOCD config files.
+* [#3975](https://github.com/apache/nuttx/pull/3975) xtensa/esp32: Fix RTC WDT deinitialization on start routine
+* [#3987](https://github.com/apache/nuttx/pull/3987) tools/esp32/backtrace.gdbscript: don't modify registers
+* [#4001](https://github.com/apache/nuttx/pull/4001) xtensa/esp32: Support to select different clock source for RTC controller and close TODOs.
+* [#4073](https://github.com/apache/nuttx/pull/4073) xtensa/esp32: Fix uart 2 issue.
+* [#3800](https://github.com/apache/nuttx/pull/3800) arch/xtensa/esp32_emac.c: Call phy_enable_interrupt correctly.
+* [#4157](https://github.com/apache/nuttx/pull/4157) boards/esp32: Refactor the linker scripts into the common directory.
+* [#4249](https://github.com/apache/nuttx/pull/4249) xtensa/esp32-s2: Adds GPIO board logic to esp32s2-saola-1.
+* [#4471](https://github.com/apache/nuttx/pull/4471) xtensa/esp32: Wi-Fi board logic refactoring.
+* [#4497](https://github.com/apache/nuttx/pull/4497) esp32_serial.c: Don't fake an interrupt when interrupts are not suppressed.
+* [#3829](https://github.com/apache/nuttx/pull/3829) xtensa/esp32: Fixes support for UART HW flow control
+* [#3943](https://github.com/apache/nuttx/pull/3943) xtensa/esp32: Adds I2C Bit banging reset
+* [#3960](https://github.com/apache/nuttx/pull/3960) xtensa/esp32: Refactor the text heap and add RTC memory to it
+* [#4646](https://github.com/apache/nuttx/pull/4646) Add example to use BLE and WiFi at same time
 
 ## File System
 
 ### Bug Fixes
-* [#3653](https://github.com/apache/incubator-nuttx/pull/3653) fs:cromf Use inttypes in printing macros
-* [#4573](https://github.com/apache/incubator-nuttx/pull/4573) fs:procfs: add waiting_paging_fill state names
-* [#3745](https://github.com/apache/incubator-nuttx/pull/3745) fs/vfs/fs_select.c: Fix select() to return EINVAL when nfds is negative
-* [#3740](https://github.com/apache/incubator-nuttx/pull/3740) fs/fat/fat32util.c: Fix calculation of current sector with invalid cl…
-* [#3724](https://github.com/apache/incubator-nuttx/pull/3724) fs/hostfs: fix bug about getting error file size by fstat
-* [#3785](https://github.com/apache/incubator-nuttx/pull/3785) FAT32 fix skipping sectors at computing the number of free clusters
-* [#4171](https://github.com/apache/incubator-nuttx/pull/4171) fs/tmpfs: Handle the tail '/' correctly
-* [#4539](https://github.com/apache/incubator-nuttx/pull/4539) vfs/poll: correct the return event if inode has closed
-* [#3760](https://github.com/apache/incubator-nuttx/pull/3760) Fix calculation of free clusters at mounting a fat partition
-* [#4012](https://github.com/apache/incubator-nuttx/pull/4012) fs: move out nx_close from filelock
-* [#3974](https://github.com/apache/incubator-nuttx/pull/3974) fs/tmpfs: Fix the memory corruption when reallocate tmpfs_directory_s
-* [#3986](https://github.com/apache/incubator-nuttx/pull/3986) fs: nfs: Reconnect to the NFS server in TCP mode
-* [#4031](https://github.com/apache/incubator-nuttx/pull/4031) fs/fs_dup2: (sanity check )correct check before calling dup
-* [#4033](https://github.com/apache/incubator-nuttx/pull/4033) fs/procfs: add StackAlloc field for task stack info
-* [#4061](https://github.com/apache/incubator-nuttx/pull/4061) FAT32 kconfig entry to enforce computation of free clusters at mount
-* [#4079](https://github.com/apache/incubator-nuttx/pull/4079) fs/procfs: layout the output of meminfo correctly
-* [#4093](https://github.com/apache/incubator-nuttx/pull/4093) fs: Move the default ioctl handle from nx_vioctl to file_vioctl
-* [#4097](https://github.com/apache/incubator-nuttx/pull/4097) fs: Remove the inernal st_count field from struct stat
-* [#4101](https://github.com/apache/incubator-nuttx/pull/4101) fs: pseudorename should call inode_release in the error path
-* [#4118](https://github.com/apache/incubator-nuttx/pull/4118) fs: Support the root file system attributes(mode, uid, gid and time)
-* [#4119](https://github.com/apache/incubator-nuttx/pull/4119) fs: fstat shouldn't follow the symbol link
-* [#4121](https://github.com/apache/incubator-nuttx/pull/4121) vfs: stat_recursive should return -ENOSYS if stat callback is NULL
-* [#4123](https://github.com/apache/incubator-nuttx/pull/4123) nuttx: littlefs_close should return value bugfix
-* [#4153](https://github.com/apache/incubator-nuttx/pull/4153) fs: Add fchstat and chstat callback into mountpt_operations
-* [#4165](https://github.com/apache/incubator-nuttx/pull/4165) fs: should only apply umask to the userspace caller
-* [#4174](https://github.com/apache/incubator-nuttx/pull/4174) Fix nfs and statfs
-* [#4193](https://github.com/apache/incubator-nuttx/pull/4193) fs: Change off_t and related types to int64_t if long long is supported
-* [#4224](https://github.com/apache/incubator-nuttx/pull/4224) fs/inode: add sanity check for inode to avoid nullpointer
-* [#4263](https://github.com/apache/incubator-nuttx/pull/4263) fs: Save umask to tls_task_s for non kernel mode only
-* [#4300](https://github.com/apache/incubator-nuttx/pull/4300) fs: Add utimens and lutimens
-* [#4307](https://github.com/apache/incubator-nuttx/pull/4307) fs/userfs: Support fchstat and chstat callback
-* [#4308](https://github.com/apache/incubator-nuttx/pull/4308) fs/unionfs: Support fchstat and chstat callback
-* [#4309](https://github.com/apache/incubator-nuttx/pull/4309) fs/nfs: Support fchstat and chstat callback
-* [#4330](https://github.com/apache/incubator-nuttx/pull/4330) fs/littlefs: improve littlefs flash block erase balance performance
-* [#4332](https://github.com/apache/incubator-nuttx/pull/4332) fs: Support 64bit in register_[block|mtd]partition
-* [#4333](https://github.com/apache/incubator-nuttx/pull/4333) fs/partition: Support BIOC_PARTINFO
-* [#4321](https://github.com/apache/incubator-nuttx/pull/4321) fs: Remove endsector from partition_info_s
-* [#3680](https://github.com/apache/incubator-nuttx/pull/3680) fs/eventfd: add EVENT_FD_POLL as a Kconfig dependency for EVENT_FD_NPOLLWAITERS
-* [#4514](https://github.com/apache/incubator-nuttx/pull/4514) fs/ioctl: using FIOC_FILEPATH instead of FIOC_FILENAME
-* [#4511](https://github.com/apache/incubator-nuttx/pull/4511) inode_getpath: correct get path whether path buffer is clean or not.
-* [#4276](https://github.com/apache/incubator-nuttx/pull/4276) Fix status register reading in ramtron_read()
-* [#4290](https://github.com/apache/incubator-nuttx/pull/4290) cmd/df: Fix the abnormal output after off_t change
-* [#4133](https://github.com/apache/incubator-nuttx/pull/4133) profs: Print StackAlloc by procfs_snprintf
+* [#3653](https://github.com/apache/nuttx/pull/3653) fs:cromf Use inttypes in printing macros
+* [#4573](https://github.com/apache/nuttx/pull/4573) fs:procfs: add waiting_paging_fill state names
+* [#3745](https://github.com/apache/nuttx/pull/3745) fs/vfs/fs_select.c: Fix select() to return EINVAL when nfds is negative
+* [#3740](https://github.com/apache/nuttx/pull/3740) fs/fat/fat32util.c: Fix calculation of current sector with invalid cl…
+* [#3724](https://github.com/apache/nuttx/pull/3724) fs/hostfs: fix bug about getting error file size by fstat
+* [#3785](https://github.com/apache/nuttx/pull/3785) FAT32 fix skipping sectors at computing the number of free clusters
+* [#4171](https://github.com/apache/nuttx/pull/4171) fs/tmpfs: Handle the tail '/' correctly
+* [#4539](https://github.com/apache/nuttx/pull/4539) vfs/poll: correct the return event if inode has closed
+* [#3760](https://github.com/apache/nuttx/pull/3760) Fix calculation of free clusters at mounting a fat partition
+* [#4012](https://github.com/apache/nuttx/pull/4012) fs: move out nx_close from filelock
+* [#3974](https://github.com/apache/nuttx/pull/3974) fs/tmpfs: Fix the memory corruption when reallocate tmpfs_directory_s
+* [#3986](https://github.com/apache/nuttx/pull/3986) fs: nfs: Reconnect to the NFS server in TCP mode
+* [#4031](https://github.com/apache/nuttx/pull/4031) fs/fs_dup2: (sanity check )correct check before calling dup
+* [#4033](https://github.com/apache/nuttx/pull/4033) fs/procfs: add StackAlloc field for task stack info
+* [#4061](https://github.com/apache/nuttx/pull/4061) FAT32 kconfig entry to enforce computation of free clusters at mount
+* [#4079](https://github.com/apache/nuttx/pull/4079) fs/procfs: layout the output of meminfo correctly
+* [#4093](https://github.com/apache/nuttx/pull/4093) fs: Move the default ioctl handle from nx_vioctl to file_vioctl
+* [#4097](https://github.com/apache/nuttx/pull/4097) fs: Remove the inernal st_count field from struct stat
+* [#4101](https://github.com/apache/nuttx/pull/4101) fs: pseudorename should call inode_release in the error path
+* [#4118](https://github.com/apache/nuttx/pull/4118) fs: Support the root file system attributes(mode, uid, gid and time)
+* [#4119](https://github.com/apache/nuttx/pull/4119) fs: fstat shouldn't follow the symbol link
+* [#4121](https://github.com/apache/nuttx/pull/4121) vfs: stat_recursive should return -ENOSYS if stat callback is NULL
+* [#4123](https://github.com/apache/nuttx/pull/4123) nuttx: littlefs_close should return value bugfix
+* [#4153](https://github.com/apache/nuttx/pull/4153) fs: Add fchstat and chstat callback into mountpt_operations
+* [#4165](https://github.com/apache/nuttx/pull/4165) fs: should only apply umask to the userspace caller
+* [#4174](https://github.com/apache/nuttx/pull/4174) Fix nfs and statfs
+* [#4193](https://github.com/apache/nuttx/pull/4193) fs: Change off_t and related types to int64_t if long long is supported
+* [#4224](https://github.com/apache/nuttx/pull/4224) fs/inode: add sanity check for inode to avoid nullpointer
+* [#4263](https://github.com/apache/nuttx/pull/4263) fs: Save umask to tls_task_s for non kernel mode only
+* [#4300](https://github.com/apache/nuttx/pull/4300) fs: Add utimens and lutimens
+* [#4307](https://github.com/apache/nuttx/pull/4307) fs/userfs: Support fchstat and chstat callback
+* [#4308](https://github.com/apache/nuttx/pull/4308) fs/unionfs: Support fchstat and chstat callback
+* [#4309](https://github.com/apache/nuttx/pull/4309) fs/nfs: Support fchstat and chstat callback
+* [#4330](https://github.com/apache/nuttx/pull/4330) fs/littlefs: improve littlefs flash block erase balance performance
+* [#4332](https://github.com/apache/nuttx/pull/4332) fs: Support 64bit in register_[block|mtd]partition
+* [#4333](https://github.com/apache/nuttx/pull/4333) fs/partition: Support BIOC_PARTINFO
+* [#4321](https://github.com/apache/nuttx/pull/4321) fs: Remove endsector from partition_info_s
+* [#3680](https://github.com/apache/nuttx/pull/3680) fs/eventfd: add EVENT_FD_POLL as a Kconfig dependency for EVENT_FD_NPOLLWAITERS
+* [#4514](https://github.com/apache/nuttx/pull/4514) fs/ioctl: using FIOC_FILEPATH instead of FIOC_FILENAME
+* [#4511](https://github.com/apache/nuttx/pull/4511) inode_getpath: correct get path whether path buffer is clean or not.
+* [#4276](https://github.com/apache/nuttx/pull/4276) Fix status register reading in ramtron_read()
+* [#4290](https://github.com/apache/nuttx/pull/4290) cmd/df: Fix the abnormal output after off_t change
+* [#4133](https://github.com/apache/nuttx/pull/4133) profs: Print StackAlloc by procfs_snprintf
 
 ### Significant Improvements
 
 ## Networking
 
 ### Improvements
-* [#4538](https://github.com/apache/incubator-nuttx/pull/4538) sys/socket/scm: add more socket message control helper
-* [#4080](https://github.com/apache/incubator-nuttx/pull/4080) net/socket: add SO_SNDBUF support
-* [#4116](https://github.com/apache/incubator-nuttx/pull/4116) net: Add file_socket function
-* [#4135](https://github.com/apache/incubator-nuttx/pull/4135) net/rpmsg: add multi-iov support
-* [#4179](https://github.com/apache/incubator-nuttx/pull/4179) Update socket rpmsg
-* [#4355](https://github.com/apache/incubator-nuttx/pull/4355) net/rpmsg: add nonblock connect(2) support
-* [#4356](https://github.com/apache/incubator-nuttx/pull/4356) net/local: add nonblock connect(2) support
-* [#4357](https://github.com/apache/incubator-nuttx/pull/4357) net/tcp: add nonblock connect(2) support
-* [#4070](https://github.com/apache/incubator-nuttx/pull/4070) net/tcp: add window scale support
-* [#3926](https://github.com/apache/incubator-nuttx/pull/3926) net/inet: add support of FIONREAD
-* [#3896](https://github.com/apache/incubator-nuttx/pull/3896) net/local: add local_nextconn() helper
-* [#3961](https://github.com/apache/incubator-nuttx/pull/3961) net: Add if_nameindex and if_freenameindex API
-* [#4069](https://github.com/apache/incubator-nuttx/pull/4069) net/socket: add SO_RCVBUF support
-* [#4071](https://github.com/apache/incubator-nuttx/pull/4071) net/local: add AF_[UNIX|LOCAL] socketpair support
-* [#4540](https://github.com/apache/incubator-nuttx/pull/4540) net/local: add FIONSPACE support
-* [#4593](https://github.com/apache/incubator-nuttx/pull/4593) net/local: add socket message control support
+* [#4538](https://github.com/apache/nuttx/pull/4538) sys/socket/scm: add more socket message control helper
+* [#4080](https://github.com/apache/nuttx/pull/4080) net/socket: add SO_SNDBUF support
+* [#4116](https://github.com/apache/nuttx/pull/4116) net: Add file_socket function
+* [#4135](https://github.com/apache/nuttx/pull/4135) net/rpmsg: add multi-iov support
+* [#4179](https://github.com/apache/nuttx/pull/4179) Update socket rpmsg
+* [#4355](https://github.com/apache/nuttx/pull/4355) net/rpmsg: add nonblock connect(2) support
+* [#4356](https://github.com/apache/nuttx/pull/4356) net/local: add nonblock connect(2) support
+* [#4357](https://github.com/apache/nuttx/pull/4357) net/tcp: add nonblock connect(2) support
+* [#4070](https://github.com/apache/nuttx/pull/4070) net/tcp: add window scale support
+* [#3926](https://github.com/apache/nuttx/pull/3926) net/inet: add support of FIONREAD
+* [#3896](https://github.com/apache/nuttx/pull/3896) net/local: add local_nextconn() helper
+* [#3961](https://github.com/apache/nuttx/pull/3961) net: Add if_nameindex and if_freenameindex API
+* [#4069](https://github.com/apache/nuttx/pull/4069) net/socket: add SO_RCVBUF support
+* [#4071](https://github.com/apache/nuttx/pull/4071) net/local: add AF_[UNIX|LOCAL] socketpair support
+* [#4540](https://github.com/apache/nuttx/pull/4540) net/local: add FIONSPACE support
+* [#4593](https://github.com/apache/nuttx/pull/4593) net/local: add socket message control support
 
 ### Bug Fixes
-* [#4602](https://github.com/apache/incubator-nuttx/pull/4602) net/dup: only start tcp monitor on INET domain
-* [#4649](https://github.com/apache/incubator-nuttx/pull/4649) net: always compile listen.c and accept.c when enable CONFIG_NET
-* [#4603](https://github.com/apache/incubator-nuttx/pull/4603) [SECURITY]net/tcp: sanity check for the listen address
-* [#4579](https://github.com/apache/incubator-nuttx/pull/4579) net/devif/devif_callback.c: made the connection event list doubly linked
-* [#4433](https://github.com/apache/incubator-nuttx/pull/4433) net/devif/devif_callback.c: corrected the connection event list to work as FIFO instead of LIFO
-* [#3776](https://github.com/apache/incubator-nuttx/pull/3776) net/dev: link the net device as order of registration
-* [#3758](https://github.com/apache/incubator-nuttx/pull/3758) net/tcp/retransmit: recounter the ack counter during obtain newdata
-* [#3723](https://github.com/apache/incubator-nuttx/pull/3723) net: Forward socket option only when the socket type is usrsock
-* [#4480](https://github.com/apache/incubator-nuttx/pull/4480) net: utils: Remove critical section for SMP in net_lock.c
-* [#3707](https://github.com/apache/incubator-nuttx/pull/3707) Fix NFS over TCP
-* [#3818](https://github.com/apache/incubator-nuttx/pull/3818) tcp: recv window update improvement
-* [#3655](https://github.com/apache/incubator-nuttx/pull/3655) Attempt to fix race condition reported in issue #3647
-* [#3865](https://github.com/apache/incubator-nuttx/pull/3865) Fix tcp seq wrap around issues
-* [#3889](https://github.com/apache/incubator-nuttx/pull/3889) net/dns:fix unaligned access in dns query
-* [#3894](https://github.com/apache/incubator-nuttx/pull/3894) net/telnet: fix a potential busyloop if rxbuffer writes faster than read
-* [#3934](https://github.com/apache/incubator-nuttx/pull/3934) net/local: Remove all HAVE_LOCAL_POLL reference
-* [#3755](https://github.com/apache/incubator-nuttx/pull/3755) net/icmp: icmp bug fix and enhancement
-* [#3993](https://github.com/apache/incubator-nuttx/pull/3993) tcp_reset: Don't copy the peer window
-* [#3994](https://github.com/apache/incubator-nuttx/pull/3994) tcp: always responds to keep-alive segments
-* [#3995](https://github.com/apache/incubator-nuttx/pull/3995) fix active close for CONFIG_NET_TCP_WRITE_BUFFERS
-* [#3999](https://github.com/apache/incubator-nuttx/pull/3999) some follow-up patches for the recent tcp readahead
-* [#4017](https://github.com/apache/incubator-nuttx/pull/4017) rpmsg_socket: fix rpmsg_socket_device_destroy() multi-access
-* [#4022](https://github.com/apache/incubator-nuttx/pull/4022) tcp_close: Fix a race with passive close
-* [#3966](https://github.com/apache/incubator-nuttx/pull/3966) net: Fix: left shift of 1 by 31 places cannot be represented in type long int
-* [#3948](https://github.com/apache/incubator-nuttx/pull/3948) TCP: simplify readahead
-* [#3114](https://github.com/apache/incubator-nuttx/pull/3114) usrsock/recv: guarantee all data is received before close
-* [#3756](https://github.com/apache/incubator-nuttx/pull/3756) net/tcp: set/get TCP_KEEPINTVL/IDLE value as BSD style
-* [#3895](https://github.com/apache/incubator-nuttx/pull/3895) net/accept: alloc the accept fd after accept success
-* [#3937](https://github.com/apache/incubator-nuttx/pull/3937) dns_recv_response: Fix IPv6 address in an ninfo()
-* [#4408](https://github.com/apache/incubator-nuttx/pull/4408) Fix up that local socket will be endless loop when write data size more than the fifo size.
-* [#4517](https://github.com/apache/incubator-nuttx/pull/4517) rpmsg_socket: add prefix "rpmsg-socket" for the name of rpmsg endpoint
-* [#4537](https://github.com/apache/incubator-nuttx/pull/4537) net/udp: fix buffer release handling on failed buffer alloc
-* [#4120](https://github.com/apache/incubator-nuttx/pull/4120) net/tcp: tcp_sendfile need restore the file location at the end
-* [#4134](https://github.com/apache/incubator-nuttx/pull/4134) net/tcp: only print the error when disable the TCP_NODELAY
-* [#4142](https://github.com/apache/incubator-nuttx/pull/4142) tcp_send_buffered: throttle IOB allocations for send
-* [#4159](https://github.com/apache/incubator-nuttx/pull/4159) tcp_send_buffered.c: Fix broken retransmit
-* [#4126](https://github.com/apache/incubator-nuttx/pull/4126) include/netinet: Add missing IP_TTL definition
-* [#4197](https://github.com/apache/incubator-nuttx/pull/4197) local/stream: remove preamble header in stream mode
-* [#4273](https://github.com/apache/incubator-nuttx/pull/4273) tcp: some fixes in snd_wnd processing
-* [#4293](https://github.com/apache/incubator-nuttx/pull/4293) tcp: make our sequence number a bit more monotonic
-* [#4257](https://github.com/apache/incubator-nuttx/pull/4257) Fix a few deadlock in tcp/iob
-* [#4480](https://github.com/apache/incubator-nuttx/pull/4480) net: utils: Remove critical section for SMP in net_lock.c
-* [#3919](https://github.com/apache/incubator-nuttx/pull/3919) tcp iob throttling related fixes
+* [#4602](https://github.com/apache/nuttx/pull/4602) net/dup: only start tcp monitor on INET domain
+* [#4649](https://github.com/apache/nuttx/pull/4649) net: always compile listen.c and accept.c when enable CONFIG_NET
+* [#4603](https://github.com/apache/nuttx/pull/4603) [SECURITY]net/tcp: sanity check for the listen address
+* [#4579](https://github.com/apache/nuttx/pull/4579) net/devif/devif_callback.c: made the connection event list doubly linked
+* [#4433](https://github.com/apache/nuttx/pull/4433) net/devif/devif_callback.c: corrected the connection event list to work as FIFO instead of LIFO
+* [#3776](https://github.com/apache/nuttx/pull/3776) net/dev: link the net device as order of registration
+* [#3758](https://github.com/apache/nuttx/pull/3758) net/tcp/retransmit: recounter the ack counter during obtain newdata
+* [#3723](https://github.com/apache/nuttx/pull/3723) net: Forward socket option only when the socket type is usrsock
+* [#4480](https://github.com/apache/nuttx/pull/4480) net: utils: Remove critical section for SMP in net_lock.c
+* [#3707](https://github.com/apache/nuttx/pull/3707) Fix NFS over TCP
+* [#3818](https://github.com/apache/nuttx/pull/3818) tcp: recv window update improvement
+* [#3655](https://github.com/apache/nuttx/pull/3655) Attempt to fix race condition reported in issue #3647
+* [#3865](https://github.com/apache/nuttx/pull/3865) Fix tcp seq wrap around issues
+* [#3889](https://github.com/apache/nuttx/pull/3889) net/dns:fix unaligned access in dns query
+* [#3894](https://github.com/apache/nuttx/pull/3894) net/telnet: fix a potential busyloop if rxbuffer writes faster than read
+* [#3934](https://github.com/apache/nuttx/pull/3934) net/local: Remove all HAVE_LOCAL_POLL reference
+* [#3755](https://github.com/apache/nuttx/pull/3755) net/icmp: icmp bug fix and enhancement
+* [#3993](https://github.com/apache/nuttx/pull/3993) tcp_reset: Don't copy the peer window
+* [#3994](https://github.com/apache/nuttx/pull/3994) tcp: always responds to keep-alive segments
+* [#3995](https://github.com/apache/nuttx/pull/3995) fix active close for CONFIG_NET_TCP_WRITE_BUFFERS
+* [#3999](https://github.com/apache/nuttx/pull/3999) some follow-up patches for the recent tcp readahead
+* [#4017](https://github.com/apache/nuttx/pull/4017) rpmsg_socket: fix rpmsg_socket_device_destroy() multi-access
+* [#4022](https://github.com/apache/nuttx/pull/4022) tcp_close: Fix a race with passive close
+* [#3966](https://github.com/apache/nuttx/pull/3966) net: Fix: left shift of 1 by 31 places cannot be represented in type long int
+* [#3948](https://github.com/apache/nuttx/pull/3948) TCP: simplify readahead
+* [#3114](https://github.com/apache/nuttx/pull/3114) usrsock/recv: guarantee all data is received before close
+* [#3756](https://github.com/apache/nuttx/pull/3756) net/tcp: set/get TCP_KEEPINTVL/IDLE value as BSD style
+* [#3895](https://github.com/apache/nuttx/pull/3895) net/accept: alloc the accept fd after accept success
+* [#3937](https://github.com/apache/nuttx/pull/3937) dns_recv_response: Fix IPv6 address in an ninfo()
+* [#4408](https://github.com/apache/nuttx/pull/4408) Fix up that local socket will be endless loop when write data size more than the fifo size.
+* [#4517](https://github.com/apache/nuttx/pull/4517) rpmsg_socket: add prefix "rpmsg-socket" for the name of rpmsg endpoint
+* [#4537](https://github.com/apache/nuttx/pull/4537) net/udp: fix buffer release handling on failed buffer alloc
+* [#4120](https://github.com/apache/nuttx/pull/4120) net/tcp: tcp_sendfile need restore the file location at the end
+* [#4134](https://github.com/apache/nuttx/pull/4134) net/tcp: only print the error when disable the TCP_NODELAY
+* [#4142](https://github.com/apache/nuttx/pull/4142) tcp_send_buffered: throttle IOB allocations for send
+* [#4159](https://github.com/apache/nuttx/pull/4159) tcp_send_buffered.c: Fix broken retransmit
+* [#4126](https://github.com/apache/nuttx/pull/4126) include/netinet: Add missing IP_TTL definition
+* [#4197](https://github.com/apache/nuttx/pull/4197) local/stream: remove preamble header in stream mode
+* [#4273](https://github.com/apache/nuttx/pull/4273) tcp: some fixes in snd_wnd processing
+* [#4293](https://github.com/apache/nuttx/pull/4293) tcp: make our sequence number a bit more monotonic
+* [#4257](https://github.com/apache/nuttx/pull/4257) Fix a few deadlock in tcp/iob
+* [#4480](https://github.com/apache/nuttx/pull/4480) net: utils: Remove critical section for SMP in net_lock.c
+* [#3919](https://github.com/apache/nuttx/pull/3919) tcp iob throttling related fixes
 
 # Security Issues Fixed In This Release
 
@@ -816,9 +816,9 @@ When they appear in code, these identifiers begin with a `CONFIG_*` prefix (e.g.
 
 All in-tree boards have been updated, but users who maintain their own out-of-tree boards will have to update all instances of these identifiers.
 
-See PR-4266 https://github.com/apache/incubator-nuttx/pull/4266 and PR-4267 https://github.com/apache/incubator-nuttx/pull/4267 in the main NuttX repository.
+See PR-4266 https://github.com/apache/nuttx/pull/4266 and PR-4267 https://github.com/apache/nuttx/pull/4267 in the main NuttX repository.
 
-See also PR-820 https://github.com/apache/incubator-nuttx-apps/pull/820 and PR-821 https://github.com/apache/incubator-nuttx-apps/pull/821 in the NuttX apps repository.
+See also PR-820 https://github.com/apache/nuttx-apps/pull/820 and PR-821 https://github.com/apache/nuttx-apps/pull/821 in the NuttX apps repository.
 
 ## Changes to MTD subsystem
 
@@ -827,7 +827,7 @@ MTDIOC_XIPBASE, MTDIOC_FLUSH and MTDIOC_PARTINFO is removed and replace with BIO
 * Simplify the general driver(e.g. partition, flt) implementation
 * Reduce the confusion with the same IOCTL in the different layer
 
-See PR-4325 https://github.com/apache/incubator-nuttx/pull/4325
+See PR-4325 https://github.com/apache/nuttx/pull/4325
 
 ## Changes to Build System
 
@@ -1014,12 +1014,12 @@ LD = $(CROSSDEV)gcc
 #### References
 
 * Git commit # 45672c269db13f59bdaa417e564837e8bbb6c8c1 in the NuttX main repository:
-- https://github.com/apache/incubator-nuttx/commit/45672c269db13f59bdaa417e564837e8bbb6c8c1
+- https://github.com/apache/nuttx/commit/45672c269db13f59bdaa417e564837e8bbb6c8c1
 * PR-3836 in the NuttX main repository:
-- https://github.com/apache/incubator-nuttx/pull/3836
+- https://github.com/apache/nuttx/pull/3836
 * Issues 3209 and 3826 in the NuttX issue tracker:
-- https://github.com/apache/incubator-nuttx/issues/3209
-- https://github.com/apache/incubator-nuttx/issues/3826
+- https://github.com/apache/nuttx/issues/3209
+- https://github.com/apache/nuttx/issues/3826
 * Description of the change on Binutils mailing list:
 - https://sourceware.org/pipermail/binutils/2021-June/116826.html
 * Description of -Wl,option in the GCC manual:

--- a/_releases/10.3.0.md
+++ b/_releases/10.3.0.md
@@ -51,980 +51,980 @@ limitations under the License.
 
 ### New Features
 
-* [#5524](https://github.com/apache/incubator-nuttx/pull/5524) mm: iob: add support of alloc with timeout iob_timedalloc() 
-* [#4743](https://github.com/apache/incubator-nuttx/pull/4743) mm: Support the kernel address sanitizer 
-* [#5498](https://github.com/apache/incubator-nuttx/pull/5498) sched: Implement task local storage 
-* [#5418](https://github.com/apache/incubator-nuttx/pull/5418) sched: Implement sysinfo function 
-* [#5590](https://github.com/apache/incubator-nuttx/pull/5590) sched: os init_state: add new state OSINIT_IDLELOOP 
-* [#4698](https://github.com/apache/incubator-nuttx/pull/4698) sched: mq_open: add long file name check and parameter check 
-* [#5445](https://github.com/apache/incubator-nuttx/pull/5445) task: Always implement posix_spawnp as macro 
-* [#4963](https://github.com/apache/incubator-nuttx/pull/4963) trace: and sched note dump 
-* [#5366](https://github.com/apache/incubator-nuttx/pull/5366) binfmt: libelf: Implement sh_addralign handling
-* [#4871](https://github.com/apache/incubator-nuttx/pull/4871) binfmt: elf: add bare metal coredump support 
+* [#5524](https://github.com/apache/nuttx/pull/5524) mm: iob: add support of alloc with timeout iob_timedalloc() 
+* [#4743](https://github.com/apache/nuttx/pull/4743) mm: Support the kernel address sanitizer 
+* [#5498](https://github.com/apache/nuttx/pull/5498) sched: Implement task local storage 
+* [#5418](https://github.com/apache/nuttx/pull/5418) sched: Implement sysinfo function 
+* [#5590](https://github.com/apache/nuttx/pull/5590) sched: os init_state: add new state OSINIT_IDLELOOP 
+* [#4698](https://github.com/apache/nuttx/pull/4698) sched: mq_open: add long file name check and parameter check 
+* [#5445](https://github.com/apache/nuttx/pull/5445) task: Always implement posix_spawnp as macro 
+* [#4963](https://github.com/apache/nuttx/pull/4963) trace: and sched note dump 
+* [#5366](https://github.com/apache/nuttx/pull/5366) binfmt: libelf: Implement sh_addralign handling
+* [#4871](https://github.com/apache/nuttx/pull/4871) binfmt: elf: add bare metal coredump support 
 
 ### Bug Fixes
 
-* [#5503](https://github.com/apache/incubator-nuttx/pull/5503) Replece clock_gettime with clock_systime_timespec if suitable 
-* [#5721](https://github.com/apache/incubator-nuttx/pull/5721) Remove the unnecessary code from nx_start
-* [#5681](https://github.com/apache/incubator-nuttx/pull/5681) Simplify and unify fcntl with FIOCLEX and FIONCLEX 
-* [#5082](https://github.com/apache/incubator-nuttx/pull/5082) compile/flags: add FRAME_POINTER into Toolchain.defs 
-* [#5199](https://github.com/apache/incubator-nuttx/pull/5199) file_operations: get back C89 compatible initializer 
-* [#5065](https://github.com/apache/incubator-nuttx/pull/5065) reanme CONFIG_USER_ENTRYPOINT to CONFIG_INIT_ENTRYPOINT
-* [#5399](https://github.com/apache/incubator-nuttx/pull/5399) Add CONFIG_NDEBUG Kconfig to control NDEBUG definition 
-* [#5347](https://github.com/apache/incubator-nuttx/pull/5347) register_driver: fix driver modes accross the code 
-* [#5509](https://github.com/apache/incubator-nuttx/pull/5509) libc.csv: Add pthread_setname_np and pthread_getname_np 
-* [#5364](https://github.com/apache/incubator-nuttx/pull/5364) libc.csv: Add more symbols 
+* [#5503](https://github.com/apache/nuttx/pull/5503) Replece clock_gettime with clock_systime_timespec if suitable 
+* [#5721](https://github.com/apache/nuttx/pull/5721) Remove the unnecessary code from nx_start
+* [#5681](https://github.com/apache/nuttx/pull/5681) Simplify and unify fcntl with FIOCLEX and FIONCLEX 
+* [#5082](https://github.com/apache/nuttx/pull/5082) compile/flags: add FRAME_POINTER into Toolchain.defs 
+* [#5199](https://github.com/apache/nuttx/pull/5199) file_operations: get back C89 compatible initializer 
+* [#5065](https://github.com/apache/nuttx/pull/5065) reanme CONFIG_USER_ENTRYPOINT to CONFIG_INIT_ENTRYPOINT
+* [#5399](https://github.com/apache/nuttx/pull/5399) Add CONFIG_NDEBUG Kconfig to control NDEBUG definition 
+* [#5347](https://github.com/apache/nuttx/pull/5347) register_driver: fix driver modes accross the code 
+* [#5509](https://github.com/apache/nuttx/pull/5509) libc.csv: Add pthread_setname_np and pthread_getname_np 
+* [#5364](https://github.com/apache/nuttx/pull/5364) libc.csv: Add more symbols 
 
-* [#4971](https://github.com/apache/incubator-nuttx/pull/4971) audio: audio_comp.c: capbility should use collections 
-* [#5072](https://github.com/apache/incubator-nuttx/pull/5072) graphics: vncserver: Implement vsync 
-* [#5058](https://github.com/apache/incubator-nuttx/pull/5058) graphics: vncserver: Fix buffer overflow 
-* [#5132](https://github.com/apache/incubator-nuttx/pull/5132) graphics: vnc: Decouple VNC server from NX graphic stack 
-* [#4998](https://github.com/apache/incubator-nuttx/pull/4998) system: note dump: add CONFIG_SCHED_INSTRUMENTATION_SWITCH 
-* [#5435](https://github.com/apache/incubator-nuttx/pull/5435) wireless: bluetooth: fix build break if NET_6LOWPAN enabled 
+* [#4971](https://github.com/apache/nuttx/pull/4971) audio: audio_comp.c: capbility should use collections 
+* [#5072](https://github.com/apache/nuttx/pull/5072) graphics: vncserver: Implement vsync 
+* [#5058](https://github.com/apache/nuttx/pull/5058) graphics: vncserver: Fix buffer overflow 
+* [#5132](https://github.com/apache/nuttx/pull/5132) graphics: vnc: Decouple VNC server from NX graphic stack 
+* [#4998](https://github.com/apache/nuttx/pull/4998) system: note dump: add CONFIG_SCHED_INSTRUMENTATION_SWITCH 
+* [#5435](https://github.com/apache/nuttx/pull/5435) wireless: bluetooth: fix build break if NET_6LOWPAN enabled 
 
-* [#5487](https://github.com/apache/incubator-nuttx/pull/5487) binfmt: Decouple builtin from binfs file system
-* [#4667](https://github.com/apache/incubator-nuttx/pull/4667) binfmt: Remove umm_initialize from elf_load
-* [#5351](https://github.com/apache/incubator-nuttx/pull/5351) binfmt: elf.c: Fix syslog formats for ELF64 
-* [#5522](https://github.com/apache/incubator-nuttx/pull/5522) binfmt: Fix binfmt for BUILD_KERNEL & ADDRENV 
-* [#4689](https://github.com/apache/incubator-nuttx/pull/4689) binfmt: remove the specified prefix from target variables 
-* [#5229](https://github.com/apache/incubator-nuttx/pull/5229) binfmt: coredump: remove the block fragmentation 
+* [#5487](https://github.com/apache/nuttx/pull/5487) binfmt: Decouple builtin from binfs file system
+* [#4667](https://github.com/apache/nuttx/pull/4667) binfmt: Remove umm_initialize from elf_load
+* [#5351](https://github.com/apache/nuttx/pull/5351) binfmt: elf.c: Fix syslog formats for ELF64 
+* [#5522](https://github.com/apache/nuttx/pull/5522) binfmt: Fix binfmt for BUILD_KERNEL & ADDRENV 
+* [#4689](https://github.com/apache/nuttx/pull/4689) binfmt: remove the specified prefix from target variables 
+* [#5229](https://github.com/apache/nuttx/pull/5229) binfmt: coredump: remove the block fragmentation 
 
-* [#5409](https://github.com/apache/incubator-nuttx/pull/5409) libc: stdlib: Compile lib_openpty.c without checking CONFIG_SERIAL_TERMIOS 
-* [#5600](https://github.com/apache/incubator-nuttx/pull/5600) libc: Imx6 thumb 
-* [#5474](https://github.com/apache/incubator-nuttx/pull/5474) libc: posix_openpty should use the absolute path("dev/ptmx") 
-* [#5508](https://github.com/apache/incubator-nuttx/pull/5508) libc: sim: Rename arch_setjmp[64].S to arch_setjmp_x86[_64].S 
-* [#4829](https://github.com/apache/incubator-nuttx/pull/4829) libc: Make perror work without CONFIG_FILE_STREAM 
-* [#4779](https://github.com/apache/incubator-nuttx/pull/4779) libc: wqueue Correct time calculation in work_p… 
-* [#4756](https://github.com/apache/incubator-nuttx/pull/4756) libc: machine: xtensa: add xtensa libc implement 
-* [#4752](https://github.com/apache/incubator-nuttx/pull/4752) libc Move lib_filesem.c, lib_stream.c and lib_streamsem.c to libc/stdio 
-* [#5288](https://github.com/apache/incubator-nuttx/pull/5288) libc: misc: lib_execinfo.c: fix bad memory access 
-* [#5290](https://github.com/apache/incubator-nuttx/pull/5290) libc: backtrace_malloc change sprintf to snprintf 
-* [#5381](https://github.com/apache/incubator-nuttx/pull/5381) libc: sim: arch_elf64.c: Implement R_X86_64_PC64 
-* [#4870](https://github.com/apache/incubator-nuttx/pull/4870) libc: add interface to support output stream as buffer style 
-* [#4861](https://github.com/apache/incubator-nuttx/pull/4861) libc: pthread: Implement pthread_atfork 
-* [#4992](https://github.com/apache/incubator-nuttx/pull/4992) libc: Move stream implementation from libs/libc/stdio to libs/libc/stream 
-* [#4768](https://github.com/apache/incubator-nuttx/pull/4768) libc: machine: add config LIBC_ARCH_MEMCHR 
-* [#4855](https://github.com/apache/incubator-nuttx/pull/4855) libc: psignal: Output the message to STDERR_FILENO instead STDOUT_FILENO 
-* [#4853](https://github.com/apache/incubator-nuttx/pull/4853) libc: hex2bin: Handle the line ending(\r, \n and \r\n) dynamically 
-* [#5690](https://github.com/apache/incubator-nuttx/pull/5690) libc: gettext: Support the plural format 
-* [#5692](https://github.com/apache/incubator-nuttx/pull/5692) libc: stdio: Fix bug when CONFIG_LIBC_NUMBERED_ARGS is enabled 
-* [#5465](https://github.com/apache/incubator-nuttx/pull/5465) libc: chdir:"PWD" should save absolute path 
-* [#4994](https://github.com/apache/incubator-nuttx/pull/4994) libc: textdomain: Fix error behaviour 
-* [#5039](https://github.com/apache/incubator-nuttx/pull/5039) libc: lzfcompress: add lzf compress stream 
-* [#4859](https://github.com/apache/incubator-nuttx/pull/4859) libc: getdelim: Remove KERNEL check since it shouldn't be called inside kernel 
-* [#4944](https://github.com/apache/incubator-nuttx/pull/4944) libc: getopt: Move struct getopt_s to include/nuttx/tls.h 
-* [#4881](https://github.com/apache/incubator-nuttx/pull/4881) libc: Update include/nuttx/input/x11_keysymdef.h to the latest version 
-* [#5126](https://github.com/apache/incubator-nuttx/pull/5126) libc: math: fix fmod family operation 
-* [#5125](https://github.com/apache/incubator-nuttx/pull/5125) libc: math: fix log and logf calculations on ARMv7 (and maybe others) 
-* [#5170](https://github.com/apache/incubator-nuttx/pull/5170) libc: pthread:pthread_barrierinit sem use pri_none 
-* [#2063](https://github.com/apache/incubator-nuttx/pull/2063) libc: Fix libcxx for sim/macOS 
-* [#5269](https://github.com/apache/incubator-nuttx/pull/5269) libc: Fix a few libcxx build issues for sim/macOS 
-* [#5202](https://github.com/apache/incubator-nuttx/pull/5202) libc: libcxx-mini: operator new will assert when alloc failed. 
-* [#5180](https://github.com/apache/incubator-nuttx/pull/5180) libc: pthread: restore pthread mutex default protocol POSIX compatibility 
-* [#5549](https://github.com/apache/incubator-nuttx/pull/5549) libc: pthread: add the kernel stack allocation for ADDRENV=y and BUILD_KERNEL 
-* [#4978](https://github.com/apache/incubator-nuttx/pull/4978) libc: Add getprogname function 
-* [#5004](https://github.com/apache/incubator-nuttx/pull/5004) libc: unistd: getopt: Use argc to end parsing 
-* [#5017](https://github.com/apache/incubator-nuttx/pull/5017) libc: Enable terminal api regardless of CONFIG_SERIAL_TERMIOS setting 
-* [#5053](https://github.com/apache/incubator-nuttx/pull/5053) libc: symtab: optimize the find speed by bisection 
-* [#5096](https://github.com/apache/incubator-nuttx/pull/5096) libc: Add backtrace_symbols[_fd] functions 
-* [#4874](https://github.com/apache/incubator-nuttx/pull/4874) libc: stdoutstream: restore the output method to fputc() 
-* [#5564](https://github.com/apache/incubator-nuttx/pull/5564) libc: machine: Implement ARM aeabi_xxx API called by clang 
-* [#5398](https://github.com/apache/incubator-nuttx/pull/5398) libc: Implement posix_openpt 
-* [#4962](https://github.com/apache/incubator-nuttx/pull/4962) libc: allsyms: Load all symbols for debugging 
-* [#4909](https://github.com/apache/incubator-nuttx/pull/4909) libc: Add mknod implementation 
-* [#4894](https://github.com/apache/incubator-nuttx/pull/4894) libc: misc: add err.c to libc 
-* [#4893](https://github.com/apache/incubator-nuttx/pull/4893) libc: str: add strlcat to libc 
-* [#5575](https://github.com/apache/incubator-nuttx/pull/5575) libc: sched: task_setcanceltype: fix function name in comment 
-* [#4828](https://github.com/apache/incubator-nuttx/pull/4828) libc: stdio: Handle 64bits off_t correctly 
-* [#4804](https://github.com/apache/incubator-nuttx/pull/4804) libc: netdb: fix access within misaligned address error 
-* [#4725](https://github.com/apache/incubator-nuttx/pull/4725) libc: Improve the netdb config consistency 
-* [#4985](https://github.com/apache/incubator-nuttx/pull/4985) libc: Remove CEVA tl420/tl421 support on Nuttx 
-* [#5036](https://github.com/apache/incubator-nuttx/pull/5036) libc: net: Implement getifaddrs and freeifaddrs 
-* [#5519](https://github.com/apache/incubator-nuttx/pull/5519) libc: Fix -Werror=nonnull-compare and -Werror=format-truncation= 
-* [#5629](https://github.com/apache/incubator-nuttx/pull/5629) libc: fix up_tls_info define for BUILD_KERNEL 
-* [#5307](https://github.com/apache/incubator-nuttx/pull/5307) libc: bug patch for frexpf function 
-* [#5107](https://github.com/apache/incubator-nuttx/pull/5107) libc: Ensure that sethostname null terminates the hostname correctly 
-* [#5479](https://github.com/apache/incubator-nuttx/pull/5479) libdsp: lib_observer: add nolinear fluxlink observer 
-* [#5483](https://github.com/apache/incubator-nuttx/pull/5483) libdsp: improvements for lib_observer.c 
-* [#5563](https://github.com/apache/incubator-nuttx/pull/5563) libdsp: minor improvements and support for fixed16 observers 
-* [#5527](https://github.com/apache/incubator-nuttx/pull/5527) libnx: handle the bad message correctly 
-* [#5321](https://github.com/apache/incubator-nuttx/pull/5321) libxx: uclibxx: add patch use overload constructor of filebuf & ostream 
-* [#4747](https://github.com/apache/incubator-nuttx/pull/4747) Revert "libc: Implement fesetround & fegetround for arm" 
-* [#4739](https://github.com/apache/incubator-nuttx/pull/4739) Revert "lib/netdb: Change the default NETDB_DNSCLIENT_NAMESIZE to NAM… 
+* [#5409](https://github.com/apache/nuttx/pull/5409) libc: stdlib: Compile lib_openpty.c without checking CONFIG_SERIAL_TERMIOS 
+* [#5600](https://github.com/apache/nuttx/pull/5600) libc: Imx6 thumb 
+* [#5474](https://github.com/apache/nuttx/pull/5474) libc: posix_openpty should use the absolute path("dev/ptmx") 
+* [#5508](https://github.com/apache/nuttx/pull/5508) libc: sim: Rename arch_setjmp[64].S to arch_setjmp_x86[_64].S 
+* [#4829](https://github.com/apache/nuttx/pull/4829) libc: Make perror work without CONFIG_FILE_STREAM 
+* [#4779](https://github.com/apache/nuttx/pull/4779) libc: wqueue Correct time calculation in work_p… 
+* [#4756](https://github.com/apache/nuttx/pull/4756) libc: machine: xtensa: add xtensa libc implement 
+* [#4752](https://github.com/apache/nuttx/pull/4752) libc Move lib_filesem.c, lib_stream.c and lib_streamsem.c to libc/stdio 
+* [#5288](https://github.com/apache/nuttx/pull/5288) libc: misc: lib_execinfo.c: fix bad memory access 
+* [#5290](https://github.com/apache/nuttx/pull/5290) libc: backtrace_malloc change sprintf to snprintf 
+* [#5381](https://github.com/apache/nuttx/pull/5381) libc: sim: arch_elf64.c: Implement R_X86_64_PC64 
+* [#4870](https://github.com/apache/nuttx/pull/4870) libc: add interface to support output stream as buffer style 
+* [#4861](https://github.com/apache/nuttx/pull/4861) libc: pthread: Implement pthread_atfork 
+* [#4992](https://github.com/apache/nuttx/pull/4992) libc: Move stream implementation from libs/libc/stdio to libs/libc/stream 
+* [#4768](https://github.com/apache/nuttx/pull/4768) libc: machine: add config LIBC_ARCH_MEMCHR 
+* [#4855](https://github.com/apache/nuttx/pull/4855) libc: psignal: Output the message to STDERR_FILENO instead STDOUT_FILENO 
+* [#4853](https://github.com/apache/nuttx/pull/4853) libc: hex2bin: Handle the line ending(\r, \n and \r\n) dynamically 
+* [#5690](https://github.com/apache/nuttx/pull/5690) libc: gettext: Support the plural format 
+* [#5692](https://github.com/apache/nuttx/pull/5692) libc: stdio: Fix bug when CONFIG_LIBC_NUMBERED_ARGS is enabled 
+* [#5465](https://github.com/apache/nuttx/pull/5465) libc: chdir:"PWD" should save absolute path 
+* [#4994](https://github.com/apache/nuttx/pull/4994) libc: textdomain: Fix error behaviour 
+* [#5039](https://github.com/apache/nuttx/pull/5039) libc: lzfcompress: add lzf compress stream 
+* [#4859](https://github.com/apache/nuttx/pull/4859) libc: getdelim: Remove KERNEL check since it shouldn't be called inside kernel 
+* [#4944](https://github.com/apache/nuttx/pull/4944) libc: getopt: Move struct getopt_s to include/nuttx/tls.h 
+* [#4881](https://github.com/apache/nuttx/pull/4881) libc: Update include/nuttx/input/x11_keysymdef.h to the latest version 
+* [#5126](https://github.com/apache/nuttx/pull/5126) libc: math: fix fmod family operation 
+* [#5125](https://github.com/apache/nuttx/pull/5125) libc: math: fix log and logf calculations on ARMv7 (and maybe others) 
+* [#5170](https://github.com/apache/nuttx/pull/5170) libc: pthread:pthread_barrierinit sem use pri_none 
+* [#2063](https://github.com/apache/nuttx/pull/2063) libc: Fix libcxx for sim/macOS 
+* [#5269](https://github.com/apache/nuttx/pull/5269) libc: Fix a few libcxx build issues for sim/macOS 
+* [#5202](https://github.com/apache/nuttx/pull/5202) libc: libcxx-mini: operator new will assert when alloc failed. 
+* [#5180](https://github.com/apache/nuttx/pull/5180) libc: pthread: restore pthread mutex default protocol POSIX compatibility 
+* [#5549](https://github.com/apache/nuttx/pull/5549) libc: pthread: add the kernel stack allocation for ADDRENV=y and BUILD_KERNEL 
+* [#4978](https://github.com/apache/nuttx/pull/4978) libc: Add getprogname function 
+* [#5004](https://github.com/apache/nuttx/pull/5004) libc: unistd: getopt: Use argc to end parsing 
+* [#5017](https://github.com/apache/nuttx/pull/5017) libc: Enable terminal api regardless of CONFIG_SERIAL_TERMIOS setting 
+* [#5053](https://github.com/apache/nuttx/pull/5053) libc: symtab: optimize the find speed by bisection 
+* [#5096](https://github.com/apache/nuttx/pull/5096) libc: Add backtrace_symbols[_fd] functions 
+* [#4874](https://github.com/apache/nuttx/pull/4874) libc: stdoutstream: restore the output method to fputc() 
+* [#5564](https://github.com/apache/nuttx/pull/5564) libc: machine: Implement ARM aeabi_xxx API called by clang 
+* [#5398](https://github.com/apache/nuttx/pull/5398) libc: Implement posix_openpt 
+* [#4962](https://github.com/apache/nuttx/pull/4962) libc: allsyms: Load all symbols for debugging 
+* [#4909](https://github.com/apache/nuttx/pull/4909) libc: Add mknod implementation 
+* [#4894](https://github.com/apache/nuttx/pull/4894) libc: misc: add err.c to libc 
+* [#4893](https://github.com/apache/nuttx/pull/4893) libc: str: add strlcat to libc 
+* [#5575](https://github.com/apache/nuttx/pull/5575) libc: sched: task_setcanceltype: fix function name in comment 
+* [#4828](https://github.com/apache/nuttx/pull/4828) libc: stdio: Handle 64bits off_t correctly 
+* [#4804](https://github.com/apache/nuttx/pull/4804) libc: netdb: fix access within misaligned address error 
+* [#4725](https://github.com/apache/nuttx/pull/4725) libc: Improve the netdb config consistency 
+* [#4985](https://github.com/apache/nuttx/pull/4985) libc: Remove CEVA tl420/tl421 support on Nuttx 
+* [#5036](https://github.com/apache/nuttx/pull/5036) libc: net: Implement getifaddrs and freeifaddrs 
+* [#5519](https://github.com/apache/nuttx/pull/5519) libc: Fix -Werror=nonnull-compare and -Werror=format-truncation= 
+* [#5629](https://github.com/apache/nuttx/pull/5629) libc: fix up_tls_info define for BUILD_KERNEL 
+* [#5307](https://github.com/apache/nuttx/pull/5307) libc: bug patch for frexpf function 
+* [#5107](https://github.com/apache/nuttx/pull/5107) libc: Ensure that sethostname null terminates the hostname correctly 
+* [#5479](https://github.com/apache/nuttx/pull/5479) libdsp: lib_observer: add nolinear fluxlink observer 
+* [#5483](https://github.com/apache/nuttx/pull/5483) libdsp: improvements for lib_observer.c 
+* [#5563](https://github.com/apache/nuttx/pull/5563) libdsp: minor improvements and support for fixed16 observers 
+* [#5527](https://github.com/apache/nuttx/pull/5527) libnx: handle the bad message correctly 
+* [#5321](https://github.com/apache/nuttx/pull/5321) libxx: uclibxx: add patch use overload constructor of filebuf & ostream 
+* [#4747](https://github.com/apache/nuttx/pull/4747) Revert "libc: Implement fesetround & fegetround for arm" 
+* [#4739](https://github.com/apache/nuttx/pull/4739) Revert "lib/netdb: Change the default NETDB_DNSCLIENT_NAMESIZE to NAM… 
 
-* [#5459](https://github.com/apache/incubator-nuttx/pull/5459) mm: mm_heap: add mm_foreach to run handler for every memory node
-* [#5504](https://github.com/apache/incubator-nuttx/pull/5504) mm: handle take mm sem in IRQ 
-* [#4765](https://github.com/apache/incubator-nuttx/pull/4765) mm: fix realloc overwrite memcpy when use a new block 
-* [#4759](https://github.com/apache/incubator-nuttx/pull/4759) mm: do kmm_checkcorruption in IRQ when TCB_FLAG_DEBUG_CHECK set
-* [#5532](https://github.com/apache/incubator-nuttx/pull/5532) mm: fix gran_alloc() array index range checking 
-* [#5548](https://github.com/apache/incubator-nuttx/pull/5548) mm: fix #if condition of g_mmheap for BUILD_KERNEL and ADDRENV 
-* [#5539](https://github.com/apache/incubator-nuttx/pull/5539) mm: handle take mm sem in IRQ 
-* [#5585](https://github.com/apache/incubator-nuttx/pull/5585) mm: Add memory dump function when enable CONFIG_DEBUG_MM 
+* [#5459](https://github.com/apache/nuttx/pull/5459) mm: mm_heap: add mm_foreach to run handler for every memory node
+* [#5504](https://github.com/apache/nuttx/pull/5504) mm: handle take mm sem in IRQ 
+* [#4765](https://github.com/apache/nuttx/pull/4765) mm: fix realloc overwrite memcpy when use a new block 
+* [#4759](https://github.com/apache/nuttx/pull/4759) mm: do kmm_checkcorruption in IRQ when TCB_FLAG_DEBUG_CHECK set
+* [#5532](https://github.com/apache/nuttx/pull/5532) mm: fix gran_alloc() array index range checking 
+* [#5548](https://github.com/apache/nuttx/pull/5548) mm: fix #if condition of g_mmheap for BUILD_KERNEL and ADDRENV 
+* [#5539](https://github.com/apache/nuttx/pull/5539) mm: handle take mm sem in IRQ 
+* [#5585](https://github.com/apache/nuttx/pull/5585) mm: Add memory dump function when enable CONFIG_DEBUG_MM 
 
-* [#5417](https://github.com/apache/incubator-nuttx/pull/5417) pthread: Add len argument to pthread_getname_np 
+* [#5417](https://github.com/apache/nuttx/pull/5417) pthread: Add len argument to pthread_getname_np 
 
-* [#4798](https://github.com/apache/incubator-nuttx/pull/4798) sched: Reduce the default preallocated buffer when DEFAULT_SMALL=y 
-* [#5632](https://github.com/apache/incubator-nuttx/pull/5632) sched: group: Fix dataabort when exiting task or pthread if ARCH_ADDR_ENV=y 
-* [#5658](https://github.com/apache/incubator-nuttx/pull/5658) sched: group: Simplify the allocation and deallocation logic 
-* [#5649](https://github.com/apache/incubator-nuttx/pull/5649) Revert "sched: Don't duplicate caller file handler when creating kernel thread"
-* [#5543](https://github.com/apache/incubator-nuttx/pull/5543) sched: Mark pthread as non-cancelable to avoid additional calls to pthread_exit() 
-* [#5583](https://github.com/apache/incubator-nuttx/pull/5583) sched: note:add switch and dump instrumentation 
-* [#5416](https://github.com/apache/incubator-nuttx/pull/5416) sched: Disable pthread by default when DEFAULT_SMALL is enabled
-* [#5015](https://github.com/apache/incubator-nuttx/pull/5015) sched: add holder in sem_trywait 
-* [#5264](https://github.com/apache/incubator-nuttx/pull/5264) sched: Define SMP_NCPUS to 1 in no SMP case 
-* [#4803](https://github.com/apache/incubator-nuttx/pull/4803) sched: signal: add spinlock to g_sigfreeaction 
-* [#4799](https://github.com/apache/incubator-nuttx/pull/4799) sched: Disable message queue by default when DEFAULT_SMALL equals y 
-* [#4772](https://github.com/apache/incubator-nuttx/pull/4772) sched: vfork: allocate tls_info_s instead task_info_s from stack 
-* [#4931](https://github.com/apache/incubator-nuttx/pull/4931) sched: sched_waitpid:delete debugassert 
-* [#4863](https://github.com/apache/incubator-nuttx/pull/4863) sched: Move g_tcbinfo to include/nuttx/sched.h 
-* [#5331](https://github.com/apache/incubator-nuttx/pull/5331) sched: critmonitor: remove the assertion if counter == 0 
-* [#5098](https://github.com/apache/incubator-nuttx/pull/5098) sched: backtrace: Dump the complete stack regardless the depth 
-* [#5185](https://github.com/apache/incubator-nuttx/pull/5185) sched: Remove CONFIG_ prefix from SCHED_HPWORK 
-* [#4666](https://github.com/apache/incubator-nuttx/pull/4666) sched: Remove pidhash_s and move ticks to tcb_s 
-* [#4676](https://github.com/apache/incubator-nuttx/pull/4676) sched: Check g_pidhash[hash_ndx] isn't NULL before access pid field in nxsched_get_tcb 
-* [#5545](https://github.com/apache/incubator-nuttx/pull/5545) sched: clock: Remove CLOCK_MONOTONIC option from Kconfig 
-* [#5464](https://github.com/apache/incubator-nuttx/pull/5464) sched: tcbinfo: Fix warning by discarded qualifiers 
-* [#5455](https://github.com/apache/incubator-nuttx/pull/5455) sched: mqueue: remove unused leave_cancellation_point 
-* [#5456](https://github.com/apache/incubator-nuttx/pull/5456) sched: module: remove redundant unlock 
-* [#5392](https://github.com/apache/incubator-nuttx/pull/5392) sched: Remove SDCLONE_DISABLE option and config 
-* [#4858](https://github.com/apache/incubator-nuttx/pull/4858) sched: watchdog: remove tick check in wd_timer 
-* [#5018](https://github.com/apache/incubator-nuttx/pull/5018) sched: init/nx_start.c: fix compile break when CONIFG_TASK_NAME_SIZE=0 
-* [#4999](https://github.com/apache/incubator-nuttx/pull/4999) sched: sched_note: change uint32_t nbi_module into uint8_t array 
-* [#4989](https://github.com/apache/incubator-nuttx/pull/4989) sched: fix bug in the function nxsched_resume_scheduler 
-* [#4958](https://github.com/apache/incubator-nuttx/pull/4958) sched: signal: Introduce a private spinlock in sig_action.c 
-* [#4954](https://github.com/apache/incubator-nuttx/pull/4954) sched: dumpstack: raise the stack dump level to emergency 
-* [#4953](https://github.com/apache/incubator-nuttx/pull/4953) sched: semaphore: fix race condition for timed wait 
-* [#4913](https://github.com/apache/incubator-nuttx/pull/4913) sched: Move argv from tcb_s to task_info_s 
-* [#5368](https://github.com/apache/incubator-nuttx/pull/5368) sched: idle: remove heap & stack check in idle thread
-* [#4782](https://github.com/apache/incubator-nuttx/pull/4782) sched: sem: remove limitation of irq context when do sem_trywait
-* [#4972](https://github.com/apache/incubator-nuttx/pull/4972) sched: wqueue: update wqueue to support using wqueue before wqueue start 
-* [#5266](https://github.com/apache/incubator-nuttx/pull/5266) sched: IDLE thread will not boost up when IDLE hold sem 
-* [#5540](https://github.com/apache/incubator-nuttx/pull/5540) sched: semaphore: fix corner case sem_waitirq assert crash 
-* [#4682](https://github.com/apache/incubator-nuttx/pull/4682) sched: cpuload: fix crash because of the member of g_pidhash is NULL 
-* [#5171](https://github.com/apache/incubator-nuttx/pull/5171) sched: semphore: release all semphores' holder that the task held when exit 
-* [#5063](https://github.com/apache/incubator-nuttx/pull/5063) sched: wqueue: fix NO leave_critical_section() when only CONFIG_SCHED_HPWORK 
+* [#4798](https://github.com/apache/nuttx/pull/4798) sched: Reduce the default preallocated buffer when DEFAULT_SMALL=y 
+* [#5632](https://github.com/apache/nuttx/pull/5632) sched: group: Fix dataabort when exiting task or pthread if ARCH_ADDR_ENV=y 
+* [#5658](https://github.com/apache/nuttx/pull/5658) sched: group: Simplify the allocation and deallocation logic 
+* [#5649](https://github.com/apache/nuttx/pull/5649) Revert "sched: Don't duplicate caller file handler when creating kernel thread"
+* [#5543](https://github.com/apache/nuttx/pull/5543) sched: Mark pthread as non-cancelable to avoid additional calls to pthread_exit() 
+* [#5583](https://github.com/apache/nuttx/pull/5583) sched: note:add switch and dump instrumentation 
+* [#5416](https://github.com/apache/nuttx/pull/5416) sched: Disable pthread by default when DEFAULT_SMALL is enabled
+* [#5015](https://github.com/apache/nuttx/pull/5015) sched: add holder in sem_trywait 
+* [#5264](https://github.com/apache/nuttx/pull/5264) sched: Define SMP_NCPUS to 1 in no SMP case 
+* [#4803](https://github.com/apache/nuttx/pull/4803) sched: signal: add spinlock to g_sigfreeaction 
+* [#4799](https://github.com/apache/nuttx/pull/4799) sched: Disable message queue by default when DEFAULT_SMALL equals y 
+* [#4772](https://github.com/apache/nuttx/pull/4772) sched: vfork: allocate tls_info_s instead task_info_s from stack 
+* [#4931](https://github.com/apache/nuttx/pull/4931) sched: sched_waitpid:delete debugassert 
+* [#4863](https://github.com/apache/nuttx/pull/4863) sched: Move g_tcbinfo to include/nuttx/sched.h 
+* [#5331](https://github.com/apache/nuttx/pull/5331) sched: critmonitor: remove the assertion if counter == 0 
+* [#5098](https://github.com/apache/nuttx/pull/5098) sched: backtrace: Dump the complete stack regardless the depth 
+* [#5185](https://github.com/apache/nuttx/pull/5185) sched: Remove CONFIG_ prefix from SCHED_HPWORK 
+* [#4666](https://github.com/apache/nuttx/pull/4666) sched: Remove pidhash_s and move ticks to tcb_s 
+* [#4676](https://github.com/apache/nuttx/pull/4676) sched: Check g_pidhash[hash_ndx] isn't NULL before access pid field in nxsched_get_tcb 
+* [#5545](https://github.com/apache/nuttx/pull/5545) sched: clock: Remove CLOCK_MONOTONIC option from Kconfig 
+* [#5464](https://github.com/apache/nuttx/pull/5464) sched: tcbinfo: Fix warning by discarded qualifiers 
+* [#5455](https://github.com/apache/nuttx/pull/5455) sched: mqueue: remove unused leave_cancellation_point 
+* [#5456](https://github.com/apache/nuttx/pull/5456) sched: module: remove redundant unlock 
+* [#5392](https://github.com/apache/nuttx/pull/5392) sched: Remove SDCLONE_DISABLE option and config 
+* [#4858](https://github.com/apache/nuttx/pull/4858) sched: watchdog: remove tick check in wd_timer 
+* [#5018](https://github.com/apache/nuttx/pull/5018) sched: init/nx_start.c: fix compile break when CONIFG_TASK_NAME_SIZE=0 
+* [#4999](https://github.com/apache/nuttx/pull/4999) sched: sched_note: change uint32_t nbi_module into uint8_t array 
+* [#4989](https://github.com/apache/nuttx/pull/4989) sched: fix bug in the function nxsched_resume_scheduler 
+* [#4958](https://github.com/apache/nuttx/pull/4958) sched: signal: Introduce a private spinlock in sig_action.c 
+* [#4954](https://github.com/apache/nuttx/pull/4954) sched: dumpstack: raise the stack dump level to emergency 
+* [#4953](https://github.com/apache/nuttx/pull/4953) sched: semaphore: fix race condition for timed wait 
+* [#4913](https://github.com/apache/nuttx/pull/4913) sched: Move argv from tcb_s to task_info_s 
+* [#5368](https://github.com/apache/nuttx/pull/5368) sched: idle: remove heap & stack check in idle thread
+* [#4782](https://github.com/apache/nuttx/pull/4782) sched: sem: remove limitation of irq context when do sem_trywait
+* [#4972](https://github.com/apache/nuttx/pull/4972) sched: wqueue: update wqueue to support using wqueue before wqueue start 
+* [#5266](https://github.com/apache/nuttx/pull/5266) sched: IDLE thread will not boost up when IDLE hold sem 
+* [#5540](https://github.com/apache/nuttx/pull/5540) sched: semaphore: fix corner case sem_waitirq assert crash 
+* [#4682](https://github.com/apache/nuttx/pull/4682) sched: cpuload: fix crash because of the member of g_pidhash is NULL 
+* [#5171](https://github.com/apache/nuttx/pull/5171) sched: semphore: release all semphores' holder that the task held when exit 
+* [#5063](https://github.com/apache/nuttx/pull/5063) sched: wqueue: fix NO leave_critical_section() when only CONFIG_SCHED_HPWORK 
 
 ## Major Changes to the Build System
 
 ### New Features
 
-* [#5638](https://github.com/apache/incubator-nuttx/pull/5638) tools: add parsememdump.py to parse memdump info(by cmd: memdump all) 
-* [#5622](https://github.com/apache/incubator-nuttx/pull/5622) tools: add rustfmt to checkpatch 
-* [#4925](https://github.com/apache/incubator-nuttx/pull/4925) tools: Add size report script
-* [#5153](https://github.com/apache/incubator-nuttx/pull/5153) tools: mpfs: prepare OpenSBI image 
+* [#5638](https://github.com/apache/nuttx/pull/5638) tools: add parsememdump.py to parse memdump info(by cmd: memdump all) 
+* [#5622](https://github.com/apache/nuttx/pull/5622) tools: add rustfmt to checkpatch 
+* [#4925](https://github.com/apache/nuttx/pull/4925) tools: Add size report script
+* [#5153](https://github.com/apache/nuttx/pull/5153) tools: mpfs: prepare OpenSBI image 
 
 ### Bug Fixes
 
-* [#5362](https://github.com/apache/incubator-nuttx/pull/5362) tools: mkromfsimg.sh: add attribute to set minimum 4 bytes aignment for romfs image data 
-* [#4794](https://github.com/apache/incubator-nuttx/pull/4794) tools: mkconfig: Handle string with escape character correctly 
-* [#4730](https://github.com/apache/incubator-nuttx/pull/4730) tools: add code coverage tool 
-* [#5174](https://github.com/apache/incubator-nuttx/pull/5174) tools: Fix parallel build issue due to missing dependency 
-* [#5275](https://github.com/apache/incubator-nuttx/pull/5275) tools: mkromfsimg.sh: fix build error in case if romfs is used 
-* [#5274](https://github.com/apache/incubator-nuttx/pull/5274) tools: add option to reuse boards common files for custom boards 
-* [#5715](https://github.com/apache/incubator-nuttx/pull/5715) tools: define BOARD_COMMON_DIR only if ARCH_BOARD_COMMON is set 
-* [#5533](https://github.com/apache/incubator-nuttx/pull/5533) tools: Default macro to compile one Rust file. 
-* [#5494](https://github.com/apache/incubator-nuttx/pull/5494) tools: Unix.mk: silence output from version.sh 
-* [#5400](https://github.com/apache/incubator-nuttx/pull/5400) tools: mkconfig: Remove the unnecessary config option correction 
-* [#4701](https://github.com/apache/incubator-nuttx/pull/4701) tools: esp32: Refactor generation of QEMU-compatible image 
-* [#4865](https://github.com/apache/incubator-nuttx/pull/4865) tools: gdbinit: add sim:x86-m32 support 
-* [#4926](https://github.com/apache/incubator-nuttx/pull/4926) tools: rp2040: Compile with C++14
-* [#4936](https://github.com/apache/incubator-nuttx/pull/4936) tools: Rename size_report to size_report.py 
-* [#5518](https://github.com/apache/incubator-nuttx/pull/5518) tools: mkallsyms.sh: Disable the mismatch warning of builtin declaration 
-* [#5346](https://github.com/apache/incubator-nuttx/pull/5346) tools: Config.mk: suppress all normal output for cmp 
-* [#5374](https://github.com/apache/incubator-nuttx/pull/5374) tools: Detect correct host CPU on MacOS/Linux running on ARM. 
-* [#4673](https://github.com/apache/incubator-nuttx/pull/4673) tools: CeDeROM add *BSD support 20211016 
-* [#4494](https://github.com/apache/incubator-nuttx/pull/4494) tools: build: Replace 'make download' with 'make flash', but keep both for now
-* [#5116](https://github.com/apache/incubator-nuttx/pull/5116) tools: Remove .clean_context 
-* [#4869](https://github.com/apache/incubator-nuttx/pull/4869) tools: Improve releasecheck.sh 
-* [#5491](https://github.com/apache/incubator-nuttx/pull/5491) tools: Fix configure.sh for custom apps dir. 
-* [#5495](https://github.com/apache/incubator-nuttx/pull/5495) tools: Fix jlink-nuttx build with GCC 10.2 
-* [#5505](https://github.com/apache/incubator-nuttx/pull/5505) tools: Fix JLinkGDBServer crash attaching to target
-* [#5147](https://github.com/apache/incubator-nuttx/pull/5147) tools: Improve dependencies for include/nuttx/version.h 
-* [#5162](https://github.com/apache/incubator-nuttx/pull/5162) tools: Improve dirlinks dependencies for Makefile.win 
-* [#5055](https://github.com/apache/incubator-nuttx/pull/5055) tools: Improve Makefile.[unix|win]::context's dependencies 
-* [#5163](https://github.com/apache/incubator-nuttx/pull/5163) tools: Rename Makefile.* to have the .mk extension 
+* [#5362](https://github.com/apache/nuttx/pull/5362) tools: mkromfsimg.sh: add attribute to set minimum 4 bytes aignment for romfs image data 
+* [#4794](https://github.com/apache/nuttx/pull/4794) tools: mkconfig: Handle string with escape character correctly 
+* [#4730](https://github.com/apache/nuttx/pull/4730) tools: add code coverage tool 
+* [#5174](https://github.com/apache/nuttx/pull/5174) tools: Fix parallel build issue due to missing dependency 
+* [#5275](https://github.com/apache/nuttx/pull/5275) tools: mkromfsimg.sh: fix build error in case if romfs is used 
+* [#5274](https://github.com/apache/nuttx/pull/5274) tools: add option to reuse boards common files for custom boards 
+* [#5715](https://github.com/apache/nuttx/pull/5715) tools: define BOARD_COMMON_DIR only if ARCH_BOARD_COMMON is set 
+* [#5533](https://github.com/apache/nuttx/pull/5533) tools: Default macro to compile one Rust file. 
+* [#5494](https://github.com/apache/nuttx/pull/5494) tools: Unix.mk: silence output from version.sh 
+* [#5400](https://github.com/apache/nuttx/pull/5400) tools: mkconfig: Remove the unnecessary config option correction 
+* [#4701](https://github.com/apache/nuttx/pull/4701) tools: esp32: Refactor generation of QEMU-compatible image 
+* [#4865](https://github.com/apache/nuttx/pull/4865) tools: gdbinit: add sim:x86-m32 support 
+* [#4926](https://github.com/apache/nuttx/pull/4926) tools: rp2040: Compile with C++14
+* [#4936](https://github.com/apache/nuttx/pull/4936) tools: Rename size_report to size_report.py 
+* [#5518](https://github.com/apache/nuttx/pull/5518) tools: mkallsyms.sh: Disable the mismatch warning of builtin declaration 
+* [#5346](https://github.com/apache/nuttx/pull/5346) tools: Config.mk: suppress all normal output for cmp 
+* [#5374](https://github.com/apache/nuttx/pull/5374) tools: Detect correct host CPU on MacOS/Linux running on ARM. 
+* [#4673](https://github.com/apache/nuttx/pull/4673) tools: CeDeROM add *BSD support 20211016 
+* [#4494](https://github.com/apache/nuttx/pull/4494) tools: build: Replace 'make download' with 'make flash', but keep both for now
+* [#5116](https://github.com/apache/nuttx/pull/5116) tools: Remove .clean_context 
+* [#4869](https://github.com/apache/nuttx/pull/4869) tools: Improve releasecheck.sh 
+* [#5491](https://github.com/apache/nuttx/pull/5491) tools: Fix configure.sh for custom apps dir. 
+* [#5495](https://github.com/apache/nuttx/pull/5495) tools: Fix jlink-nuttx build with GCC 10.2 
+* [#5505](https://github.com/apache/nuttx/pull/5505) tools: Fix JLinkGDBServer crash attaching to target
+* [#5147](https://github.com/apache/nuttx/pull/5147) tools: Improve dependencies for include/nuttx/version.h 
+* [#5162](https://github.com/apache/nuttx/pull/5162) tools: Improve dirlinks dependencies for Makefile.win 
+* [#5055](https://github.com/apache/nuttx/pull/5055) tools: Improve Makefile.[unix|win]::context's dependencies 
+* [#5163](https://github.com/apache/nuttx/pull/5163) tools: Rename Makefile.* to have the .mk extension 
 
 ## Architectural Support
 
 ### New Architecture Support
 
-* [#4897](https://github.com/apache/incubator-nuttx/pull/4897) arch: arm: phy62xx: Phyplus release 1.2 
-* [#5470](https://github.com/apache/incubator-nuttx/pull/5470) arch: arm: STM32U5 Architecture Support 
-* [#5165](https://github.com/apache/incubator-nuttx/pull/5165) arch: ceva: add ceva platform xc5 xm6 support 
-* [#5352](https://github.com/apache/incubator-nuttx/pull/5352) arch: xtensa: Add initial support for ESP32-S3 
-* [#5241](https://github.com/apache/incubator-nuttx/pull/5241) arch: sparc: Port nuttx to sparc-v8
+* [#4897](https://github.com/apache/nuttx/pull/4897) arch: arm: phy62xx: Phyplus release 1.2 
+* [#5470](https://github.com/apache/nuttx/pull/5470) arch: arm: STM32U5 Architecture Support 
+* [#5165](https://github.com/apache/nuttx/pull/5165) arch: ceva: add ceva platform xc5 xm6 support 
+* [#5352](https://github.com/apache/nuttx/pull/5352) arch: xtensa: Add initial support for ESP32-S3 
+* [#5241](https://github.com/apache/nuttx/pull/5241) arch: sparc: Port nuttx to sparc-v8
 
 ### Architecture with Significant Improvements
 
-* [#5468](https://github.com/apache/incubator-nuttx/pull/5468) arch: Add xxx_tcbinfo.c to SoC level Make.defs 
-* [#5482](https://github.com/apache/incubator-nuttx/pull/5482) arch: Replace nx_vsyslog with vsyslog 
-* [#5507](https://github.com/apache/incubator-nuttx/pull/5507) arch: Align the implementation of stack related functions 
-* [#4830](https://github.com/apache/incubator-nuttx/pull/4830) arch: Remove fflush(stdout) from driver code 
-* [#5741](https://github.com/apache/incubator-nuttx/pull/5741) arch: Make the comment and definition of CONFIG_SYS_RESERVED correctly 
-* [#5332](https://github.com/apache/incubator-nuttx/pull/5332) arch: Toolchain.defs: Simplify addition builtin library to EXTRA_LIBS 
-* [#5122](https://github.com/apache/incubator-nuttx/pull/5122) arch: backtrace: correct the skip counter 
-* [#5095](https://github.com/apache/incubator-nuttx/pull/5095) arch: Select ARCH_HAVE_BACKTRACE in Kconfig for supported arch 
-* [#5342](https://github.com/apache/incubator-nuttx/pull/5342) arch: Add up_perf_getfreq function 
-* [#5335](https://github.com/apache/incubator-nuttx/pull/5335) arch: cache: flush/clean dcache all if size large than cache size 
-* [#5328](https://github.com/apache/incubator-nuttx/pull/5328) arch: Decouple up_critmon_[gettime|convert] from critmon 
-* [#4699](https://github.com/apache/incubator-nuttx/pull/4699) arch: cache: add lock & unlock feature 
-* [#4910](https://github.com/apache/incubator-nuttx/pull/4910) arch: Dump task name through tcb_s::name instead of argv[0] 
-* [#4677](https://github.com/apache/incubator-nuttx/pull/4677) arch: *_cpupause:Allow a spin before taking the g_cpu_wait spinlock. 
-* [#5007](https://github.com/apache/incubator-nuttx/pull/5007) arch: assert: flush the syslog before stack dump to avoid buffer overwrite 
-* [#4942](https://github.com/apache/incubator-nuttx/pull/4942) arch: tcbinfo: fix build break if task name disabled 
-* [#4941](https://github.com/apache/incubator-nuttx/pull/4941) arch: Remove the duplicated up_tls_info implementation 
-* [#5385](https://github.com/apache/incubator-nuttx/pull/5385) arch: Toolchain.defs: Replace --print-file-name=libgcc.a with --print-libgcc-file-name 
-* [#5371](https://github.com/apache/incubator-nuttx/pull/5371) arch: Toolchain.defs: Don't expand EXTRA_LIBS immediately 
-* [#5057](https://github.com/apache/incubator-nuttx/pull/5057) arch: arm/risc-v/xtensa: enhance the task dump 
-* [#5397](https://github.com/apache/incubator-nuttx/pull/5397) arch: arm/renesas/xtensa: fix leaving from critical section 
-* [#5231](https://github.com/apache/incubator-nuttx/pull/5231) arch: arm/xtensa/risc-v: save the running registers to xcp context 
-* [#5719](https://github.com/apache/incubator-nuttx/pull/5719) arch: Move [arm|xtensa]_intstack_[alloc|top] to common header file 
-* [#5060](https://github.com/apache/incubator-nuttx/pull/5060) arch: Kconfig: Add HAVE_SYSCALL_HOOKS configs to Xtensa arch. 
-* [#4840](https://github.com/apache/incubator-nuttx/pull/4840) arch: add MTDIOCTL_PROGMEM_ERASESTATE support 
-* [#5259](https://github.com/apache/incubator-nuttx/pull/5259) arch: use HTONS, NTOHS, HTONL, NTOHL macro in kernel code 
-* [#5008](https://github.com/apache/incubator-nuttx/pull/5008) arch: assert: unify stack and register dump across platforms 
-* [#4810](https://github.com/apache/incubator-nuttx/pull/4810) arch: debug: add tools for task aware debug 
-* [#5088](https://github.com/apache/incubator-nuttx/pull/5088) arch: make/allsyms: skip the unnecessary link operation 
-* [#4749](https://github.com/apache/incubator-nuttx/pull/4749) arch: Remove FILE dump code from _up_dumponexit
-* [#5309](https://github.com/apache/incubator-nuttx/pull/5309) arch: toolchain: add libm to EXTRA_LIBS only if it is provided by the compiler 
-* [#5120](https://github.com/apache/incubator-nuttx/pull/5120) arch: signal: signal handler may cause task's state error 
-* [#4993](https://github.com/apache/incubator-nuttx/pull/4993) arch: tls: restore C89 compatibility for TLS 
+* [#5468](https://github.com/apache/nuttx/pull/5468) arch: Add xxx_tcbinfo.c to SoC level Make.defs 
+* [#5482](https://github.com/apache/nuttx/pull/5482) arch: Replace nx_vsyslog with vsyslog 
+* [#5507](https://github.com/apache/nuttx/pull/5507) arch: Align the implementation of stack related functions 
+* [#4830](https://github.com/apache/nuttx/pull/4830) arch: Remove fflush(stdout) from driver code 
+* [#5741](https://github.com/apache/nuttx/pull/5741) arch: Make the comment and definition of CONFIG_SYS_RESERVED correctly 
+* [#5332](https://github.com/apache/nuttx/pull/5332) arch: Toolchain.defs: Simplify addition builtin library to EXTRA_LIBS 
+* [#5122](https://github.com/apache/nuttx/pull/5122) arch: backtrace: correct the skip counter 
+* [#5095](https://github.com/apache/nuttx/pull/5095) arch: Select ARCH_HAVE_BACKTRACE in Kconfig for supported arch 
+* [#5342](https://github.com/apache/nuttx/pull/5342) arch: Add up_perf_getfreq function 
+* [#5335](https://github.com/apache/nuttx/pull/5335) arch: cache: flush/clean dcache all if size large than cache size 
+* [#5328](https://github.com/apache/nuttx/pull/5328) arch: Decouple up_critmon_[gettime|convert] from critmon 
+* [#4699](https://github.com/apache/nuttx/pull/4699) arch: cache: add lock & unlock feature 
+* [#4910](https://github.com/apache/nuttx/pull/4910) arch: Dump task name through tcb_s::name instead of argv[0] 
+* [#4677](https://github.com/apache/nuttx/pull/4677) arch: *_cpupause:Allow a spin before taking the g_cpu_wait spinlock. 
+* [#5007](https://github.com/apache/nuttx/pull/5007) arch: assert: flush the syslog before stack dump to avoid buffer overwrite 
+* [#4942](https://github.com/apache/nuttx/pull/4942) arch: tcbinfo: fix build break if task name disabled 
+* [#4941](https://github.com/apache/nuttx/pull/4941) arch: Remove the duplicated up_tls_info implementation 
+* [#5385](https://github.com/apache/nuttx/pull/5385) arch: Toolchain.defs: Replace --print-file-name=libgcc.a with --print-libgcc-file-name 
+* [#5371](https://github.com/apache/nuttx/pull/5371) arch: Toolchain.defs: Don't expand EXTRA_LIBS immediately 
+* [#5057](https://github.com/apache/nuttx/pull/5057) arch: arm/risc-v/xtensa: enhance the task dump 
+* [#5397](https://github.com/apache/nuttx/pull/5397) arch: arm/renesas/xtensa: fix leaving from critical section 
+* [#5231](https://github.com/apache/nuttx/pull/5231) arch: arm/xtensa/risc-v: save the running registers to xcp context 
+* [#5719](https://github.com/apache/nuttx/pull/5719) arch: Move [arm|xtensa]_intstack_[alloc|top] to common header file 
+* [#5060](https://github.com/apache/nuttx/pull/5060) arch: Kconfig: Add HAVE_SYSCALL_HOOKS configs to Xtensa arch. 
+* [#4840](https://github.com/apache/nuttx/pull/4840) arch: add MTDIOCTL_PROGMEM_ERASESTATE support 
+* [#5259](https://github.com/apache/nuttx/pull/5259) arch: use HTONS, NTOHS, HTONL, NTOHL macro in kernel code 
+* [#5008](https://github.com/apache/nuttx/pull/5008) arch: assert: unify stack and register dump across platforms 
+* [#4810](https://github.com/apache/nuttx/pull/4810) arch: debug: add tools for task aware debug 
+* [#5088](https://github.com/apache/nuttx/pull/5088) arch: make/allsyms: skip the unnecessary link operation 
+* [#4749](https://github.com/apache/nuttx/pull/4749) arch: Remove FILE dump code from _up_dumponexit
+* [#5309](https://github.com/apache/nuttx/pull/5309) arch: toolchain: add libm to EXTRA_LIBS only if it is provided by the compiler 
+* [#5120](https://github.com/apache/nuttx/pull/5120) arch: signal: signal handler may cause task's state error 
+* [#4993](https://github.com/apache/nuttx/pull/4993) arch: tls: restore C89 compatibility for TLS 
 
 #### ARM
 
-* [#4816](https://github.com/apache/incubator-nuttx/pull/4816) arch: arm: Remove EXPERIMENTAL from ARCH_TRUSTZONE_XXX 
-* [#5562](https://github.com/apache/incubator-nuttx/pull/5562) arch: arm: add BUILD_KERNEL code in arm: arm_vectors.S 
-* [#4980](https://github.com/apache/incubator-nuttx/pull/4980) arch: arm: select LIBC_ARCH_ATOMIC when config ARCH_CHIP_RP2040 
-* [#4961](https://github.com/apache/incubator-nuttx/pull/4961) arch: arm: assert: fix the stack dump overflow 
-* [#4935](https://github.com/apache/incubator-nuttx/pull/4935) arch: arm: Implement TLS support 
-* [#4917](https://github.com/apache/incubator-nuttx/pull/4917) arch: arm: Kconfig: Add ARCH_HAVE_PROGMEM config 
-* [#5593](https://github.com/apache/incubator-nuttx/pull/5593) arch: arm: unify some duplicate code to common layer 
-* [#5691](https://github.com/apache/incubator-nuttx/pull/5691) arch: arm: Move setjmp to common place 
-* [#4878](https://github.com/apache/incubator-nuttx/pull/4878) arch: arm: fix unalign cacheline invalidate & add cache coherence config for semihosting option 
-* [#5744](https://github.com/apache/incubator-nuttx/pull/5744) arch: arm: timer_lowerhalf: minor improvements 
-* [#5087](https://github.com/apache/incubator-nuttx/pull/5087) arch: arm: assert: move the arm_assert to common code 
-* [#5085](https://github.com/apache/incubator-nuttx/pull/5085) arch: arm: move the backtrace implement to common code 
-* [#5084](https://github.com/apache/incubator-nuttx/pull/5084) arch: arm: select ARM_THUMB by default for Cortex-M 
-* [#5329](https://github.com/apache/incubator-nuttx/pull/5329) arch: arm: Fix make export for armv7-a SoCs 
-* [#5105](https://github.com/apache/incubator-nuttx/pull/5105) arch: arm: Fix rebase error in arm_backtrace_thumb.c 
-* [#5703](https://github.com/apache/incubator-nuttx/pull/5703) arch: arm: Support setjmp/longjmp for all socs 
-* [#5582](https://github.com/apache/incubator-nuttx/pull/5582) arch: arm: replace SYS_syscall_return hardcode from syscall 
-* [#5502](https://github.com/apache/incubator-nuttx/pull/5502) arch: arm: armv7-a: Add debug messages for addrenv
-* [#5511](https://github.com/apache/incubator-nuttx/pull/5511) arch: arm: armv7-a: Fix arm_syscall for SYS_pthread_start 
-* [#5517](https://github.com/apache/incubator-nuttx/pull/5517) arch: arm: armv7-a: fix gtm.h GTM_COMP1 and GTM_AUTO defines 
-* [#5620](https://github.com/apache/incubator-nuttx/pull/5620) arch: arm: armv7-a: Remove CONFIG_SMP guard from arm_scu.c 
-* [#5742](https://github.com/apache/incubator-nuttx/pull/5742) arch: arm: armv7-a/r: unified syscall registers dump 
-* [#5066](https://github.com/apache/incubator-nuttx/pull/5066) arch: arm: armv7-a/r: dump all registers with alias 
-* [#5354](https://github.com/apache/incubator-nuttx/pull/5354) arch: arm: armv7-a/r: cp15_invalidate_dcache_all: fix Sets mask error. 
-* [#5367](https://github.com/apache/incubator-nuttx/pull/5367) arch: arm: armv7-a/r: bugfix: fix a4 register use but not store in xxx_invalidate/flush/clean_all.S 
-* [#5558](https://github.com/apache/incubator-nuttx/pull/5558) arch: arm: armv7-a/r: fix SVC's sp restore in arm_vectors.S 
-* [#5628](https://github.com/apache/incubator-nuttx/pull/5628) arch: arm: armv7-a/r: handle swi on interrupt stack 
-* [#5734](https://github.com/apache/incubator-nuttx/pull/5734) arch: arm: armv7-a/r: set the default CPU mode to System 
-* [#5506](https://github.com/apache/incubator-nuttx/pull/5506) arch: arm: armv7-a/r: unify switch context from software interrupt 
-* [#5441](https://github.com/apache/incubator-nuttx/pull/5441) arch: arm: armv7-a/r: cache: add cp15_cache_size function and use flush/clean_all if size large than cache size 
-* [#5650](https://github.com/apache/incubator-nuttx/pull/5650) arch: arm: armv7-a/r: cache: modify hardcode in cache set/way operation 
-* [#4702](https://github.com/apache/incubator-nuttx/pull/4702) arch: arm: armv7-m,armv7-r,armv8-m:MPU Add mpu_reset and ARM_MPU_EARLY_RESET 
-* [#5477](https://github.com/apache/incubator-nuttx/pull/5477) arch: arm: armv8-m: Handle the special irq correctly in up_secure_irq 
-* [#5355](https://github.com/apache/incubator-nuttx/pull/5355) arch: arm: cortex-m: doirq: do not update the CURRENT_REGS on nested interrupt handling 
-* [#4960](https://github.com/apache/incubator-nuttx/pull/4960) arch: arm: cortex-m: backtrace: remove the push process to simplify backtrace 
-* [#4956](https://github.com/apache/incubator-nuttx/pull/4956) arch: arm: cortex-m: assert: dump all registers with alias 
-* [#4955](https://github.com/apache/incubator-nuttx/pull/4955) arch: arm: cortex-m: fault: add CFSR(Configurable Fault Status Register) Definitions 
-* [#5048](https://github.com/apache/incubator-nuttx/pull/5048) arch: arm: cortex-m: hardfault: add secure-fault handler 
-* [#4959](https://github.com/apache/incubator-nuttx/pull/4959) arch: arm: cortex-m: enhance the crash dump 
-* [#4957](https://github.com/apache/incubator-nuttx/pull/4957) arch: arm: cortex-m: hardfault: add usage/bus-fault handler 
-* [#4965](https://github.com/apache/incubator-nuttx/pull/4965) arch: arm: cortex-m23: remove mem-fault select from armv8-m baseline 
+* [#4816](https://github.com/apache/nuttx/pull/4816) arch: arm: Remove EXPERIMENTAL from ARCH_TRUSTZONE_XXX 
+* [#5562](https://github.com/apache/nuttx/pull/5562) arch: arm: add BUILD_KERNEL code in arm: arm_vectors.S 
+* [#4980](https://github.com/apache/nuttx/pull/4980) arch: arm: select LIBC_ARCH_ATOMIC when config ARCH_CHIP_RP2040 
+* [#4961](https://github.com/apache/nuttx/pull/4961) arch: arm: assert: fix the stack dump overflow 
+* [#4935](https://github.com/apache/nuttx/pull/4935) arch: arm: Implement TLS support 
+* [#4917](https://github.com/apache/nuttx/pull/4917) arch: arm: Kconfig: Add ARCH_HAVE_PROGMEM config 
+* [#5593](https://github.com/apache/nuttx/pull/5593) arch: arm: unify some duplicate code to common layer 
+* [#5691](https://github.com/apache/nuttx/pull/5691) arch: arm: Move setjmp to common place 
+* [#4878](https://github.com/apache/nuttx/pull/4878) arch: arm: fix unalign cacheline invalidate & add cache coherence config for semihosting option 
+* [#5744](https://github.com/apache/nuttx/pull/5744) arch: arm: timer_lowerhalf: minor improvements 
+* [#5087](https://github.com/apache/nuttx/pull/5087) arch: arm: assert: move the arm_assert to common code 
+* [#5085](https://github.com/apache/nuttx/pull/5085) arch: arm: move the backtrace implement to common code 
+* [#5084](https://github.com/apache/nuttx/pull/5084) arch: arm: select ARM_THUMB by default for Cortex-M 
+* [#5329](https://github.com/apache/nuttx/pull/5329) arch: arm: Fix make export for armv7-a SoCs 
+* [#5105](https://github.com/apache/nuttx/pull/5105) arch: arm: Fix rebase error in arm_backtrace_thumb.c 
+* [#5703](https://github.com/apache/nuttx/pull/5703) arch: arm: Support setjmp/longjmp for all socs 
+* [#5582](https://github.com/apache/nuttx/pull/5582) arch: arm: replace SYS_syscall_return hardcode from syscall 
+* [#5502](https://github.com/apache/nuttx/pull/5502) arch: arm: armv7-a: Add debug messages for addrenv
+* [#5511](https://github.com/apache/nuttx/pull/5511) arch: arm: armv7-a: Fix arm_syscall for SYS_pthread_start 
+* [#5517](https://github.com/apache/nuttx/pull/5517) arch: arm: armv7-a: fix gtm.h GTM_COMP1 and GTM_AUTO defines 
+* [#5620](https://github.com/apache/nuttx/pull/5620) arch: arm: armv7-a: Remove CONFIG_SMP guard from arm_scu.c 
+* [#5742](https://github.com/apache/nuttx/pull/5742) arch: arm: armv7-a/r: unified syscall registers dump 
+* [#5066](https://github.com/apache/nuttx/pull/5066) arch: arm: armv7-a/r: dump all registers with alias 
+* [#5354](https://github.com/apache/nuttx/pull/5354) arch: arm: armv7-a/r: cp15_invalidate_dcache_all: fix Sets mask error. 
+* [#5367](https://github.com/apache/nuttx/pull/5367) arch: arm: armv7-a/r: bugfix: fix a4 register use but not store in xxx_invalidate/flush/clean_all.S 
+* [#5558](https://github.com/apache/nuttx/pull/5558) arch: arm: armv7-a/r: fix SVC's sp restore in arm_vectors.S 
+* [#5628](https://github.com/apache/nuttx/pull/5628) arch: arm: armv7-a/r: handle swi on interrupt stack 
+* [#5734](https://github.com/apache/nuttx/pull/5734) arch: arm: armv7-a/r: set the default CPU mode to System 
+* [#5506](https://github.com/apache/nuttx/pull/5506) arch: arm: armv7-a/r: unify switch context from software interrupt 
+* [#5441](https://github.com/apache/nuttx/pull/5441) arch: arm: armv7-a/r: cache: add cp15_cache_size function and use flush/clean_all if size large than cache size 
+* [#5650](https://github.com/apache/nuttx/pull/5650) arch: arm: armv7-a/r: cache: modify hardcode in cache set/way operation 
+* [#4702](https://github.com/apache/nuttx/pull/4702) arch: arm: armv7-m,armv7-r,armv8-m:MPU Add mpu_reset and ARM_MPU_EARLY_RESET 
+* [#5477](https://github.com/apache/nuttx/pull/5477) arch: arm: armv8-m: Handle the special irq correctly in up_secure_irq 
+* [#5355](https://github.com/apache/nuttx/pull/5355) arch: arm: cortex-m: doirq: do not update the CURRENT_REGS on nested interrupt handling 
+* [#4960](https://github.com/apache/nuttx/pull/4960) arch: arm: cortex-m: backtrace: remove the push process to simplify backtrace 
+* [#4956](https://github.com/apache/nuttx/pull/4956) arch: arm: cortex-m: assert: dump all registers with alias 
+* [#4955](https://github.com/apache/nuttx/pull/4955) arch: arm: cortex-m: fault: add CFSR(Configurable Fault Status Register) Definitions 
+* [#5048](https://github.com/apache/nuttx/pull/5048) arch: arm: cortex-m: hardfault: add secure-fault handler 
+* [#4959](https://github.com/apache/nuttx/pull/4959) arch: arm: cortex-m: enhance the crash dump 
+* [#4957](https://github.com/apache/nuttx/pull/4957) arch: arm: cortex-m: hardfault: add usage/bus-fault handler 
+* [#4965](https://github.com/apache/nuttx/pull/4965) arch: arm: cortex-m23: remove mem-fault select from armv8-m baseline 
 
 #### EFM32
 
-* [#5587](https://github.com/apache/incubator-nuttx/pull/5587) arch: arm: efm32: Garbage configuration setting in EFM32 code 
+* [#5587](https://github.com/apache/nuttx/pull/5587) arch: arm: efm32: Garbage configuration setting in EFM32 code 
 
 #### IMX6
 
-* [#5633](https://github.com/apache/incubator-nuttx/pull/5633) arch: arm: imx6: Fix imx6 
-* [#5639](https://github.com/apache/incubator-nuttx/pull/5639) arch: arm: imx6: Add the pgheap for imx6 
+* [#5633](https://github.com/apache/nuttx/pull/5633) arch: arm: imx6: Fix imx6 
+* [#5639](https://github.com/apache/nuttx/pull/5639) arch: arm: imx6: Add the pgheap for imx6 
 
 #### IMXRT
 
-* [#4784](https://github.com/apache/incubator-nuttx/pull/4784) arch: arm: imxrt: fixes 
-* [#4717](https://github.com/apache/incubator-nuttx/pull/4717) arch: arm: imxrt: rename imxrt_lowputc to arm_lowputc and drop CONFIG_DEBUG_FEATURES 
+* [#4784](https://github.com/apache/nuttx/pull/4784) arch: arm: imxrt: fixes 
+* [#4717](https://github.com/apache/nuttx/pull/4717) arch: arm: imxrt: rename imxrt_lowputc to arm_lowputc and drop CONFIG_DEBUG_FEATURES 
 
 #### LC823450
 
-* [#4951](https://github.com/apache/incubator-nuttx/pull/4951) arch: arm: lc823450: Replace the critical section with spinlock in lc823450_serial.c 
+* [#4951](https://github.com/apache/nuttx/pull/4951) arch: arm: lc823450: Replace the critical section with spinlock in lc823450_serial.c 
 
 #### NRF52
 
-* [#5025](https://github.com/apache/incubator-nuttx/pull/5025) arch: arm: nrf52: Fixes for NRF52 SoftDevice Controller 
-* [#5032](https://github.com/apache/incubator-nuttx/pull/5032) arch: arm: nrf52: NRF52_SDC_LE_CODED_PHY not available for nrf52832 
-* [#5031](https://github.com/apache/incubator-nuttx/pull/5031) arch: arm: nrf52: small improvements for softdevice 
+* [#5025](https://github.com/apache/nuttx/pull/5025) arch: arm: nrf52: Fixes for NRF52 SoftDevice Controller 
+* [#5032](https://github.com/apache/nuttx/pull/5032) arch: arm: nrf52: NRF52_SDC_LE_CODED_PHY not available for nrf52832 
+* [#5031](https://github.com/apache/nuttx/pull/5031) arch: arm: nrf52: small improvements for softdevice 
 
 #### PHY62XX
 
-* [#5642](https://github.com/apache/incubator-nuttx/pull/5642) arch: arm: phy62xx: remove unused private header 
+* [#5642](https://github.com/apache/nuttx/pull/5642) arch: arm: phy62xx: remove unused private header 
 
 #### RP2040
 
-* [#4786](https://github.com/apache/incubator-nuttx/pull/4786) arch: arm: rp2040: support I2C_RESET 
+* [#4786](https://github.com/apache/nuttx/pull/4786) arch: arm: rp2040: support I2C_RESET 
 
 #### RTL8720C
 
-* [#5552](https://github.com/apache/incubator-nuttx/pull/5552) arch: arm: rtl8720c: Remove the unused Toolchain.defs 
+* [#5552](https://github.com/apache/nuttx/pull/5552) arch: arm: rtl8720c: Remove the unused Toolchain.defs 
 
 #### S32K1XX
 
-* [#5220](https://github.com/apache/incubator-nuttx/pull/5220) arch: arm: s32k1xx: implement uniqueid 
+* [#5220](https://github.com/apache/nuttx/pull/5220) arch: arm: s32k1xx: implement uniqueid 
 
 #### SAM34
 
-* [#5700](https://github.com/apache/incubator-nuttx/pull/5700) arch: arm: sam34: sam_dmac.c: Fix compilation error 
+* [#5700](https://github.com/apache/nuttx/pull/5700) arch: arm: sam34: sam_dmac.c: Fix compilation error 
 
 #### SAMV7
 
-* [#5513](https://github.com/apache/incubator-nuttx/pull/5513) arch: arm: samv7: fix peripheral id shift during transmit xdma configuration 
-* [#5413](https://github.com/apache/incubator-nuttx/pull/5413) arch: arm: samv7: sam_progmem: insert DMB instruction into data write loop 
-* [#5411](https://github.com/apache/incubator-nuttx/pull/5411) arch: arm: samv7: add arm_systemreset.c to CMN_CSRCS 
-* [#5471](https://github.com/apache/incubator-nuttx/pull/5471) arch: arm: samv7: Added support for PWM driver
-* [#4795](https://github.com/apache/incubator-nuttx/pull/4795) arch: arm: samv7: add support for AFEC driver 
-* [#4737](https://github.com/apache/incubator-nuttx/pull/4737) arch: arm: samv7: add support for QSPI driver in SPI Mode 
-* [#5145](https://github.com/apache/incubator-nuttx/pull/5145) arch: arm: samv7: correct number on interrupts 
-* [#4950](https://github.com/apache/incubator-nuttx/pull/4950) arch: arm: samv7: enable MCAN driver support for both rev A and rev B 
-* [#4901](https://github.com/apache/incubator-nuttx/pull/4901) arch: arm: samv7: Add DMA and TC support to AFEC (ADC) driver 
-* [#5146](https://github.com/apache/incubator-nuttx/pull/5146) arch: arm: samv7: rework SAMv7 timer counter implementation 
-* [#5219](https://github.com/apache/incubator-nuttx/pull/5219) arch: arm: samv7: implement quadrature encoder driver 
-* [#5043](https://github.com/apache/incubator-nuttx/pull/5043) arch: arm: samv7: initial support for LIN bus communication (Master only) 
-* [#4904](https://github.com/apache/incubator-nuttx/pull/4904) arch: arm: samv7: fix unaligned address write for progmem interface 
-* [#4899](https://github.com/apache/incubator-nuttx/pull/4899) arch: arm: samv7: fix page size flash writing for page unaligned addresses 
-* [#5393](https://github.com/apache/incubator-nuttx/pull/5393) arch: arm: samv7: fix leaving from critical section in HSMCI callback 
+* [#5513](https://github.com/apache/nuttx/pull/5513) arch: arm: samv7: fix peripheral id shift during transmit xdma configuration 
+* [#5413](https://github.com/apache/nuttx/pull/5413) arch: arm: samv7: sam_progmem: insert DMB instruction into data write loop 
+* [#5411](https://github.com/apache/nuttx/pull/5411) arch: arm: samv7: add arm_systemreset.c to CMN_CSRCS 
+* [#5471](https://github.com/apache/nuttx/pull/5471) arch: arm: samv7: Added support for PWM driver
+* [#4795](https://github.com/apache/nuttx/pull/4795) arch: arm: samv7: add support for AFEC driver 
+* [#4737](https://github.com/apache/nuttx/pull/4737) arch: arm: samv7: add support for QSPI driver in SPI Mode 
+* [#5145](https://github.com/apache/nuttx/pull/5145) arch: arm: samv7: correct number on interrupts 
+* [#4950](https://github.com/apache/nuttx/pull/4950) arch: arm: samv7: enable MCAN driver support for both rev A and rev B 
+* [#4901](https://github.com/apache/nuttx/pull/4901) arch: arm: samv7: Add DMA and TC support to AFEC (ADC) driver 
+* [#5146](https://github.com/apache/nuttx/pull/5146) arch: arm: samv7: rework SAMv7 timer counter implementation 
+* [#5219](https://github.com/apache/nuttx/pull/5219) arch: arm: samv7: implement quadrature encoder driver 
+* [#5043](https://github.com/apache/nuttx/pull/5043) arch: arm: samv7: initial support for LIN bus communication (Master only) 
+* [#4904](https://github.com/apache/nuttx/pull/4904) arch: arm: samv7: fix unaligned address write for progmem interface 
+* [#4899](https://github.com/apache/nuttx/pull/4899) arch: arm: samv7: fix page size flash writing for page unaligned addresses 
+* [#5393](https://github.com/apache/nuttx/pull/5393) arch: arm: samv7: fix leaving from critical section in HSMCI callback 
 
 #### STM32
 
-* [#5206](https://github.com/apache/incubator-nuttx/pull/5206) arch: arm: stm32: add FDCAN support 
-* [#5169](https://github.com/apache/incubator-nuttx/pull/5169) arch: arm: stm32: add SocketCAN support 
-* [#5167](https://github.com/apache/incubator-nuttx/pull/5167) arch: arm: stm32: add CAN error support 
-* [#5419](https://github.com/apache/incubator-nuttx/pull/5419) arch: arm: stm32: add FDCAN SocketCAN support 
-* [#5523](https://github.com/apache/incubator-nuttx/pull/5523) arch: arm: stm32: dp83848c ethernet phy interrupt support 
-* [#5481](https://github.com/apache/incubator-nuttx/pull/5481) arch: arm: stm32: fdcan: add CAN FD frames support 
-* [#5370](https://github.com/apache/incubator-nuttx/pull/5370) arch: arm: stm32: Add OTG ID GPIO disable 
-* [#4790](https://github.com/apache/incubator-nuttx/pull/4790) arch: arm: stm32: Qencoder: add support for the encoder index pin and implementation for stm32/qenco 
-* [#5627](https://github.com/apache/incubator-nuttx/pull/5627) arch: arm: stm32f103re has a dac module.but the pinmap file has no corresponding
-* [#5300](https://github.com/apache/incubator-nuttx/pull/5300) arch: arm: stm32f20xxf40xx: up_progmem_erasesize for stm32f20xxf40xx_flash.c 
-* [#5605](https://github.com/apache/incubator-nuttx/pull/5605) arch: arm: stm32f405: Add DAC2 configuration 
-* [#4967](https://github.com/apache/incubator-nuttx/pull/4967) arch: arm: stm32f412: add SPI2 & SPI3 
-* [#5267](https://github.com/apache/incubator-nuttx/pull/5267) arch: arm: stm32f7: serial fix PM_CONFIG build 
-* [#5064](https://github.com/apache/incubator-nuttx/pull/5064) arch: arm: stm32f7: sdmmc invalidate before DMA to avoid eviction overwrite -
-* [#4704](https://github.com/apache/incubator-nuttx/pull/4704) arch: arm: stm32f0/g0/l0: Add custom clock config option to stm32f0/g0/l0 chips 
-* [#4872](https://github.com/apache/incubator-nuttx/pull/4872) arch: arm: stm32f7: sdmmc defer invalidate until after DMA completion 
-* [#5677](https://github.com/apache/incubator-nuttx/pull/5677) arch: arm: stm32f7: fix CAN3 receiving 
-* [#4741](https://github.com/apache/incubator-nuttx/pull/4741) arch: arm: stm32g4: Minor fixes for stm32g4 foc 
-* [#4780](https://github.com/apache/incubator-nuttx/pull/4780) arch: arm: stm32h7: sdmmc: do not enable power saving configuration bit in SD 4-bit mode 
-* [#4770](https://github.com/apache/incubator-nuttx/pull/4770) arch: arm: stm32h7: dmamux: correct bit fields 
-* [#4755](https://github.com/apache/incubator-nuttx/pull/4755) arch: arm: stm32h7: sdmmc: added missing sdio_set_sdio_card_isr() function to initialize SDIO in-band interrupt logic 
-* [#4731](https://github.com/apache/incubator-nuttx/pull/4731) arch: arm: stm32h7: add low power timers 
-* [#5492](https://github.com/apache/incubator-nuttx/pull/5492) arch: arm: stm32h7: Fix build for all config {R|T}XDMA states 
-* [#5493](https://github.com/apache/incubator-nuttx/pull/5493) arch: arm: stm32h7: Flash fixes from 328374f4658d11655f268f968f4c6c7a3942f320 
-* [#4815](https://github.com/apache/incubator-nuttx/pull/4815) arch: arm: stm32l4: dfumode: enable for STM32L4+ chips 
-* [#5666](https://github.com/apache/incubator-nuttx/pull/5666) arch: arm: stm32l4: stm32l4+ might need flash data cache corruption workaround 
-* [#4975](https://github.com/apache/incubator-nuttx/pull/4975) arch: arm: stm32l4: stm32l4_pwm.c: fix printf format 
+* [#5206](https://github.com/apache/nuttx/pull/5206) arch: arm: stm32: add FDCAN support 
+* [#5169](https://github.com/apache/nuttx/pull/5169) arch: arm: stm32: add SocketCAN support 
+* [#5167](https://github.com/apache/nuttx/pull/5167) arch: arm: stm32: add CAN error support 
+* [#5419](https://github.com/apache/nuttx/pull/5419) arch: arm: stm32: add FDCAN SocketCAN support 
+* [#5523](https://github.com/apache/nuttx/pull/5523) arch: arm: stm32: dp83848c ethernet phy interrupt support 
+* [#5481](https://github.com/apache/nuttx/pull/5481) arch: arm: stm32: fdcan: add CAN FD frames support 
+* [#5370](https://github.com/apache/nuttx/pull/5370) arch: arm: stm32: Add OTG ID GPIO disable 
+* [#4790](https://github.com/apache/nuttx/pull/4790) arch: arm: stm32: Qencoder: add support for the encoder index pin and implementation for stm32/qenco 
+* [#5627](https://github.com/apache/nuttx/pull/5627) arch: arm: stm32f103re has a dac module.but the pinmap file has no corresponding
+* [#5300](https://github.com/apache/nuttx/pull/5300) arch: arm: stm32f20xxf40xx: up_progmem_erasesize for stm32f20xxf40xx_flash.c 
+* [#5605](https://github.com/apache/nuttx/pull/5605) arch: arm: stm32f405: Add DAC2 configuration 
+* [#4967](https://github.com/apache/nuttx/pull/4967) arch: arm: stm32f412: add SPI2 & SPI3 
+* [#5267](https://github.com/apache/nuttx/pull/5267) arch: arm: stm32f7: serial fix PM_CONFIG build 
+* [#5064](https://github.com/apache/nuttx/pull/5064) arch: arm: stm32f7: sdmmc invalidate before DMA to avoid eviction overwrite -
+* [#4704](https://github.com/apache/nuttx/pull/4704) arch: arm: stm32f0/g0/l0: Add custom clock config option to stm32f0/g0/l0 chips 
+* [#4872](https://github.com/apache/nuttx/pull/4872) arch: arm: stm32f7: sdmmc defer invalidate until after DMA completion 
+* [#5677](https://github.com/apache/nuttx/pull/5677) arch: arm: stm32f7: fix CAN3 receiving 
+* [#4741](https://github.com/apache/nuttx/pull/4741) arch: arm: stm32g4: Minor fixes for stm32g4 foc 
+* [#4780](https://github.com/apache/nuttx/pull/4780) arch: arm: stm32h7: sdmmc: do not enable power saving configuration bit in SD 4-bit mode 
+* [#4770](https://github.com/apache/nuttx/pull/4770) arch: arm: stm32h7: dmamux: correct bit fields 
+* [#4755](https://github.com/apache/nuttx/pull/4755) arch: arm: stm32h7: sdmmc: added missing sdio_set_sdio_card_isr() function to initialize SDIO in-band interrupt logic 
+* [#4731](https://github.com/apache/nuttx/pull/4731) arch: arm: stm32h7: add low power timers 
+* [#5492](https://github.com/apache/nuttx/pull/5492) arch: arm: stm32h7: Fix build for all config {R|T}XDMA states 
+* [#5493](https://github.com/apache/nuttx/pull/5493) arch: arm: stm32h7: Flash fixes from 328374f4658d11655f268f968f4c6c7a3942f320 
+* [#4815](https://github.com/apache/nuttx/pull/4815) arch: arm: stm32l4: dfumode: enable for STM32L4+ chips 
+* [#5666](https://github.com/apache/nuttx/pull/5666) arch: arm: stm32l4: stm32l4+ might need flash data cache corruption workaround 
+* [#4975](https://github.com/apache/nuttx/pull/4975) arch: arm: stm32l4: stm32l4_pwm.c: fix printf format 
 
 #### CEVA
 
-* [#5520](https://github.com/apache/incubator-nuttx/pull/5520) arch: ceva: update the code to the latest mainline 
-* [#5568](https://github.com/apache/incubator-nuttx/pull/5568) arch: ceva: Replace OUTDIR with TOPDIR 
-* [#5727](https://github.com/apache/incubator-nuttx/pull/5727) arch: ceva: Move the idle stack initialization to up_initial_state 
+* [#5520](https://github.com/apache/nuttx/pull/5520) arch: ceva: update the code to the latest mainline 
+* [#5568](https://github.com/apache/nuttx/pull/5568) arch: ceva: Replace OUTDIR with TOPDIR 
+* [#5727](https://github.com/apache/nuttx/pull/5727) arch: ceva: Move the idle stack initialization to up_initial_state 
 
 #### SIM
 
-* [#5696](https://github.com/apache/incubator-nuttx/pull/5696) arch: sim: add all symbols support 
-* [#5641](https://github.com/apache/incubator-nuttx/pull/5641) arch: sim: add loop thread to handle dev loops 
-* [#4716](https://github.com/apache/incubator-nuttx/pull/4716) arch: sim: add native socket support based on usrsock 
-* [#4882](https://github.com/apache/incubator-nuttx/pull/4882) arch: sim: Add new option to enable arch specific hostfs 
-* [#4776](https://github.com/apache/incubator-nuttx/pull/4776) arch: sim: host ASAN improvement 
-* [#5401](https://github.com/apache/incubator-nuttx/pull/5401) arch: sim: initial support sim:nsh on MacOS M1 based hosts. 
-* [#5452](https://github.com/apache/incubator-nuttx/pull/5452) arch: sim: detect clang native compiler on MacOS. 
-* [#5414](https://github.com/apache/incubator-nuttx/pull/5414) arch: sim: Unify the return value of usrsock_xxx_handler 
-* [#5473](https://github.com/apache/incubator-nuttx/pull/5473) arch: sim: Always typedef xcpt_reg_t to unsigned long 
-* [#4751](https://github.com/apache/incubator-nuttx/pull/4751) arch: arm: Add l suffix for INT32_C macro 
-* [#5099](https://github.com/apache/incubator-nuttx/pull/5099) arch: sim: Implement up_backtrace 
-* [#5071](https://github.com/apache/incubator-nuttx/pull/5071) arch: sim: Support vncserver as display device 
-* [#4977](https://github.com/apache/incubator-nuttx/pull/4977) arch: sim: add CONFIG_SIM_STACKSIZE_ADJUSTMENT to reduce variability 
-* [#5384](https://github.com/apache/incubator-nuttx/pull/5384) arch: sim: Adjust the stack size for up_use_stack too 
-* [#5486](https://github.com/apache/incubator-nuttx/pull/5486) arch: sim: Fix a build with clang on linux 
-* [#5295](https://github.com/apache/incubator-nuttx/pull/5295) arch: sim: Added Kconfig option for UART buffer size. 
-* [#5188](https://github.com/apache/incubator-nuttx/pull/5188) arch: sim: Rename up_vfork_x[32|64].S to up_vfork_x86[_64].S 
-* [#5179](https://github.com/apache/incubator-nuttx/pull/5179) arch: sim: Move spiflash simulation to drivers/spi instead 
-* [#5178](https://github.com/apache/incubator-nuttx/pull/5178) arch: sim: Rename up_vfork[32|64].S to up_vfork_x[32|64].S 
-* [#5431](https://github.com/apache/incubator-nuttx/pull/5431) arch: sim: Don't add up_tls_size in up_use_stack before foward to up_create_stack 
-* [#4487](https://github.com/apache/incubator-nuttx/pull/4487) arch: sim: Don't add -lc++abi to STDLIBS 
-* [#4791](https://github.com/apache/incubator-nuttx/pull/4791) arch: sim: btuart: Remove the unnecessary config 
-* [#5313](https://github.com/apache/incubator-nuttx/pull/5313) arch: sim: netdev: retrieve all the queued RX frames from the network device on every poll 
-* [#4696](https://github.com/apache/incubator-nuttx/pull/4696) arch: sim: rptun: Trigger the callback only the sequnece number change 
-* [#5286](https://github.com/apache/incubator-nuttx/pull/5286) arch: sim: up_macho_init.c: Add a workaround for Monterey 
-* [#5046](https://github.com/apache/incubator-nuttx/pull/5046) arch: sim: usrsock: increase the sim usrsock buffer size 
-* [#5030](https://github.com/apache/incubator-nuttx/pull/5030) arch: sim: usrsock: reuse the socket address to avoid bind timeout 
-* [#5685](https://github.com/apache/incubator-nuttx/pull/5685) arch: sim: syscall: add syscall note support in the flat build 
-* [#4754](https://github.com/apache/incubator-nuttx/pull/4754) Revert "sim: Specify -fshort-wchar as NuttX wchar_t is 16-bit" 
-* [#5343](https://github.com/apache/incubator-nuttx/pull/5343) arch: sim: netdev,tapdev: implemented emulation of TX done and RX ready interrupts 
-* [#5295](https://github.com/apache/incubator-nuttx/pull/5295) arch: sim: Added Kconfig option for UART buffer size.
-* [#5260](https://github.com/apache/incubator-nuttx/pull/5260) arch: sim: up_touchscreen: update up_touchscreen, using touch_upperhalf 
-* [#5226](https://github.com/apache/incubator-nuttx/pull/5226) arch: sim: netdev: eliminated RX data stream congestion in case of high TX network traffic 
+* [#5696](https://github.com/apache/nuttx/pull/5696) arch: sim: add all symbols support 
+* [#5641](https://github.com/apache/nuttx/pull/5641) arch: sim: add loop thread to handle dev loops 
+* [#4716](https://github.com/apache/nuttx/pull/4716) arch: sim: add native socket support based on usrsock 
+* [#4882](https://github.com/apache/nuttx/pull/4882) arch: sim: Add new option to enable arch specific hostfs 
+* [#4776](https://github.com/apache/nuttx/pull/4776) arch: sim: host ASAN improvement 
+* [#5401](https://github.com/apache/nuttx/pull/5401) arch: sim: initial support sim:nsh on MacOS M1 based hosts. 
+* [#5452](https://github.com/apache/nuttx/pull/5452) arch: sim: detect clang native compiler on MacOS. 
+* [#5414](https://github.com/apache/nuttx/pull/5414) arch: sim: Unify the return value of usrsock_xxx_handler 
+* [#5473](https://github.com/apache/nuttx/pull/5473) arch: sim: Always typedef xcpt_reg_t to unsigned long 
+* [#4751](https://github.com/apache/nuttx/pull/4751) arch: arm: Add l suffix for INT32_C macro 
+* [#5099](https://github.com/apache/nuttx/pull/5099) arch: sim: Implement up_backtrace 
+* [#5071](https://github.com/apache/nuttx/pull/5071) arch: sim: Support vncserver as display device 
+* [#4977](https://github.com/apache/nuttx/pull/4977) arch: sim: add CONFIG_SIM_STACKSIZE_ADJUSTMENT to reduce variability 
+* [#5384](https://github.com/apache/nuttx/pull/5384) arch: sim: Adjust the stack size for up_use_stack too 
+* [#5486](https://github.com/apache/nuttx/pull/5486) arch: sim: Fix a build with clang on linux 
+* [#5295](https://github.com/apache/nuttx/pull/5295) arch: sim: Added Kconfig option for UART buffer size. 
+* [#5188](https://github.com/apache/nuttx/pull/5188) arch: sim: Rename up_vfork_x[32|64].S to up_vfork_x86[_64].S 
+* [#5179](https://github.com/apache/nuttx/pull/5179) arch: sim: Move spiflash simulation to drivers/spi instead 
+* [#5178](https://github.com/apache/nuttx/pull/5178) arch: sim: Rename up_vfork[32|64].S to up_vfork_x[32|64].S 
+* [#5431](https://github.com/apache/nuttx/pull/5431) arch: sim: Don't add up_tls_size in up_use_stack before foward to up_create_stack 
+* [#4487](https://github.com/apache/nuttx/pull/4487) arch: sim: Don't add -lc++abi to STDLIBS 
+* [#4791](https://github.com/apache/nuttx/pull/4791) arch: sim: btuart: Remove the unnecessary config 
+* [#5313](https://github.com/apache/nuttx/pull/5313) arch: sim: netdev: retrieve all the queued RX frames from the network device on every poll 
+* [#4696](https://github.com/apache/nuttx/pull/4696) arch: sim: rptun: Trigger the callback only the sequnece number change 
+* [#5286](https://github.com/apache/nuttx/pull/5286) arch: sim: up_macho_init.c: Add a workaround for Monterey 
+* [#5046](https://github.com/apache/nuttx/pull/5046) arch: sim: usrsock: increase the sim usrsock buffer size 
+* [#5030](https://github.com/apache/nuttx/pull/5030) arch: sim: usrsock: reuse the socket address to avoid bind timeout 
+* [#5685](https://github.com/apache/nuttx/pull/5685) arch: sim: syscall: add syscall note support in the flat build 
+* [#4754](https://github.com/apache/nuttx/pull/4754) Revert "sim: Specify -fshort-wchar as NuttX wchar_t is 16-bit" 
+* [#5343](https://github.com/apache/nuttx/pull/5343) arch: sim: netdev,tapdev: implemented emulation of TX done and RX ready interrupts 
+* [#5295](https://github.com/apache/nuttx/pull/5295) arch: sim: Added Kconfig option for UART buffer size.
+* [#5260](https://github.com/apache/nuttx/pull/5260) arch: sim: up_touchscreen: update up_touchscreen, using touch_upperhalf 
+* [#5226](https://github.com/apache/nuttx/pull/5226) arch: sim: netdev: eliminated RX data stream congestion in case of high TX network traffic 
 
 #### RISC-V
 
-* [#5619](https://github.com/apache/incubator-nuttx/pull/5619) arch: espressif: Fix SCHED_CPULOAD feature using Oneshot Timer 
-* [#4728](https://github.com/apache/incubator-nuttx/pull/4728) arch: espressif: Rename MTD-related configs to become more intuitive 
-* [#5044](https://github.com/apache/incubator-nuttx/pull/5044) arch: espressif: Add hardware-supported Secure Boot on top of MCUboot 
-* [#4671](https://github.com/apache/incubator-nuttx/pull/4671) arch: espressif: Provide SPI Flash parameters to MCUboot build 
-* [#5173](https://github.com/apache/incubator-nuttx/pull/5173) arch: espressif: Fix build system issues related to Flash Encryption 
-* [#5619](https://github.com/apache/incubator-nuttx/pull/5619) arch: espressif: Fix SCHED_CPULOAD feature using Oneshot Timer 
-* [#4727](https://github.com/apache/incubator-nuttx/pull/4727) arch: espressif: Enable Partition Table allocation at custom offset 
-* [#4945](https://github.com/apache/incubator-nuttx/pull/4945) arch: risc-v: Introduce basic support for qemu rv32 
-* [#5291](https://github.com/apache/incubator-nuttx/pull/5291) arch: risc-v: Unify common irq code 
-* [#5192](https://github.com/apache/incubator-nuttx/pull/5192) arch: risc-v: Merge rv32im and rv64gc into common 
-* [#5228](https://github.com/apache/incubator-nuttx/pull/5228) arch: risc-v: Support both rv32/rv64 on qemu-rv 
-* [#5160](https://github.com/apache/incubator-nuttx/pull/5160) arch: risc-v: Replace __LP64__ with CONFIG_ARCH_RV64 
-* [#5148](https://github.com/apache/incubator-nuttx/pull/5148) arch: risc-v: Refine riscv_assert.c and arch.h 
-* [#5243](https://github.com/apache/incubator-nuttx/pull/5243) arch: risc-v: Make exception_common 8 byte align 
-* [#5709](https://github.com/apache/incubator-nuttx/pull/5709) arch: risc-v: mpfs: Make cleaner pinmux configurations for USB 
-* [#5209](https://github.com/apache/incubator-nuttx/pull/5209) arch: risc-v: Refine riscv_vectors.S 
-* [#5123](https://github.com/apache/incubator-nuttx/pull/5123) arch: risc-v: Correct epc adjustment with C ISA 
-* [#5106](https://github.com/apache/incubator-nuttx/pull/5106) arch: risc-v: Refine riscv_testset.S 
-* [#5076](https://github.com/apache/incubator-nuttx/pull/5076) arch: risc-v: Refine Toolchain.defs 
-* [#5097](https://github.com/apache/incubator-nuttx/pull/5097) arch: risc-v: Move riscv_blocktask.c to common 
-* [#5092](https://github.com/apache/incubator-nuttx/pull/5092) arch: risc-v: Remove unneeded kconfigs 
-* [#5064](https://github.com/apache/incubator-nuttx/pull/5064) arch: risc-v: opensbi: Make.defs: use a wildcard for file listing 
-* [#5314](https://github.com/apache/incubator-nuttx/pull/5314) arch: risc-v: Move xxx_cpustart.c to common 
-* [#5103](https://github.com/apache/incubator-nuttx/pull/5103) arch: risc-v: Refine riscv_fpu.S 
-* [#5273](https://github.com/apache/incubator-nuttx/pull/5273) arch: risc-v: Sv39 MMU driver
-* [#5135](https://github.com/apache/incubator-nuttx/pull/5135) arch: risc-v: Refine riscv_initialstate.c 
-* [#5115](https://github.com/apache/incubator-nuttx/pull/5115) arch: risc-v: Refine syscall interface 
-* [#5113](https://github.com/apache/incubator-nuttx/pull/5113) arch: risc-v: Add backtrace to risc-v common sources 
-* [#4983](https://github.com/apache/incubator-nuttx/pull/4983) arch: risc-v: Implement TLS support 
-* [#5707](https://github.com/apache/incubator-nuttx/pull/5707) arch: risc-v: Implement SYS_save_context in swint 
-* [#5695](https://github.com/apache/incubator-nuttx/pull/5695) arch: risc-v: Save/Load float register in setjmp 
-* [#5478](https://github.com/apache/incubator-nuttx/pull/5478) arch: risc-v: Use _ebss instead of _default_stack_limit as idle stack base
-* [#5484](https://github.com/apache/incubator-nuttx/pull/5484) arch: risc-v: Implement common up_cpu_idlestack 
-* [#5490](https://github.com/apache/incubator-nuttx/pull/5490) arch: risc-v: Let g_cpu_basestack determined at compile time 
-* [#5091](https://github.com/apache/incubator-nuttx/pull/5091) arch: risc-v: pwm: add option to break the loops when using multiple PWM channels 
-* [#5454](https://github.com/apache/incubator-nuttx/pull/5454) arch: risc-v: Remove duplicated up_idle logic 
-* [#5358](https://github.com/apache/incubator-nuttx/pull/5358) arch: risc-v: RISC-V MMU: Add missing implementation for PTE getter 
-* [#5240](https://github.com/apache/incubator-nuttx/pull/5240) arch: risc-v: Refine riscv_cpupause.c 
-* [#5308](https://github.com/apache/incubator-nuttx/pull/5308) arch: risc-v: Merge mcause.h into irq.h 
-* [#5210](https://github.com/apache/incubator-nuttx/pull/5210) arch: risc-v: Refine exception_common 
-* [#5236](https://github.com/apache/incubator-nuttx/pull/5236) arch: risc-v: Refine riscv_cpuindex.c 
+* [#5619](https://github.com/apache/nuttx/pull/5619) arch: espressif: Fix SCHED_CPULOAD feature using Oneshot Timer 
+* [#4728](https://github.com/apache/nuttx/pull/4728) arch: espressif: Rename MTD-related configs to become more intuitive 
+* [#5044](https://github.com/apache/nuttx/pull/5044) arch: espressif: Add hardware-supported Secure Boot on top of MCUboot 
+* [#4671](https://github.com/apache/nuttx/pull/4671) arch: espressif: Provide SPI Flash parameters to MCUboot build 
+* [#5173](https://github.com/apache/nuttx/pull/5173) arch: espressif: Fix build system issues related to Flash Encryption 
+* [#5619](https://github.com/apache/nuttx/pull/5619) arch: espressif: Fix SCHED_CPULOAD feature using Oneshot Timer 
+* [#4727](https://github.com/apache/nuttx/pull/4727) arch: espressif: Enable Partition Table allocation at custom offset 
+* [#4945](https://github.com/apache/nuttx/pull/4945) arch: risc-v: Introduce basic support for qemu rv32 
+* [#5291](https://github.com/apache/nuttx/pull/5291) arch: risc-v: Unify common irq code 
+* [#5192](https://github.com/apache/nuttx/pull/5192) arch: risc-v: Merge rv32im and rv64gc into common 
+* [#5228](https://github.com/apache/nuttx/pull/5228) arch: risc-v: Support both rv32/rv64 on qemu-rv 
+* [#5160](https://github.com/apache/nuttx/pull/5160) arch: risc-v: Replace __LP64__ with CONFIG_ARCH_RV64 
+* [#5148](https://github.com/apache/nuttx/pull/5148) arch: risc-v: Refine riscv_assert.c and arch.h 
+* [#5243](https://github.com/apache/nuttx/pull/5243) arch: risc-v: Make exception_common 8 byte align 
+* [#5709](https://github.com/apache/nuttx/pull/5709) arch: risc-v: mpfs: Make cleaner pinmux configurations for USB 
+* [#5209](https://github.com/apache/nuttx/pull/5209) arch: risc-v: Refine riscv_vectors.S 
+* [#5123](https://github.com/apache/nuttx/pull/5123) arch: risc-v: Correct epc adjustment with C ISA 
+* [#5106](https://github.com/apache/nuttx/pull/5106) arch: risc-v: Refine riscv_testset.S 
+* [#5076](https://github.com/apache/nuttx/pull/5076) arch: risc-v: Refine Toolchain.defs 
+* [#5097](https://github.com/apache/nuttx/pull/5097) arch: risc-v: Move riscv_blocktask.c to common 
+* [#5092](https://github.com/apache/nuttx/pull/5092) arch: risc-v: Remove unneeded kconfigs 
+* [#5064](https://github.com/apache/nuttx/pull/5064) arch: risc-v: opensbi: Make.defs: use a wildcard for file listing 
+* [#5314](https://github.com/apache/nuttx/pull/5314) arch: risc-v: Move xxx_cpustart.c to common 
+* [#5103](https://github.com/apache/nuttx/pull/5103) arch: risc-v: Refine riscv_fpu.S 
+* [#5273](https://github.com/apache/nuttx/pull/5273) arch: risc-v: Sv39 MMU driver
+* [#5135](https://github.com/apache/nuttx/pull/5135) arch: risc-v: Refine riscv_initialstate.c 
+* [#5115](https://github.com/apache/nuttx/pull/5115) arch: risc-v: Refine syscall interface 
+* [#5113](https://github.com/apache/nuttx/pull/5113) arch: risc-v: Add backtrace to risc-v common sources 
+* [#4983](https://github.com/apache/nuttx/pull/4983) arch: risc-v: Implement TLS support 
+* [#5707](https://github.com/apache/nuttx/pull/5707) arch: risc-v: Implement SYS_save_context in swint 
+* [#5695](https://github.com/apache/nuttx/pull/5695) arch: risc-v: Save/Load float register in setjmp 
+* [#5478](https://github.com/apache/nuttx/pull/5478) arch: risc-v: Use _ebss instead of _default_stack_limit as idle stack base
+* [#5484](https://github.com/apache/nuttx/pull/5484) arch: risc-v: Implement common up_cpu_idlestack 
+* [#5490](https://github.com/apache/nuttx/pull/5490) arch: risc-v: Let g_cpu_basestack determined at compile time 
+* [#5091](https://github.com/apache/nuttx/pull/5091) arch: risc-v: pwm: add option to break the loops when using multiple PWM channels 
+* [#5454](https://github.com/apache/nuttx/pull/5454) arch: risc-v: Remove duplicated up_idle logic 
+* [#5358](https://github.com/apache/nuttx/pull/5358) arch: risc-v: RISC-V MMU: Add missing implementation for PTE getter 
+* [#5240](https://github.com/apache/nuttx/pull/5240) arch: risc-v: Refine riscv_cpupause.c 
+* [#5308](https://github.com/apache/nuttx/pull/5308) arch: risc-v: Merge mcause.h into irq.h 
+* [#5210](https://github.com/apache/nuttx/pull/5210) arch: risc-v: Refine exception_common 
+* [#5236](https://github.com/apache/nuttx/pull/5236) arch: risc-v: Refine riscv_cpuindex.c 
 
 #### BL602
 
-* [#5316](https://github.com/apache/incubator-nuttx/pull/5316) arch: risc-v: bl602: Fix broken bl602 flash due to partition_table being incorrectly marked as unused 
-* [#5221](https://github.com/apache/incubator-nuttx/pull/5221) arch: risc-v: bl602: Rename bl602_entry.S to bl602_head.S 
-* [#4876](https://github.com/apache/incubator-nuttx/pull/4876) arch: risc-v: bl602: Enable GPIO output 
-* [#4984](https://github.com/apache/incubator-nuttx/pull/4984) arch: risc-v: bl602: Swap SPI MISO and MOSI 
-* [#5131](https://github.com/apache/incubator-nuttx/pull/5131) arch: risc-v: bl602: Fix preprocessing directives for uart flow control 
-* [#5093](https://github.com/apache/incubator-nuttx/pull/5093) arch: risc-v: bl602: Use userspace chosen channel numbers when starting bl602 pwm 
+* [#5316](https://github.com/apache/nuttx/pull/5316) arch: risc-v: bl602: Fix broken bl602 flash due to partition_table being incorrectly marked as unused 
+* [#5221](https://github.com/apache/nuttx/pull/5221) arch: risc-v: bl602: Rename bl602_entry.S to bl602_head.S 
+* [#4876](https://github.com/apache/nuttx/pull/4876) arch: risc-v: bl602: Enable GPIO output 
+* [#4984](https://github.com/apache/nuttx/pull/4984) arch: risc-v: bl602: Swap SPI MISO and MOSI 
+* [#5131](https://github.com/apache/nuttx/pull/5131) arch: risc-v: bl602: Fix preprocessing directives for uart flow control 
+* [#5093](https://github.com/apache/nuttx/pull/5093) arch: risc-v: bl602: Use userspace chosen channel numbers when starting bl602 pwm 
 
 #### ESP32C3
 
-* [#5129](https://github.com/apache/incubator-nuttx/pull/5129) arch: risc-v: esp32c3: SPI flash MTD device uses all flash space 
-* [#4771](https://github.com/apache/incubator-nuttx/pull/4771) arch: risc-v: esp32c3: Remove the DMA test included in the driver along with its defconfig. 
-* [#4700](https://github.com/apache/incubator-nuttx/pull/4700) arch: risc-v: esp32c3: Remove test code from crypto accelerators drivers. 
-* [#4711](https://github.com/apache/incubator-nuttx/pull/4711) arch: risc-v: esp32c3: Remove the stub implementations of the early serial 
-* [#5615](https://github.com/apache/incubator-nuttx/pull/5615) arch: risc-v: esp32c3: Fix detection of CPU reset by Watchdog Timer 
-* [#4796](https://github.com/apache/incubator-nuttx/pull/4796) arch: risc-v: esp32c3: Fix MMU pages number calculation error 
-* [#4820](https://github.com/apache/incubator-nuttx/pull/4820) arch: risc-v: esp32c3: Partition supports BIO cmd 
-* [#4821](https://github.com/apache/incubator-nuttx/pull/4821) arch: risc-v: esp32c3: Add hardware brownout check and reset 
-* [#4834](https://github.com/apache/incubator-nuttx/pull/4834) arch: risc-v: esp32c3: esp32c3_usbserial.c: Initialize cpuint to ENOMEM. 
-* [#4813](https://github.com/apache/incubator-nuttx/pull/4813) arch: risc-v: esp32c3: Fix GPIO Output on pins 18 and 19 USB/JTAG 
-* [#4809](https://github.com/apache/incubator-nuttx/pull/4809) arch: risc-v: esp32c3: Driver for the ESP32-C3's CDC console. 
-* [#5615](https://github.com/apache/incubator-nuttx/pull/5615) arch: risc-v: esp32c3: Fix detection of CPU reset by Watchdog Timer 
-* [#4787](https://github.com/apache/incubator-nuttx/pull/4787) arch: risc-v: esp32c3: Initialize the BLE Mac 
-* [#4822](https://github.com/apache/incubator-nuttx/pull/4822) arch: risc-v: esp32c3: Fix reset triggering crash nested when crash 
-* [#4740](https://github.com/apache/incubator-nuttx/pull/4740) arch: risc-v: esp32c3: Fix Wi-Fi & BLE coexist issues 
-* [#4886](https://github.com/apache/incubator-nuttx/pull/4886) arch: risc-v: esp32c3: Refactor SPI Flash to support umask interrupt when R/W/E SPI Flash 
-* [#4885](https://github.com/apache/incubator-nuttx/pull/4885) arch: risc-v: esp32c3: Refactor ADC calibration 
-* [#5616](https://github.com/apache/incubator-nuttx/pull/5616) arch: risc-v: esp32c3: Enable Timer Groups clocks on timer initialization 
-* [#5304](https://github.com/apache/incubator-nuttx/pull/5304) arch: risc-v: esp32c3: esp32c3_irq.c: Skip over ECALL instruction. 
-* [#5457](https://github.com/apache/incubator-nuttx/pull/5457) arch: risc-v: esp32c3: Fix issue #5377 UART1 not working because clock as disabled 
-* [#5016](https://github.com/apache/incubator-nuttx/pull/5016) arch: risc-v: esp32c3: Initialize rtc and peripheral parameters by default when chip starts 
-* [#5124](https://github.com/apache/incubator-nuttx/pull/5124) arch: risc-v: esp32s2/esp32c3: Remove unavailable support for ROM Basic Console 
-* [#5133](https://github.com/apache/incubator-nuttx/pull/5133) arch: risc-v: esp32s2/esp32c3: Add support for enabling hardware Flash Encryption on boot
+* [#5129](https://github.com/apache/nuttx/pull/5129) arch: risc-v: esp32c3: SPI flash MTD device uses all flash space 
+* [#4771](https://github.com/apache/nuttx/pull/4771) arch: risc-v: esp32c3: Remove the DMA test included in the driver along with its defconfig. 
+* [#4700](https://github.com/apache/nuttx/pull/4700) arch: risc-v: esp32c3: Remove test code from crypto accelerators drivers. 
+* [#4711](https://github.com/apache/nuttx/pull/4711) arch: risc-v: esp32c3: Remove the stub implementations of the early serial 
+* [#5615](https://github.com/apache/nuttx/pull/5615) arch: risc-v: esp32c3: Fix detection of CPU reset by Watchdog Timer 
+* [#4796](https://github.com/apache/nuttx/pull/4796) arch: risc-v: esp32c3: Fix MMU pages number calculation error 
+* [#4820](https://github.com/apache/nuttx/pull/4820) arch: risc-v: esp32c3: Partition supports BIO cmd 
+* [#4821](https://github.com/apache/nuttx/pull/4821) arch: risc-v: esp32c3: Add hardware brownout check and reset 
+* [#4834](https://github.com/apache/nuttx/pull/4834) arch: risc-v: esp32c3: esp32c3_usbserial.c: Initialize cpuint to ENOMEM. 
+* [#4813](https://github.com/apache/nuttx/pull/4813) arch: risc-v: esp32c3: Fix GPIO Output on pins 18 and 19 USB/JTAG 
+* [#4809](https://github.com/apache/nuttx/pull/4809) arch: risc-v: esp32c3: Driver for the ESP32-C3's CDC console. 
+* [#5615](https://github.com/apache/nuttx/pull/5615) arch: risc-v: esp32c3: Fix detection of CPU reset by Watchdog Timer 
+* [#4787](https://github.com/apache/nuttx/pull/4787) arch: risc-v: esp32c3: Initialize the BLE Mac 
+* [#4822](https://github.com/apache/nuttx/pull/4822) arch: risc-v: esp32c3: Fix reset triggering crash nested when crash 
+* [#4740](https://github.com/apache/nuttx/pull/4740) arch: risc-v: esp32c3: Fix Wi-Fi & BLE coexist issues 
+* [#4886](https://github.com/apache/nuttx/pull/4886) arch: risc-v: esp32c3: Refactor SPI Flash to support umask interrupt when R/W/E SPI Flash 
+* [#4885](https://github.com/apache/nuttx/pull/4885) arch: risc-v: esp32c3: Refactor ADC calibration 
+* [#5616](https://github.com/apache/nuttx/pull/5616) arch: risc-v: esp32c3: Enable Timer Groups clocks on timer initialization 
+* [#5304](https://github.com/apache/nuttx/pull/5304) arch: risc-v: esp32c3: esp32c3_irq.c: Skip over ECALL instruction. 
+* [#5457](https://github.com/apache/nuttx/pull/5457) arch: risc-v: esp32c3: Fix issue #5377 UART1 not working because clock as disabled 
+* [#5016](https://github.com/apache/nuttx/pull/5016) arch: risc-v: esp32c3: Initialize rtc and peripheral parameters by default when chip starts 
+* [#5124](https://github.com/apache/nuttx/pull/5124) arch: risc-v: esp32s2/esp32c3: Remove unavailable support for ROM Basic Console 
+* [#5133](https://github.com/apache/nuttx/pull/5133) arch: risc-v: esp32s2/esp32c3: Add support for enabling hardware Flash Encryption on boot
 
 #### MPFS
 
-* [#4877](https://github.com/apache/incubator-nuttx/pull/4877) arch: risc-v: mpfs: Add spi cs control for mpfs 
-* [#5289](https://github.com/apache/incubator-nuttx/pull/5289) arch: risc-v: mpfs: bootloader entrypoints 
-* [#5247](https://github.com/apache/incubator-nuttx/pull/5247) arch: risc-v: mpfs: switch to exception common 
-* [#5360](https://github.com/apache/incubator-nuttx/pull/5360) arch: risc-v: mpfs: Add support for a ROMFS image for MPFS 
-* [#5322](https://github.com/apache/incubator-nuttx/pull/5322) arch: risc-v: mpfs: build protected
-* [#5109](https://github.com/apache/incubator-nuttx/pull/5109) arch: risc-v: mpfs: Add MSSIO GPIO pinmap configuration 
-* [#5306](https://github.com/apache/incubator-nuttx/pull/5306) arch: risc-v: mpfs: OpenSBI: utilize an index2id table 
-* [#5287](https://github.com/apache/incubator-nuttx/pull/5287) arch: risc-v: mpfs: opensbi redefinition fixes
-* [#5225](https://github.com/apache/incubator-nuttx/pull/5225) arch: risc-v: mpfs: Opensbi fixes 
-* [#5325](https://github.com/apache/incubator-nuttx/pull/5325) arch: risc-v: mpfs: opensbi conf  
-* [#5310](https://github.com/apache/incubator-nuttx/pull/5310) arch: risc-v: mpfs: switch to NuttX types for opensbi 
-* [#5702](https://github.com/apache/incubator-nuttx/pull/5702) arch: risc-v: mpfs: usb: apply review fixes 
-* [#5040](https://github.com/apache/incubator-nuttx/pull/5040) arch: risc-v: mpfs: add opensbi support 
-* [#4709](https://github.com/apache/incubator-nuttx/pull/4709) arch: risc-v: mpfs: emmcsd: provide proper internal emmc settings 
-* [#4714](https://github.com/apache/incubator-nuttx/pull/4714) arch: risc-v: mpfs: ddr training and system clock init 
-* [#4839](https://github.com/apache/incubator-nuttx/pull/4839) arch: risc-v: mpfs: emmcsd: boost waitresponse perf 
-* [#4817](https://github.com/apache/incubator-nuttx/pull/4817) arch: risc-v: mpfs: uart: add a way to configure uart3 and uart4 
-* [#4788](https://github.com/apache/incubator-nuttx/pull/4788) arch: risc-v: mpfs: emmcsd: fix uninitialized value 
-* [#4781](https://github.com/apache/incubator-nuttx/pull/4781) arch: risc-v: mpfs: cache: provide L1/L2 cache enablers 
-* [#4773](https://github.com/apache/incubator-nuttx/pull/4773) arch: risc-v: mpfs: i2c: Add support for adaptive I2C bus frequency 
-* [#5694](https://github.com/apache/incubator-nuttx/pull/5694) arch: risc-v: mpfs: usb: fix an unused variable warning 
-* [#5161](https://github.com/apache/incubator-nuttx/pull/5161) arch: risc-v: mpfs: mpfs_serial.c: Correct setting of nbits 
-* [#5152](https://github.com/apache/incubator-nuttx/pull/5152) arch: risc-v: opensbi: update to version 1.0 
-* [#5636](https://github.com/apache/incubator-nuttx/pull/5636) arch: risc-v/qemu-rv: Set FS bits in mstatus 
-* [#5529](https://github.com/apache/incubator-nuttx/pull/5529) arch: risc-v/qemu-rv: Supports SMP up to 8 cores and other minor changes 
-* [#4825](https://github.com/apache/incubator-nuttx/pull/4825) arch: risc-v/xtensa: Kconfig: Some cleanup and improvements to arch versions of C library functions. 
-* [#5683](https://github.com/apache/incubator-nuttx/pull/5683) arch: risc-v/xtensa: corrent dumpstate xcp size 
-* [#5717](https://github.com/apache/incubator-nuttx/pull/5717) Revert "arch: risc-v: Correct FPU register save area in riscv_copystate" 
+* [#4877](https://github.com/apache/nuttx/pull/4877) arch: risc-v: mpfs: Add spi cs control for mpfs 
+* [#5289](https://github.com/apache/nuttx/pull/5289) arch: risc-v: mpfs: bootloader entrypoints 
+* [#5247](https://github.com/apache/nuttx/pull/5247) arch: risc-v: mpfs: switch to exception common 
+* [#5360](https://github.com/apache/nuttx/pull/5360) arch: risc-v: mpfs: Add support for a ROMFS image for MPFS 
+* [#5322](https://github.com/apache/nuttx/pull/5322) arch: risc-v: mpfs: build protected
+* [#5109](https://github.com/apache/nuttx/pull/5109) arch: risc-v: mpfs: Add MSSIO GPIO pinmap configuration 
+* [#5306](https://github.com/apache/nuttx/pull/5306) arch: risc-v: mpfs: OpenSBI: utilize an index2id table 
+* [#5287](https://github.com/apache/nuttx/pull/5287) arch: risc-v: mpfs: opensbi redefinition fixes
+* [#5225](https://github.com/apache/nuttx/pull/5225) arch: risc-v: mpfs: Opensbi fixes 
+* [#5325](https://github.com/apache/nuttx/pull/5325) arch: risc-v: mpfs: opensbi conf  
+* [#5310](https://github.com/apache/nuttx/pull/5310) arch: risc-v: mpfs: switch to NuttX types for opensbi 
+* [#5702](https://github.com/apache/nuttx/pull/5702) arch: risc-v: mpfs: usb: apply review fixes 
+* [#5040](https://github.com/apache/nuttx/pull/5040) arch: risc-v: mpfs: add opensbi support 
+* [#4709](https://github.com/apache/nuttx/pull/4709) arch: risc-v: mpfs: emmcsd: provide proper internal emmc settings 
+* [#4714](https://github.com/apache/nuttx/pull/4714) arch: risc-v: mpfs: ddr training and system clock init 
+* [#4839](https://github.com/apache/nuttx/pull/4839) arch: risc-v: mpfs: emmcsd: boost waitresponse perf 
+* [#4817](https://github.com/apache/nuttx/pull/4817) arch: risc-v: mpfs: uart: add a way to configure uart3 and uart4 
+* [#4788](https://github.com/apache/nuttx/pull/4788) arch: risc-v: mpfs: emmcsd: fix uninitialized value 
+* [#4781](https://github.com/apache/nuttx/pull/4781) arch: risc-v: mpfs: cache: provide L1/L2 cache enablers 
+* [#4773](https://github.com/apache/nuttx/pull/4773) arch: risc-v: mpfs: i2c: Add support for adaptive I2C bus frequency 
+* [#5694](https://github.com/apache/nuttx/pull/5694) arch: risc-v: mpfs: usb: fix an unused variable warning 
+* [#5161](https://github.com/apache/nuttx/pull/5161) arch: risc-v: mpfs: mpfs_serial.c: Correct setting of nbits 
+* [#5152](https://github.com/apache/nuttx/pull/5152) arch: risc-v: opensbi: update to version 1.0 
+* [#5636](https://github.com/apache/nuttx/pull/5636) arch: risc-v/qemu-rv: Set FS bits in mstatus 
+* [#5529](https://github.com/apache/nuttx/pull/5529) arch: risc-v/qemu-rv: Supports SMP up to 8 cores and other minor changes 
+* [#4825](https://github.com/apache/nuttx/pull/4825) arch: risc-v/xtensa: Kconfig: Some cleanup and improvements to arch versions of C library functions. 
+* [#5683](https://github.com/apache/nuttx/pull/5683) arch: risc-v/xtensa: corrent dumpstate xcp size 
+* [#5717](https://github.com/apache/nuttx/pull/5717) Revert "arch: risc-v: Correct FPU register save area in riscv_copystate" 
 
 #### SPARC
 
-* [#5394](https://github.com/apache/incubator-nuttx/pull/5394) arch: sparc: adaptive patch 
-* [#5521](https://github.com/apache/incubator-nuttx/pull/5521) arch: sparc: Replace adj_stack_ptr with stack_base_ptr 
+* [#5394](https://github.com/apache/nuttx/pull/5394) arch: sparc: adaptive patch 
+* [#5521](https://github.com/apache/nuttx/pull/5521) arch: sparc: Replace adj_stack_ptr with stack_base_ptr 
 
 #### XTENSA
 
-* [#4688](https://github.com/apache/incubator-nuttx/pull/4688) arch: xtensa: Kconfig: add quotes in source to clean warnings from setconfig 
-* [#5738](https://github.com/apache/incubator-nuttx/pull/5738) arch: xtensa: Save exception cause and vaddr into the user frame 
-* [#5149](https://github.com/apache/incubator-nuttx/pull/5149) arch: xtensa: Rename up_stack_color to xtensa_stack_color. 
-* [#5198](https://github.com/apache/incubator-nuttx/pull/5198) arch: xtensa: fix lack of float register save & resotre 
-* [#4663](https://github.com/apache/incubator-nuttx/pull/4663) arch: xtensa: Correctly save/restore coprocessor0 state. 
-* [#5450](https://github.com/apache/incubator-nuttx/pull/5450) arch: xtensa: kconfig: move ARCH_HAVE_TESTSET config to chip 
-* [#5648](https://github.com/apache/incubator-nuttx/pull/5648) arch: xtensa: fix sp duplicate reduce in handler enter 
-* [#5541](https://github.com/apache/incubator-nuttx/pull/5541) arch: xtensa: modify svcall to swint 
-* [#5729](https://github.com/apache/incubator-nuttx/pull/5729) arch: xtensa: Small improvements around xtensa_context 
-* [#5708](https://github.com/apache/incubator-nuttx/pull/5708) arch: xtensa: small improvements around using the software interrupt. 
-* [#5684](https://github.com/apache/incubator-nuttx/pull/5684) arch: xtensa: backtrace: fix backtrace last buffer error in some scene 
-* [#5250](https://github.com/apache/incubator-nuttx/pull/5250) arch: xtensa: Fix core voltage level when SPI Flash runs at 80Mhz 
-* [#5248](https://github.com/apache/incubator-nuttx/pull/5248) arch: xtensa: some fixes in interrupt handler 
-* [#4818](https://github.com/apache/incubator-nuttx/pull/4818) arch: xtensa: mpu: use WRITEBACK attribute for intsram & extsram 
-* [#4683](https://github.com/apache/incubator-nuttx/pull/4683) arch: xtensa: mpu: modify acc and memtype to uint32_t 
-* [#4664](https://github.com/apache/incubator-nuttx/pull/4664) arch: xtensa: xtensa_context.S: Save and restore SCOMPARE1 when necessary. 
-* [#4669](https://github.com/apache/incubator-nuttx/pull/4669) arch: xtensa: xtensa_cpupause.c: Allow a spin before taking the g_cpu_wait spinlock. 
-* [#5336](https://github.com/apache/incubator-nuttx/pull/5336) arch: xtensa: use swint to swith context 
-* [#5679](https://github.com/apache/incubator-nuttx/pull/5679) arch: xtensa: xtensa_user_handler.S: Store EXCCAUSE and EXCVADDR into the user frame.
-* [#5000](https://github.com/apache/incubator-nuttx/pull/5000) arch: xtensa: correct the interrupt stack on irq handler 
+* [#4688](https://github.com/apache/nuttx/pull/4688) arch: xtensa: Kconfig: add quotes in source to clean warnings from setconfig 
+* [#5738](https://github.com/apache/nuttx/pull/5738) arch: xtensa: Save exception cause and vaddr into the user frame 
+* [#5149](https://github.com/apache/nuttx/pull/5149) arch: xtensa: Rename up_stack_color to xtensa_stack_color. 
+* [#5198](https://github.com/apache/nuttx/pull/5198) arch: xtensa: fix lack of float register save & resotre 
+* [#4663](https://github.com/apache/nuttx/pull/4663) arch: xtensa: Correctly save/restore coprocessor0 state. 
+* [#5450](https://github.com/apache/nuttx/pull/5450) arch: xtensa: kconfig: move ARCH_HAVE_TESTSET config to chip 
+* [#5648](https://github.com/apache/nuttx/pull/5648) arch: xtensa: fix sp duplicate reduce in handler enter 
+* [#5541](https://github.com/apache/nuttx/pull/5541) arch: xtensa: modify svcall to swint 
+* [#5729](https://github.com/apache/nuttx/pull/5729) arch: xtensa: Small improvements around xtensa_context 
+* [#5708](https://github.com/apache/nuttx/pull/5708) arch: xtensa: small improvements around using the software interrupt. 
+* [#5684](https://github.com/apache/nuttx/pull/5684) arch: xtensa: backtrace: fix backtrace last buffer error in some scene 
+* [#5250](https://github.com/apache/nuttx/pull/5250) arch: xtensa: Fix core voltage level when SPI Flash runs at 80Mhz 
+* [#5248](https://github.com/apache/nuttx/pull/5248) arch: xtensa: some fixes in interrupt handler 
+* [#4818](https://github.com/apache/nuttx/pull/4818) arch: xtensa: mpu: use WRITEBACK attribute for intsram & extsram 
+* [#4683](https://github.com/apache/nuttx/pull/4683) arch: xtensa: mpu: modify acc and memtype to uint32_t 
+* [#4664](https://github.com/apache/nuttx/pull/4664) arch: xtensa: xtensa_context.S: Save and restore SCOMPARE1 when necessary. 
+* [#4669](https://github.com/apache/nuttx/pull/4669) arch: xtensa: xtensa_cpupause.c: Allow a spin before taking the g_cpu_wait spinlock. 
+* [#5336](https://github.com/apache/nuttx/pull/5336) arch: xtensa: use swint to swith context 
+* [#5679](https://github.com/apache/nuttx/pull/5679) arch: xtensa: xtensa_user_handler.S: Store EXCCAUSE and EXCVADDR into the user frame.
+* [#5000](https://github.com/apache/nuttx/pull/5000) arch: xtensa: correct the interrupt stack on irq handler 
 
 #### ESP32
 
-* [#5056](https://github.com/apache/incubator-nuttx/pull/5056) arch: xtensa: esp32: Add WiFi/BLE Coexistence support  
-* [#5187](https://github.com/apache/incubator-nuttx/pull/5187) arch: xtensa: esp32: Add PWM support using the LEDC peripheral 
-* [#5143](https://github.com/apache/incubator-nuttx/pull/5143) arch: xtensa: esp32: Use ROM implementations of libc functions 
-* [#5117](https://github.com/apache/incubator-nuttx/pull/5117) arch: xtensa: esp32: Add support for enabling hardware Flash Encryption on boot 
-* [#4991](https://github.com/apache/incubator-nuttx/pull/4991) arch: xtensa: esp32: Show CPUs activity using LEDs. 
-* [#4670](https://github.com/apache/incubator-nuttx/pull/4670) arch: xtensa: esp32: Few fixes around SPI Flash to make it SMP friendly. 
-* [#4710](https://github.com/apache/incubator-nuttx/pull/4710) arch: xtensa: esp32: Make SPI Flash initialization common to all ESP32 boards 
-* [#5542](https://github.com/apache/incubator-nuttx/pull/5542) arch: xtensa: esp32: setup software interrupt for esp32chips 
-* [#5407](https://github.com/apache/incubator-nuttx/pull/5407) arch: xtensa: esp32: Remove the QEMU special case when initializing the heap. 
-* [#5536](https://github.com/apache/incubator-nuttx/pull/5536) arch: xtensa: esp32: Few improvements around interrupt handling. 
-* [#5196](https://github.com/apache/incubator-nuttx/pull/5196) arch: xtensa: esp32: Add support to RS485 
-* [#4543](https://github.com/apache/incubator-nuttx/pull/4543) arch: xtensa: esp32: Use device specific lock as much as possible. 
-* [#4796](https://github.com/apache/incubator-nuttx/pull/4796) arch: xtensa: esp32: Fix MMU pages number calculation error 
-* [#4820](https://github.com/apache/incubator-nuttx/pull/4820) arch: xtensa: esp32: Partition supports BIO cmd 
-* [#4933](https://github.com/apache/incubator-nuttx/pull/4933) arch: xtensa: esp32: Remove CONFIG_SMP conditions in the code. 
-* [#5073](https://github.com/apache/incubator-nuttx/pull/5073) arch: xtensa: esp32: Fix some Wi-Fi issues
-* [#4867](https://github.com/apache/incubator-nuttx/pull/4867) arch: xtensa: esp32: Fix retrieving GPIOs' IRQ number and peripheral ID in SMP. 
-* [#4769](https://github.com/apache/incubator-nuttx/pull/4769) arch: xtensa: esp32: Make ESP32_BT_RESERVE_DRAM default to 0 again if Bluetooth is not enabled. 
+* [#5056](https://github.com/apache/nuttx/pull/5056) arch: xtensa: esp32: Add WiFi/BLE Coexistence support  
+* [#5187](https://github.com/apache/nuttx/pull/5187) arch: xtensa: esp32: Add PWM support using the LEDC peripheral 
+* [#5143](https://github.com/apache/nuttx/pull/5143) arch: xtensa: esp32: Use ROM implementations of libc functions 
+* [#5117](https://github.com/apache/nuttx/pull/5117) arch: xtensa: esp32: Add support for enabling hardware Flash Encryption on boot 
+* [#4991](https://github.com/apache/nuttx/pull/4991) arch: xtensa: esp32: Show CPUs activity using LEDs. 
+* [#4670](https://github.com/apache/nuttx/pull/4670) arch: xtensa: esp32: Few fixes around SPI Flash to make it SMP friendly. 
+* [#4710](https://github.com/apache/nuttx/pull/4710) arch: xtensa: esp32: Make SPI Flash initialization common to all ESP32 boards 
+* [#5542](https://github.com/apache/nuttx/pull/5542) arch: xtensa: esp32: setup software interrupt for esp32chips 
+* [#5407](https://github.com/apache/nuttx/pull/5407) arch: xtensa: esp32: Remove the QEMU special case when initializing the heap. 
+* [#5536](https://github.com/apache/nuttx/pull/5536) arch: xtensa: esp32: Few improvements around interrupt handling. 
+* [#5196](https://github.com/apache/nuttx/pull/5196) arch: xtensa: esp32: Add support to RS485 
+* [#4543](https://github.com/apache/nuttx/pull/4543) arch: xtensa: esp32: Use device specific lock as much as possible. 
+* [#4796](https://github.com/apache/nuttx/pull/4796) arch: xtensa: esp32: Fix MMU pages number calculation error 
+* [#4820](https://github.com/apache/nuttx/pull/4820) arch: xtensa: esp32: Partition supports BIO cmd 
+* [#4933](https://github.com/apache/nuttx/pull/4933) arch: xtensa: esp32: Remove CONFIG_SMP conditions in the code. 
+* [#5073](https://github.com/apache/nuttx/pull/5073) arch: xtensa: esp32: Fix some Wi-Fi issues
+* [#4867](https://github.com/apache/nuttx/pull/4867) arch: xtensa: esp32: Fix retrieving GPIOs' IRQ number and peripheral ID in SMP. 
+* [#4769](https://github.com/apache/nuttx/pull/4769) arch: xtensa: esp32: Make ESP32_BT_RESERVE_DRAM default to 0 again if Bluetooth is not enabled. 
 
 #### ESP32S2
 
-* [#5213](https://github.com/apache/incubator-nuttx/pull/5213) arch: xtensa: esp32s2: Fix some wrong definitions related to IRQ management 
-* [#5212](https://github.com/apache/incubator-nuttx/pull/5212) arch: xtensa: esp32s2: Fix data cache option in menuconfig 
-* [#5693](https://github.com/apache/incubator-nuttx/pull/5693) arch: xtensa: esp32s2: Sync IRQ management API with ESP32 and ESP32-S3 
-* [#4902](https://github.com/apache/incubator-nuttx/pull/4902) arch: xtensa: esp32xx: esp32xx_rtc.c: misc. fixes. 
-* [#5609](https://github.com/apache/incubator-nuttx/pull/5609) arch: xtensa: esp32s2: Correctly enable the software interrupt. 
-* [#5698](https://github.com/apache/incubator-nuttx/pull/5698) arch: xtensa: esp32s2: Add support for Main System Watchdog Timers 
-* [#4703](https://github.com/apache/incubator-nuttx/pull/4703) arch: xtensa: esp32s2: Add RNG driver support and board profile example 
+* [#5213](https://github.com/apache/nuttx/pull/5213) arch: xtensa: esp32s2: Fix some wrong definitions related to IRQ management 
+* [#5212](https://github.com/apache/nuttx/pull/5212) arch: xtensa: esp32s2: Fix data cache option in menuconfig 
+* [#5693](https://github.com/apache/nuttx/pull/5693) arch: xtensa: esp32s2: Sync IRQ management API with ESP32 and ESP32-S3 
+* [#4902](https://github.com/apache/nuttx/pull/4902) arch: xtensa: esp32xx: esp32xx_rtc.c: misc. fixes. 
+* [#5609](https://github.com/apache/nuttx/pull/5609) arch: xtensa: esp32s2: Correctly enable the software interrupt. 
+* [#5698](https://github.com/apache/nuttx/pull/5698) arch: xtensa: esp32s2: Add support for Main System Watchdog Timers 
+* [#4703](https://github.com/apache/nuttx/pull/4703) arch: xtensa: esp32s2: Add RNG driver support and board profile example 
 
 #### ESP32S3
 
-* [#5665](https://github.com/apache/incubator-nuttx/pull/5665) arch: xtensa: esp32s3: Add SPI-Flash support 
-* [#5699](https://github.com/apache/incubator-nuttx/pull/5699) arch: xtensa: esp32s3: Enable SMP support 
-* [#5723](https://github.com/apache/incubator-nuttx/pull/5723) arch: xtensa: esp32s3: Add support for RT-Timer based on Systimer peripheral 
-* [#5668](https://github.com/apache/incubator-nuttx/pull/5668) arch: xtensa: esp32s3: Add support for Tickless kernel using Systimer 
-* [#5671](https://github.com/apache/incubator-nuttx/pull/5671) arch: xtensa: esp32s3: Add support for Free-running Timer wrapper 
-* [#5686](https://github.com/apache/incubator-nuttx/pull/5686) arch: xtensa: esp32s3: Add SPI RAM/PSRAM Support 
-* [#5601](https://github.com/apache/incubator-nuttx/pull/5601) arch: xtensa: esp32s3: Add support for Main System Watchdog Timers 
-* [#5602](https://github.com/apache/incubator-nuttx/pull/5602) arch: xtensa: esp32s3: Add support for Timer Groups 0 and 1 
-* [#5604](https://github.com/apache/incubator-nuttx/pull/5604) arch: xtensa: esp32s3: Use the running CPU ID for enabling internal interrupts 
-* [#5608](https://github.com/apache/incubator-nuttx/pull/5608) arch: xtensa: esp32s3: Add support for Oneshot timer 
-* [#5722](https://github.com/apache/incubator-nuttx/pull/5722) arch: xtensa: esp32s3: Stall Timer ISR when core 1 is temporarily stalled 
+* [#5665](https://github.com/apache/nuttx/pull/5665) arch: xtensa: esp32s3: Add SPI-Flash support 
+* [#5699](https://github.com/apache/nuttx/pull/5699) arch: xtensa: esp32s3: Enable SMP support 
+* [#5723](https://github.com/apache/nuttx/pull/5723) arch: xtensa: esp32s3: Add support for RT-Timer based on Systimer peripheral 
+* [#5668](https://github.com/apache/nuttx/pull/5668) arch: xtensa: esp32s3: Add support for Tickless kernel using Systimer 
+* [#5671](https://github.com/apache/nuttx/pull/5671) arch: xtensa: esp32s3: Add support for Free-running Timer wrapper 
+* [#5686](https://github.com/apache/nuttx/pull/5686) arch: xtensa: esp32s3: Add SPI RAM/PSRAM Support 
+* [#5601](https://github.com/apache/nuttx/pull/5601) arch: xtensa: esp32s3: Add support for Main System Watchdog Timers 
+* [#5602](https://github.com/apache/nuttx/pull/5602) arch: xtensa: esp32s3: Add support for Timer Groups 0 and 1 
+* [#5604](https://github.com/apache/nuttx/pull/5604) arch: xtensa: esp32s3: Use the running CPU ID for enabling internal interrupts 
+* [#5608](https://github.com/apache/nuttx/pull/5608) arch: xtensa: esp32s3: Add support for Oneshot timer 
+* [#5722](https://github.com/apache/nuttx/pull/5722) arch: xtensa: esp32s3: Stall Timer ISR when core 1 is temporarily stalled 
 
 #### Z80
 
-* [#5726](https://github.com/apache/incubator-nuttx/pull/5726) arch: z[80|16]: Move up_getsp declaration to arch.h 
-* [#5344](https://github.com/apache/incubator-nuttx/pull/5344) arch: z80: fix garbage collector option to linker for ez80 
+* [#5726](https://github.com/apache/nuttx/pull/5726) arch: z[80|16]: Move up_getsp declaration to arch.h 
+* [#5344](https://github.com/apache/nuttx/pull/5344) arch: z80: fix garbage collector option to linker for ez80 
 
 ## Driver Support
 
 ### Drivers With Significant Improvements
 
-* [#5256](https://github.com/apache/incubator-nuttx/pull/5256) drivers: Add usbdev serial use boardid 
-* [#5728](https://github.com/apache/incubator-nuttx/pull/5728) drivers: Merge the common driver initialization into one place 
-* [#5716](https://github.com/apache/incubator-nuttx/pull/5716) drivers: Move the common driver to misc folder 
-* [#5080](https://github.com/apache/incubator-nuttx/pull/5080) drivers: regulator/clk rpmsg: pending on wait IPC channel ready 
-* [#4864](https://github.com/apache/incubator-nuttx/pull/4864) drivers: audio: cxd56: various audio fixes 
-* [#4976](https://github.com/apache/incubator-nuttx/pull/4976) drivers: bch: support flush and aligned bch buffer 
-* [#4712](https://github.com/apache/incubator-nuttx/pull/4712) drivers: can: Fix can_poll() POLLOUT calculation 
-* [#2641](https://github.com/apache/incubator-nuttx/pull/2641) drivers: can: Cleanup usage of soft fifo semaphore 
-* [#4661](https://github.com/apache/incubator-nuttx/pull/4661) drivers: i2c: fix compile break when enable CONFIG_I2C_BITBANG_NO_DELAY 
-* [#5042](https://github.com/apache/incubator-nuttx/pull/5042) drivers: input: ads7843e: complement critical section operation 
-* [#5631](https://github.com/apache/incubator-nuttx/pull/5631) drivers: input: Remove the couple from uinput 
-* [#5624](https://github.com/apache/incubator-nuttx/pull/5624) drivers: input: joystick/buttons: Fix the event lose between the invocation of poll 
-* [#5625](https://github.com/apache/incubator-nuttx/pull/5625) drivers: input: joystick: Remove [a|d]joy_enable from [a|d]joy_sample 
-* [#5204](https://github.com/apache/incubator-nuttx/pull/5204) drivers: input: joystck/buttons: Always protect the open list by critical section 
-* [#4837](https://github.com/apache/incubator-nuttx/pull/4837) drivers: input: touchscreen: added time stamp for touchscreen event 
-* [#4800](https://github.com/apache/incubator-nuttx/pull/4800) drivers: input: touchscreen: separate the interface for user interaction 
-* [#4928](https://github.com/apache/incubator-nuttx/pull/4928) drivers: input: touchscreen: added touchscreen gesture 
-* [#5005](https://github.com/apache/incubator-nuttx/pull/5005) drivers: ioexpander: add ioe_rpmsg server and client
-* [#5657](https://github.com/apache/incubator-nuttx/pull/5657) drivers: ioexpander: Fix invert option value usage 
-* [#5680](https://github.com/apache/incubator-nuttx/pull/5680) drivers: ioexpander: fix output inversion for ioe_dummy 
-* [#4697](https://github.com/apache/incubator-nuttx/pull/4697) drivers: ioexpander: gpio: Remove the hardcode 100 lim
-* [#4774](https://github.com/apache/incubator-nuttx/pull/4774) drivers: ioexpander: gpio: Use generic /dev/gpioN 
-* [#5183](https://github.com/apache/incubator-nuttx/pull/5183) drivers: ioexpander: Select IOEXPANDER_INT_ENABLE instead depend on it 
-* [#5037](https://github.com/apache/incubator-nuttx/pull/5037) drivers: net: Replace self defined macros with NET_SOCK_[FAMILY|TYPE|PROTOCOL] itation
-* [#5733](https://github.com/apache/incubator-nuttx/pull/5733) drivers: note: Add macro guard for instrumention switch 
-* [#4530](https://github.com/apache/incubator-nuttx/pull/4530) drivers: mmcsd: Add RPMB ioctl 
-* [#5215](https://github.com/apache/incubator-nuttx/pull/5215) drivers: mmcsd: sdio.c: Fix struct packing of sdio_resp_r5 
-* [#5155](https://github.com/apache/incubator-nuttx/pull/5155) drivers: mmcsd: sdio: Move sdio utils functions to drivers/mmcsd
-* [#4472](https://github.com/apache/incubator-nuttx/pull/4472) drivers: mmcsd: sdio: Update the defintion to the latest spec 
-* [#5294](https://github.com/apache/incubator-nuttx/pull/5294) drivers: mmcsd: add option to limit block count in multiple-block trans… 
-* [#5182](https://github.com/apache/incubator-nuttx/pull/5182) drivers: motor: Move simulated drivers from sim to common place 
-* [#4833](https://github.com/apache/incubator-nuttx/pull/4833) drivers: motor: add upperhalf structure 
-* [#5442](https://github.com/apache/incubator-nuttx/pull/5442) drivers: mtd: enlarge the limits of blocksize in struct m… 
-* [#5451](https://github.com/apache/incubator-nuttx/pull/5451) drivers: mtd: sst39vf.c: patch address map issue 
-* [#4924](https://github.com/apache/incubator-nuttx/pull/4924) drivers: mtd: Support multiple SST26 devices on the same spi bus 
-* [#4921](https://github.com/apache/incubator-nuttx/pull/4921) drivers: mtd: fix overflow checks in mtdpart 
-* [#4891](https://github.com/apache/incubator-nuttx/pull/4891) drivers: mtd: ramtron: Remove errant code and definitions 
-* [#4995](https://github.com/apache/incubator-nuttx/pull/4995) drivers: mtd/filemtd: improve write and erase access 
-* [#4964](https://github.com/apache/incubator-nuttx/pull/4964) drivers: note: noteram: when the buffer overflow happen and give the asan report 
-* [#4763](https://github.com/apache/incubator-nuttx/pull/4763) drivers: pipes: pipe close should notify block writting, and write will return … 
-* [#5425](https://github.com/apache/incubator-nuttx/pull/5425) drivers: pipes: Remove pipe from file system after open 
-* [#5475](https://github.com/apache/incubator-nuttx/pull/5475) drivers: pipes: Don't use sched_[lock|unlock] to do protection 
-* [#5423](https://github.com/apache/incubator-nuttx/pull/5423) drivers: pipes: Add DEV_PIPE_VFS_PATH to specify the pipe location 
-* [#4729](https://github.com/apache/incubator-nuttx/pull/4729) drivers: power: battery: add baterr, batinfo, batwarn for debug log 
-* [#4708](https://github.com/apache/incubator-nuttx/pull/4708) drivers: power: charge: modify battery_gauge code 
-* [#4990](https://github.com/apache/incubator-nuttx/pull/4990) drivers: power: charger: fix crash when notify without pollwaiter 
-* [#4889](https://github.com/apache/incubator-nuttx/pull/4889) drivers: power: improve charger interface
-* [#5701](https://github.com/apache/incubator-nuttx/pull/5701) drivers: power: govorner: add govorner to per domain. 
-* [#5591](https://github.com/apache/incubator-nuttx/pull/5591) drivers: power: PM: add domain inner update power state feature 
-* [#5050](https://github.com/apache/incubator-nuttx/pull/5050) drivers: power: set ioexpander direction in regulator gpio init.
-* [#5689](https://github.com/apache/incubator-nuttx/pull/5689) drivers: segger/sysview: add syscall support  
-* [#5140](https://github.com/apache/incubator-nuttx/pull/5140) drivers: sensors: as5048b: fix lower half init issue 
-* [#5061](https://github.com/apache/incubator-nuttx/pull/5061) drivers: sensors: isl29023.c: fix compilation error and warnings 
-* [#4838](https://github.com/apache/incubator-nuttx/pull/4838) drivers: sensors: Add sensor type ots. 
-* [#4850](https://github.com/apache/incubator-nuttx/pull/4850) drivers: sensors: add set calibration interface 
-* [#4842](https://github.com/apache/incubator-nuttx/pull/4842) drivers: sensors: Optimized GPS sensor and add gps satellite sensor. 
-* [#5356](https://github.com/apache/incubator-nuttx/pull/5356) drivers: sensors: ppg of dual- and quad-channel sensor types 
-* [#5024](https://github.com/apache/incubator-nuttx/pull/5024) drivers: sensors: reset interval,latency and circbuf when sensor is closed 
-* [#5128](https://github.com/apache/incubator-nuttx/pull/5128) drivers: serial: uart16550: Support 64bit platform 
-* [#5573](https://github.com/apache/incubator-nuttx/pull/5573) drivers: serial: pty: Handle pty ioctl and fcntl to pipe ioctl 
-* [#5114](https://github.com/apache/incubator-nuttx/pull/5114) drivers: serial: add CONFIG_TTY_LAUNCH support 
-* [#5197](https://github.com/apache/incubator-nuttx/pull/5197) drivers: serial: merge serial check signo to one place 
-* [#5430](https://github.com/apache/incubator-nuttx/pull/5430) drivers: serial: fix cu crash caused by ioctl is NULL 
-* [#5395](https://github.com/apache/incubator-nuttx/pull/5395) drivers: serial: Consolidate the general termios in the common place 
-* [#5427](https://github.com/apache/incubator-nuttx/pull/5427) drivers: serial: Minor fix for ptmx driver 
-* [#5415](https://github.com/apache/incubator-nuttx/pull/5415) drivers: serial: pty: Sync the default value of iflag and oflag regardless CONFIG_SERIAL_TERMIOS 
-* [#5444](https://github.com/apache/incubator-nuttx/pull/5444) drivers: serial: pty: Decouple SUSv1 style from pseudo fs operation 
-* [#5227](https://github.com/apache/incubator-nuttx/pull/5227) drivers: serial: uart_16550: Allow uintptr_t as addr width 
-* [#4940](https://github.com/apache/incubator-nuttx/pull/4940) drivers: serial: Fix offset calculation in 16550 
-* [#5569](https://github.com/apache/incubator-nuttx/pull/5569) drivers: serial: pty: Move the post process after reading the buffer 
-* [#5551](https://github.com/apache/incubator-nuttx/pull/5551) drivers: serial: pty: Remove the unused code related to CONFIG_PSEUDOTERM_FULLBLOCKS 
-* [#5402](https://github.com/apache/incubator-nuttx/pull/5402) drivers: serial: pty: fix the lock handling 
-* [#5428](https://github.com/apache/incubator-nuttx/pull/5428) drivers: serial: pty: Close the internal pipe when reference count drop to zero 
-* [#5429](https://github.com/apache/incubator-nuttx/pull/5429) drivers: serial: pty: Don't use shced_[lock|unlock] to protect pp_locked 
-* [#5433](https://github.com/apache/incubator-nuttx/pull/5433) drivers: serial: pty: Reorder the register driver to simplify the error handling 
-* [#5581](https://github.com/apache/incubator-nuttx/pull/5581) drivers: serial: pty: Remove the TODO comment for O_NONBLOCK 
-* [#5158](https://github.com/apache/incubator-nuttx/pull/5158) drivers: serial: uart_rpmsg: fix data loss 
-* [#4789](https://github.com/apache/incubator-nuttx/pull/4789) drivers: spi: Extend CONFIG_SPI_CS_DELAY_CONTROL to do inter frame delay and rename CONFIG_SPI_DELAY_CONTROL 
-* [#5408](https://github.com/apache/incubator-nuttx/pull/5408) drivers: syslog: syslog_device: fix flushing data when end of line is detected 
-* [#4873](https://github.com/apache/incubator-nuttx/pull/4873) drivers: syslog: change /dev/syslog & /dev/ramlog for unix standard 
-* [#5386](https://github.com/apache/incubator-nuttx/pull/5386) drivers: syslog: Refine Kconfig option 
-* [#5386](https://github.com/apache/incubator-nuttx/pull/5388) drivers: syslog: Implement RTT based log channel 
-* [#5735](https://github.com/apache/incubator-nuttx/pull/5735) drivers: syslog: correct the return value of default channel write 
-* [#5387](https://github.com/apache/incubator-nuttx/pull/5387) drivers: syslog: Include nuttx/syslog/syslog.h in include/nuttx/syslog/syslog_rpmsg.h 
-* [#5217](https://github.com/apache/incubator-nuttx/pull/5217) drivers: syslog: Fix in file channel initialization. 
-* [#5021](https://github.com/apache/incubator-nuttx/pull/5021) drivers: syslog/rpmsg: using up_putc to force flush syslog_rpmsg buffer 
-* [#5333](https://github.com/apache/incubator-nuttx/pull/5333) drivers: timers: Add weak_function for up_ function 
-* [#5265](https://github.com/apache/incubator-nuttx/pull/5265) drivers: timers: dirctly call rpmsg_rtc_server_xx() in server_ept_cb() 
-* [#5743](https://github.com/apache/incubator-nuttx/pull/5743) drivers: timers: timer: Add option for non-periodic notification 
-* [#5232](https://github.com/apache/incubator-nuttx/pull/5232) drivers: timers: rpmsg_rtc: resolve deadlock when the receive SYNC cmd 
-* [#5230](https://github.com/apache/incubator-nuttx/pull/5230) drivers: timers: Simplify the RTC rpmsg driver implementation 
-* [#4635](https://github.com/apache/incubator-nuttx/pull/4635) drivers: userled: Implement getall by checking actual pin state 
-* [#5594](https://github.com/apache/incubator-nuttx/pull/5594) drivers: video: vncserver: Allow fb operation while no connection 
-* [#5510](https://github.com/apache/incubator-nuttx/pull/5510) drivers: video: vncserver: Fix dead lock on re-connect 
-* [#5369](https://github.com/apache/incubator-nuttx/pull/5369) drivers: usbdev: cdcacm:support returning c_cflag & speed via termios 
-* [#5249](https://github.com/apache/incubator-nuttx/pull/5249) drivers: usbdev: Fix aligment issue: pktbuf needs to be 16bit aligned 
-* [#4766](https://github.com/apache/incubator-nuttx/pull/4766) drivers: Fix syslog_write failed 
-* [#4757](https://github.com/apache/incubator-nuttx/pull/4757) drivers: rptun: add ns_unbind_notify support 
-* [#4974](https://github.com/apache/incubator-nuttx/pull/4974) drivers: rptun: support can_recursive check for openamp 
-* [#5112](https://github.com/apache/incubator-nuttx/pull/5112) drivers: wireless: bcm43xxx: supported ARM CR4 core and bcm43455 chip in particular 
-* [#4690](https://github.com/apache/incubator-nuttx/pull/4690) drivers: wireless: bcm43xxx: supported high-speed timing mode with a clock rate up to 50MHz
-* [#4778](https://github.com/apache/incubator-nuttx/pull/4778) drivers: wireless: bcm43xxx: corrected SDIO_CCCR_HIGHSPEED_SHS bit handling 
-* [#5497](https://github.com/apache/incubator-nuttx/pull/5497) drivers: wireless: Fix gs2200m_ioctl_accept() 
+* [#5256](https://github.com/apache/nuttx/pull/5256) drivers: Add usbdev serial use boardid 
+* [#5728](https://github.com/apache/nuttx/pull/5728) drivers: Merge the common driver initialization into one place 
+* [#5716](https://github.com/apache/nuttx/pull/5716) drivers: Move the common driver to misc folder 
+* [#5080](https://github.com/apache/nuttx/pull/5080) drivers: regulator/clk rpmsg: pending on wait IPC channel ready 
+* [#4864](https://github.com/apache/nuttx/pull/4864) drivers: audio: cxd56: various audio fixes 
+* [#4976](https://github.com/apache/nuttx/pull/4976) drivers: bch: support flush and aligned bch buffer 
+* [#4712](https://github.com/apache/nuttx/pull/4712) drivers: can: Fix can_poll() POLLOUT calculation 
+* [#2641](https://github.com/apache/nuttx/pull/2641) drivers: can: Cleanup usage of soft fifo semaphore 
+* [#4661](https://github.com/apache/nuttx/pull/4661) drivers: i2c: fix compile break when enable CONFIG_I2C_BITBANG_NO_DELAY 
+* [#5042](https://github.com/apache/nuttx/pull/5042) drivers: input: ads7843e: complement critical section operation 
+* [#5631](https://github.com/apache/nuttx/pull/5631) drivers: input: Remove the couple from uinput 
+* [#5624](https://github.com/apache/nuttx/pull/5624) drivers: input: joystick/buttons: Fix the event lose between the invocation of poll 
+* [#5625](https://github.com/apache/nuttx/pull/5625) drivers: input: joystick: Remove [a|d]joy_enable from [a|d]joy_sample 
+* [#5204](https://github.com/apache/nuttx/pull/5204) drivers: input: joystck/buttons: Always protect the open list by critical section 
+* [#4837](https://github.com/apache/nuttx/pull/4837) drivers: input: touchscreen: added time stamp for touchscreen event 
+* [#4800](https://github.com/apache/nuttx/pull/4800) drivers: input: touchscreen: separate the interface for user interaction 
+* [#4928](https://github.com/apache/nuttx/pull/4928) drivers: input: touchscreen: added touchscreen gesture 
+* [#5005](https://github.com/apache/nuttx/pull/5005) drivers: ioexpander: add ioe_rpmsg server and client
+* [#5657](https://github.com/apache/nuttx/pull/5657) drivers: ioexpander: Fix invert option value usage 
+* [#5680](https://github.com/apache/nuttx/pull/5680) drivers: ioexpander: fix output inversion for ioe_dummy 
+* [#4697](https://github.com/apache/nuttx/pull/4697) drivers: ioexpander: gpio: Remove the hardcode 100 lim
+* [#4774](https://github.com/apache/nuttx/pull/4774) drivers: ioexpander: gpio: Use generic /dev/gpioN 
+* [#5183](https://github.com/apache/nuttx/pull/5183) drivers: ioexpander: Select IOEXPANDER_INT_ENABLE instead depend on it 
+* [#5037](https://github.com/apache/nuttx/pull/5037) drivers: net: Replace self defined macros with NET_SOCK_[FAMILY|TYPE|PROTOCOL] itation
+* [#5733](https://github.com/apache/nuttx/pull/5733) drivers: note: Add macro guard for instrumention switch 
+* [#4530](https://github.com/apache/nuttx/pull/4530) drivers: mmcsd: Add RPMB ioctl 
+* [#5215](https://github.com/apache/nuttx/pull/5215) drivers: mmcsd: sdio.c: Fix struct packing of sdio_resp_r5 
+* [#5155](https://github.com/apache/nuttx/pull/5155) drivers: mmcsd: sdio: Move sdio utils functions to drivers/mmcsd
+* [#4472](https://github.com/apache/nuttx/pull/4472) drivers: mmcsd: sdio: Update the defintion to the latest spec 
+* [#5294](https://github.com/apache/nuttx/pull/5294) drivers: mmcsd: add option to limit block count in multiple-block trans… 
+* [#5182](https://github.com/apache/nuttx/pull/5182) drivers: motor: Move simulated drivers from sim to common place 
+* [#4833](https://github.com/apache/nuttx/pull/4833) drivers: motor: add upperhalf structure 
+* [#5442](https://github.com/apache/nuttx/pull/5442) drivers: mtd: enlarge the limits of blocksize in struct m… 
+* [#5451](https://github.com/apache/nuttx/pull/5451) drivers: mtd: sst39vf.c: patch address map issue 
+* [#4924](https://github.com/apache/nuttx/pull/4924) drivers: mtd: Support multiple SST26 devices on the same spi bus 
+* [#4921](https://github.com/apache/nuttx/pull/4921) drivers: mtd: fix overflow checks in mtdpart 
+* [#4891](https://github.com/apache/nuttx/pull/4891) drivers: mtd: ramtron: Remove errant code and definitions 
+* [#4995](https://github.com/apache/nuttx/pull/4995) drivers: mtd/filemtd: improve write and erase access 
+* [#4964](https://github.com/apache/nuttx/pull/4964) drivers: note: noteram: when the buffer overflow happen and give the asan report 
+* [#4763](https://github.com/apache/nuttx/pull/4763) drivers: pipes: pipe close should notify block writting, and write will return … 
+* [#5425](https://github.com/apache/nuttx/pull/5425) drivers: pipes: Remove pipe from file system after open 
+* [#5475](https://github.com/apache/nuttx/pull/5475) drivers: pipes: Don't use sched_[lock|unlock] to do protection 
+* [#5423](https://github.com/apache/nuttx/pull/5423) drivers: pipes: Add DEV_PIPE_VFS_PATH to specify the pipe location 
+* [#4729](https://github.com/apache/nuttx/pull/4729) drivers: power: battery: add baterr, batinfo, batwarn for debug log 
+* [#4708](https://github.com/apache/nuttx/pull/4708) drivers: power: charge: modify battery_gauge code 
+* [#4990](https://github.com/apache/nuttx/pull/4990) drivers: power: charger: fix crash when notify without pollwaiter 
+* [#4889](https://github.com/apache/nuttx/pull/4889) drivers: power: improve charger interface
+* [#5701](https://github.com/apache/nuttx/pull/5701) drivers: power: govorner: add govorner to per domain. 
+* [#5591](https://github.com/apache/nuttx/pull/5591) drivers: power: PM: add domain inner update power state feature 
+* [#5050](https://github.com/apache/nuttx/pull/5050) drivers: power: set ioexpander direction in regulator gpio init.
+* [#5689](https://github.com/apache/nuttx/pull/5689) drivers: segger/sysview: add syscall support  
+* [#5140](https://github.com/apache/nuttx/pull/5140) drivers: sensors: as5048b: fix lower half init issue 
+* [#5061](https://github.com/apache/nuttx/pull/5061) drivers: sensors: isl29023.c: fix compilation error and warnings 
+* [#4838](https://github.com/apache/nuttx/pull/4838) drivers: sensors: Add sensor type ots. 
+* [#4850](https://github.com/apache/nuttx/pull/4850) drivers: sensors: add set calibration interface 
+* [#4842](https://github.com/apache/nuttx/pull/4842) drivers: sensors: Optimized GPS sensor and add gps satellite sensor. 
+* [#5356](https://github.com/apache/nuttx/pull/5356) drivers: sensors: ppg of dual- and quad-channel sensor types 
+* [#5024](https://github.com/apache/nuttx/pull/5024) drivers: sensors: reset interval,latency and circbuf when sensor is closed 
+* [#5128](https://github.com/apache/nuttx/pull/5128) drivers: serial: uart16550: Support 64bit platform 
+* [#5573](https://github.com/apache/nuttx/pull/5573) drivers: serial: pty: Handle pty ioctl and fcntl to pipe ioctl 
+* [#5114](https://github.com/apache/nuttx/pull/5114) drivers: serial: add CONFIG_TTY_LAUNCH support 
+* [#5197](https://github.com/apache/nuttx/pull/5197) drivers: serial: merge serial check signo to one place 
+* [#5430](https://github.com/apache/nuttx/pull/5430) drivers: serial: fix cu crash caused by ioctl is NULL 
+* [#5395](https://github.com/apache/nuttx/pull/5395) drivers: serial: Consolidate the general termios in the common place 
+* [#5427](https://github.com/apache/nuttx/pull/5427) drivers: serial: Minor fix for ptmx driver 
+* [#5415](https://github.com/apache/nuttx/pull/5415) drivers: serial: pty: Sync the default value of iflag and oflag regardless CONFIG_SERIAL_TERMIOS 
+* [#5444](https://github.com/apache/nuttx/pull/5444) drivers: serial: pty: Decouple SUSv1 style from pseudo fs operation 
+* [#5227](https://github.com/apache/nuttx/pull/5227) drivers: serial: uart_16550: Allow uintptr_t as addr width 
+* [#4940](https://github.com/apache/nuttx/pull/4940) drivers: serial: Fix offset calculation in 16550 
+* [#5569](https://github.com/apache/nuttx/pull/5569) drivers: serial: pty: Move the post process after reading the buffer 
+* [#5551](https://github.com/apache/nuttx/pull/5551) drivers: serial: pty: Remove the unused code related to CONFIG_PSEUDOTERM_FULLBLOCKS 
+* [#5402](https://github.com/apache/nuttx/pull/5402) drivers: serial: pty: fix the lock handling 
+* [#5428](https://github.com/apache/nuttx/pull/5428) drivers: serial: pty: Close the internal pipe when reference count drop to zero 
+* [#5429](https://github.com/apache/nuttx/pull/5429) drivers: serial: pty: Don't use shced_[lock|unlock] to protect pp_locked 
+* [#5433](https://github.com/apache/nuttx/pull/5433) drivers: serial: pty: Reorder the register driver to simplify the error handling 
+* [#5581](https://github.com/apache/nuttx/pull/5581) drivers: serial: pty: Remove the TODO comment for O_NONBLOCK 
+* [#5158](https://github.com/apache/nuttx/pull/5158) drivers: serial: uart_rpmsg: fix data loss 
+* [#4789](https://github.com/apache/nuttx/pull/4789) drivers: spi: Extend CONFIG_SPI_CS_DELAY_CONTROL to do inter frame delay and rename CONFIG_SPI_DELAY_CONTROL 
+* [#5408](https://github.com/apache/nuttx/pull/5408) drivers: syslog: syslog_device: fix flushing data when end of line is detected 
+* [#4873](https://github.com/apache/nuttx/pull/4873) drivers: syslog: change /dev/syslog & /dev/ramlog for unix standard 
+* [#5386](https://github.com/apache/nuttx/pull/5386) drivers: syslog: Refine Kconfig option 
+* [#5386](https://github.com/apache/nuttx/pull/5388) drivers: syslog: Implement RTT based log channel 
+* [#5735](https://github.com/apache/nuttx/pull/5735) drivers: syslog: correct the return value of default channel write 
+* [#5387](https://github.com/apache/nuttx/pull/5387) drivers: syslog: Include nuttx/syslog/syslog.h in include/nuttx/syslog/syslog_rpmsg.h 
+* [#5217](https://github.com/apache/nuttx/pull/5217) drivers: syslog: Fix in file channel initialization. 
+* [#5021](https://github.com/apache/nuttx/pull/5021) drivers: syslog/rpmsg: using up_putc to force flush syslog_rpmsg buffer 
+* [#5333](https://github.com/apache/nuttx/pull/5333) drivers: timers: Add weak_function for up_ function 
+* [#5265](https://github.com/apache/nuttx/pull/5265) drivers: timers: dirctly call rpmsg_rtc_server_xx() in server_ept_cb() 
+* [#5743](https://github.com/apache/nuttx/pull/5743) drivers: timers: timer: Add option for non-periodic notification 
+* [#5232](https://github.com/apache/nuttx/pull/5232) drivers: timers: rpmsg_rtc: resolve deadlock when the receive SYNC cmd 
+* [#5230](https://github.com/apache/nuttx/pull/5230) drivers: timers: Simplify the RTC rpmsg driver implementation 
+* [#4635](https://github.com/apache/nuttx/pull/4635) drivers: userled: Implement getall by checking actual pin state 
+* [#5594](https://github.com/apache/nuttx/pull/5594) drivers: video: vncserver: Allow fb operation while no connection 
+* [#5510](https://github.com/apache/nuttx/pull/5510) drivers: video: vncserver: Fix dead lock on re-connect 
+* [#5369](https://github.com/apache/nuttx/pull/5369) drivers: usbdev: cdcacm:support returning c_cflag & speed via termios 
+* [#5249](https://github.com/apache/nuttx/pull/5249) drivers: usbdev: Fix aligment issue: pktbuf needs to be 16bit aligned 
+* [#4766](https://github.com/apache/nuttx/pull/4766) drivers: Fix syslog_write failed 
+* [#4757](https://github.com/apache/nuttx/pull/4757) drivers: rptun: add ns_unbind_notify support 
+* [#4974](https://github.com/apache/nuttx/pull/4974) drivers: rptun: support can_recursive check for openamp 
+* [#5112](https://github.com/apache/nuttx/pull/5112) drivers: wireless: bcm43xxx: supported ARM CR4 core and bcm43455 chip in particular 
+* [#4690](https://github.com/apache/nuttx/pull/4690) drivers: wireless: bcm43xxx: supported high-speed timing mode with a clock rate up to 50MHz
+* [#4778](https://github.com/apache/nuttx/pull/4778) drivers: wireless: bcm43xxx: corrected SDIO_CCCR_HIGHSPEED_SHS bit handling 
+* [#5497](https://github.com/apache/nuttx/pull/5497) drivers: wireless: Fix gs2200m_ioctl_accept() 
 
 ### New Driver Support
 
-* [#5002](https://github.com/apache/incubator-nuttx/pull/5002) drivers: analog: add mcp48xx dac support 
-* [#5376](https://github.com/apache/incubator-nuttx/pull/5376) drivers: i2c: Add TCA9548A I2C Multiplexer 
-* [#4937](https://github.com/apache/incubator-nuttx/pull/4937) drivers: mtd: add MTD null driver support 
-* [#4943](https://github.com/apache/incubator-nuttx/pull/4943) drivers: power: add regulator framework 
-* [#5317](https://github.com/apache/incubator-nuttx/pull/5317) drivers: sensors: add support to MS5611 barometer 
-* [#4691](https://github.com/apache/incubator-nuttx/pull/4691) drivers: sensors: support new sensor type 
-* [#5499](https://github.com/apache/incubator-nuttx/pull/5499) drivers: timers: add EPSON RX8010SJ I2C RTC timer support 
-* [#4918](https://github.com/apache/incubator-nuttx/pull/4918) drivers: clk: add clk framework 
-* [#5258](https://github.com/apache/incubator-nuttx/pull/5258) drivers: input: add touchscreen uinput driver 
-* [#5327](https://github.com/apache/incubator-nuttx/pull/5327) drivers: segger: add Segger System View support 
+* [#5002](https://github.com/apache/nuttx/pull/5002) drivers: analog: add mcp48xx dac support 
+* [#5376](https://github.com/apache/nuttx/pull/5376) drivers: i2c: Add TCA9548A I2C Multiplexer 
+* [#4937](https://github.com/apache/nuttx/pull/4937) drivers: mtd: add MTD null driver support 
+* [#4943](https://github.com/apache/nuttx/pull/4943) drivers: power: add regulator framework 
+* [#5317](https://github.com/apache/nuttx/pull/5317) drivers: sensors: add support to MS5611 barometer 
+* [#4691](https://github.com/apache/nuttx/pull/4691) drivers: sensors: support new sensor type 
+* [#5499](https://github.com/apache/nuttx/pull/5499) drivers: timers: add EPSON RX8010SJ I2C RTC timer support 
+* [#4918](https://github.com/apache/nuttx/pull/4918) drivers: clk: add clk framework 
+* [#5258](https://github.com/apache/nuttx/pull/5258) drivers: input: add touchscreen uinput driver 
+* [#5327](https://github.com/apache/nuttx/pull/5327) drivers: segger: add Segger System View support 
 
 ## Board Support
 
 ### New Board Support
 
-* [#5363](https://github.com/apache/incubator-nuttx/pull/5363) boards: arm: phy62xx: add phyplus_rel_1.4 
-* [#4916](https://github.com/apache/incubator-nuttx/pull/4916) boards: arm: samv7: add support for SAME70 QMTECH board 
-* [#5195](https://github.com/apache/incubator-nuttx/pull/5195) boards: arm: rp2040: add support for Pimoroni Tiny 2040 board
-* [#4851](https://github.com/apache/incubator-nuttx/pull/4851) boards: risc-v: mpfs: Add support for Aries M100PFSMVP board 
+* [#5363](https://github.com/apache/nuttx/pull/5363) boards: arm: phy62xx: add phyplus_rel_1.4 
+* [#4916](https://github.com/apache/nuttx/pull/4916) boards: arm: samv7: add support for SAME70 QMTECH board 
+* [#5195](https://github.com/apache/nuttx/pull/5195) boards: arm: rp2040: add support for Pimoroni Tiny 2040 board
+* [#4851](https://github.com/apache/nuttx/pull/4851) boards: risc-v: mpfs: Add support for Aries M100PFSMVP board 
 
 ### Boards With Significant Improvements
 
-* [#5553](https://github.com/apache/incubator-nuttx/pull/5553) boards: Add -fno-common to ARCHCFLAGS and ARCHCXXFLAGS 
-* [#5330](https://github.com/apache/incubator-nuttx/pull/5330) boards: Board.mk: Make romfs_img 4 byte aligned 
-* [#5712](https://github.com/apache/incubator-nuttx/pull/5712) boards: Kconfig: introduce ARCH_BOARD_COMMON option 
-* [#4744](https://github.com/apache/incubator-nuttx/pull/4744) boards: Rename FOC_VEL_ADC to FOC_SETPOINT_ADC
-* [#5557](https://github.com/apache/incubator-nuttx/pull/5557) boards: Replace CONFIG_CYGWIN_WINTOOL with CONVERT_PATH 
-* [#5555](https://github.com/apache/incubator-nuttx/pull/5555) boards: Remove the unnecessary customize Make.defs 
-* [#5476](https://github.com/apache/incubator-nuttx/pull/5476) boards: Remove -fno-builtin 
-* [#5244](https://github.com/apache/incubator-nuttx/pull/5244) boards: Remove -fno-strength-reduce 
-* [#5349](https://github.com/apache/incubator-nuttx/pull/5349) boards: Remove unused NXFLAT flags from Make.defs 
-* [#5348](https://github.com/apache/incubator-nuttx/pull/5348) boards: Revert user space / kernel space isolation for pthread_exit 
-* [#5557](https://github.com/apache/incubator-nuttx/pull/5557) boards: Replace CONFIG_CYGWIN_WINTOOL with CONVERT_PATH 
-* [#5282](https://github.com/apache/incubator-nuttx/pull/5282) boards: Update board Make.defs
+* [#5553](https://github.com/apache/nuttx/pull/5553) boards: Add -fno-common to ARCHCFLAGS and ARCHCXXFLAGS 
+* [#5330](https://github.com/apache/nuttx/pull/5330) boards: Board.mk: Make romfs_img 4 byte aligned 
+* [#5712](https://github.com/apache/nuttx/pull/5712) boards: Kconfig: introduce ARCH_BOARD_COMMON option 
+* [#4744](https://github.com/apache/nuttx/pull/4744) boards: Rename FOC_VEL_ADC to FOC_SETPOINT_ADC
+* [#5557](https://github.com/apache/nuttx/pull/5557) boards: Replace CONFIG_CYGWIN_WINTOOL with CONVERT_PATH 
+* [#5555](https://github.com/apache/nuttx/pull/5555) boards: Remove the unnecessary customize Make.defs 
+* [#5476](https://github.com/apache/nuttx/pull/5476) boards: Remove -fno-builtin 
+* [#5244](https://github.com/apache/nuttx/pull/5244) boards: Remove -fno-strength-reduce 
+* [#5349](https://github.com/apache/nuttx/pull/5349) boards: Remove unused NXFLAT flags from Make.defs 
+* [#5348](https://github.com/apache/nuttx/pull/5348) boards: Revert user space / kernel space isolation for pthread_exit 
+* [#5557](https://github.com/apache/nuttx/pull/5557) boards: Replace CONFIG_CYGWIN_WINTOOL with CONVERT_PATH 
+* [#5282](https://github.com/apache/nuttx/pull/5282) boards: Update board Make.defs
 
 #### CXD56
 
-* [#5440](https://github.com/apache/incubator-nuttx/pull/5440) boards: arm: cxd56xx: audio: Support I2S input 
-* [#4996](https://github.com/apache/incubator-nuttx/pull/4996) boards: arm: cxd56xx: spresense: Adjust CONFIG_FAT_MAXFNAME and CONFIG_NAME_MAX 
-* [#4969](https://github.com/apache/incubator-nuttx/pull/4969) boards: arm: cxd56xx: spresense: Update smp/defconfig 
+* [#5440](https://github.com/apache/nuttx/pull/5440) boards: arm: cxd56xx: audio: Support I2S input 
+* [#4996](https://github.com/apache/nuttx/pull/4996) boards: arm: cxd56xx: spresense: Adjust CONFIG_FAT_MAXFNAME and CONFIG_NAME_MAX 
+* [#4969](https://github.com/apache/nuttx/pull/4969) boards: arm: cxd56xx: spresense: Update smp/defconfig 
 
 #### IMX6
 
-* [#5652](https://github.com/apache/incubator-nuttx/pull/5652) boards: arm: imx6: sabre-6quad: Add knsh 
-* [#5485](https://github.com/apache/incubator-nuttx/pull/5485) boards: arm: imx6: sabre-6quad: Add -fno-common to Make.defs
-* [#5724](https://github.com/apache/incubator-nuttx/pull/5724) boards: arm: imx6: sabre-6quad: Add CONFIG_DEBUG_FULLOPT=y to knsh/defconfig 
+* [#5652](https://github.com/apache/nuttx/pull/5652) boards: arm: imx6: sabre-6quad: Add knsh 
+* [#5485](https://github.com/apache/nuttx/pull/5485) boards: arm: imx6: sabre-6quad: Add -fno-common to Make.defs
+* [#5724](https://github.com/apache/nuttx/pull/5724) boards: arm: imx6: sabre-6quad: Add CONFIG_DEBUG_FULLOPT=y to knsh/defconfig 
 
 #### IMXRT
 
-* [#5670](https://github.com/apache/incubator-nuttx/pull/5670) boards: arm: imxrt: fix userled config in appinit 
-* [#5682](https://github.com/apache/incubator-nuttx/pull/5682) boards: arm: imxrt: userleds: Teensy 4.x board LED is active high 
+* [#5670](https://github.com/apache/nuttx/pull/5670) boards: arm: imxrt: fix userled config in appinit 
+* [#5682](https://github.com/apache/nuttx/pull/5682) boards: arm: imxrt: userleds: Teensy 4.x board LED is active high 
 
 #### LC823450
 
-* [#4947](https://github.com/apache/incubator-nuttx/pull/4947) boards: arm: lc823450: lc823450-xgevk: Update bt/defconfig for SMP 
+* [#4947](https://github.com/apache/nuttx/pull/4947) boards: arm: lc823450: lc823450-xgevk: Update bt/defconfig for SMP 
  
 #### NRF52
 
-* [#5023](https://github.com/apache/incubator-nuttx/pull/5023) boards: arm: nrf52: nrf52832-dk/nrf52840-dk: add procfs and sdc support 
+* [#5023](https://github.com/apache/nuttx/pull/5023) boards: arm: nrf52: nrf52832-dk/nrf52840-dk: add procfs and sdc support 
 
 #### PHY62XX
 
-* [#5669](https://github.com/apache/incubator-nuttx/pull/5669) boards: arm: phy62xx: phy6222: remove -nostartfiles -nodefaultlibs 
+* [#5669](https://github.com/apache/nuttx/pull/5669) boards: arm: phy62xx: phy6222: remove -nostartfiles -nodefaultlibs 
 
 #### SAMV7
 
-* [#5406](https://github.com/apache/incubator-nuttx/pull/5406) boards: arm: samv7: disable systick no matter if ARMV7M_SYSTICK is enabled or not
-* [#5710](https://github.com/apache/incubator-nuttx/pull/5710) boards: arm: samv7: rework linker script usage logic to allow custom linker scripts 
-* [#5281](https://github.com/apache/incubator-nuttx/pull/5281) boards: arm: samv7: move HSMCI interface to common 
-* [#4981](https://github.com/apache/incubator-nuttx/pull/4981) boards: arm: samv7: Introduce common folder and refactor MCUboot 
-* [#5320](https://github.com/apache/incubator-nuttx/pull/5320) boards: arm: samv7: common: add HSMCI0 boot mount configuration option 
-* [#5127](https://github.com/apache/incubator-nuttx/pull/5127) boards: arm: samv7: common: Improve SAMv7 common folder approach
-* [#5318](https://github.com/apache/incubator-nuttx/pull/5318) boards: arm: samv7: same70-qmtech: enable slow crystal 
-* [#5410](https://github.com/apache/incubator-nuttx/pull/5410) boards: arm: samv7: same70-qmtech: add buttons interface 
-* [#4911](https://github.com/apache/incubator-nuttx/pull/4911) boards: arm: samv7: samv71-xult: Set console at usart1 
-* [#5676](https://github.com/apache/incubator-nuttx/pull/5676) boards: arm: samv7: default BOARD_SAMV7_COMMON to n 
-* [#5119](https://github.com/apache/incubator-nuttx/pull/5119) boards: arm: samv7: improve progmem common interface 
-* [#5276](https://github.com/apache/incubator-nuttx/pull/5276) boards: arm: samv7: fix build error when automount is enabled 
-* [#5277](https://github.com/apache/incubator-nuttx/pull/5277) boards: arm: same70-qmtech: switch console to UART0 
-* [#5312](https://github.com/apache/incubator-nuttx/pull/5312) boards: arm: same70-qmtech: clarify usage of CD signal on SD card connector 
-* [#4880](https://github.com/apache/incubator-nuttx/pull/4880) boards: arm: same70-xplained: MCUboot support for SAM E70 Xplained 
-* [#4912](https://github.com/apache/incubator-nuttx/pull/4912) boards: arm: same70-xplained: disable systick before loading MCUboot application 
-* [#4907](https://github.com/apache/incubator-nuttx/pull/4907) boards: arm: same70-xplained: scripts: fix memory region size for MCUboot app 
-* [#4906](https://github.com/apache/incubator-nuttx/pull/4906) boards: arm: same70-xplained: fix usage of SAMV71XULT instead of SAME70XPLAINED 
-* [#4915](https://github.com/apache/incubator-nuttx/pull/4915) boards: arm: same70-xplained: MCUboot related improvements 
+* [#5406](https://github.com/apache/nuttx/pull/5406) boards: arm: samv7: disable systick no matter if ARMV7M_SYSTICK is enabled or not
+* [#5710](https://github.com/apache/nuttx/pull/5710) boards: arm: samv7: rework linker script usage logic to allow custom linker scripts 
+* [#5281](https://github.com/apache/nuttx/pull/5281) boards: arm: samv7: move HSMCI interface to common 
+* [#4981](https://github.com/apache/nuttx/pull/4981) boards: arm: samv7: Introduce common folder and refactor MCUboot 
+* [#5320](https://github.com/apache/nuttx/pull/5320) boards: arm: samv7: common: add HSMCI0 boot mount configuration option 
+* [#5127](https://github.com/apache/nuttx/pull/5127) boards: arm: samv7: common: Improve SAMv7 common folder approach
+* [#5318](https://github.com/apache/nuttx/pull/5318) boards: arm: samv7: same70-qmtech: enable slow crystal 
+* [#5410](https://github.com/apache/nuttx/pull/5410) boards: arm: samv7: same70-qmtech: add buttons interface 
+* [#4911](https://github.com/apache/nuttx/pull/4911) boards: arm: samv7: samv71-xult: Set console at usart1 
+* [#5676](https://github.com/apache/nuttx/pull/5676) boards: arm: samv7: default BOARD_SAMV7_COMMON to n 
+* [#5119](https://github.com/apache/nuttx/pull/5119) boards: arm: samv7: improve progmem common interface 
+* [#5276](https://github.com/apache/nuttx/pull/5276) boards: arm: samv7: fix build error when automount is enabled 
+* [#5277](https://github.com/apache/nuttx/pull/5277) boards: arm: same70-qmtech: switch console to UART0 
+* [#5312](https://github.com/apache/nuttx/pull/5312) boards: arm: same70-qmtech: clarify usage of CD signal on SD card connector 
+* [#4880](https://github.com/apache/nuttx/pull/4880) boards: arm: same70-xplained: MCUboot support for SAM E70 Xplained 
+* [#4912](https://github.com/apache/nuttx/pull/4912) boards: arm: same70-xplained: disable systick before loading MCUboot application 
+* [#4907](https://github.com/apache/nuttx/pull/4907) boards: arm: same70-xplained: scripts: fix memory region size for MCUboot app 
+* [#4906](https://github.com/apache/nuttx/pull/4906) boards: arm: same70-xplained: fix usage of SAMV71XULT instead of SAME70XPLAINED 
+* [#4915](https://github.com/apache/nuttx/pull/4915) boards: arm: same70-xplained: MCUboot related improvements 
 
 #### STM32
 
-* [#5011](https://github.com/apache/incubator-nuttx/pull/5011) boards: arm: stm32: emw3162: enabled internal pull-up resistors on SDIO bus 
-* [#4750](https://github.com/apache/incubator-nuttx/pull/4750) boards: arm: stm32: Normalize FOC related project 
-* [#5612](https://github.com/apache/incubator-nuttx/pull/5612) boards: arm: stm32: Update adb configs 
-* [#5675](https://github.com/apache/incubator-nuttx/pull/5675) boards: arm: stm32: stm32f4discovery: Remove CONFIG_LIBC_EXECFUNCS from adb defconfig 
-* [#4775](https://github.com/apache/incubator-nuttx/pull/4775) boards: arm: stm32: b-g431b-esc1: add Hall and Qenco support 
-* [#5420](https://github.com/apache/incubator-nuttx/pull/5420) boards: arm: stm32: b-g431b-esc1/nucleo-g431rb: add SocketCAN examples 
-* [#5237](https://github.com/apache/incubator-nuttx/pull/5237) boards: arm: stm32: b-g431b-esc1/nucleo-g431rb: add CAN example for 
-* [#5238](https://github.com/apache/incubator-nuttx/pull/5238) boards: arm: stm32: nucleo-f302r8: nucleo-f446re: add SocketCAN example 
-* [#4785](https://github.com/apache/incubator-nuttx/pull/4785) boards: arm: stm32: nucleo-f302r8: disable NSH commands for FOC configs to save FLASH 
-* [#4938](https://github.com/apache/incubator-nuttx/pull/4938) boards: arm: stm32: nucleo-f302r8: add 3ph Hall sensor support 
-* [#5166](https://github.com/apache/incubator-nuttx/pull/5166) boards: arm: stm32: nucleo-f446re: add procfs support 
-* [#5614](https://github.com/apache/incubator-nuttx/pull/5614) boards: arm: stm32: nucleo-l152re: Added registering logic SPI on /dev.
-* [#5439](https://github.com/apache/incubator-nuttx/pull/5439) boards: arm: stm32: nucleo-l152re: Test/i2c 
-* [#5009](https://github.com/apache/incubator-nuttx/pull/5009) boards: arm: stm32: nucleo-f4x1re: Correct issues with userled support on the Nucleo F4x1RE. 
-* [#5130](https://github.com/apache/incubator-nuttx/pull/5130) boards: arm: stm32: photon: added configuration to measure wlan performance 
+* [#5011](https://github.com/apache/nuttx/pull/5011) boards: arm: stm32: emw3162: enabled internal pull-up resistors on SDIO bus 
+* [#4750](https://github.com/apache/nuttx/pull/4750) boards: arm: stm32: Normalize FOC related project 
+* [#5612](https://github.com/apache/nuttx/pull/5612) boards: arm: stm32: Update adb configs 
+* [#5675](https://github.com/apache/nuttx/pull/5675) boards: arm: stm32: stm32f4discovery: Remove CONFIG_LIBC_EXECFUNCS from adb defconfig 
+* [#4775](https://github.com/apache/nuttx/pull/4775) boards: arm: stm32: b-g431b-esc1: add Hall and Qenco support 
+* [#5420](https://github.com/apache/nuttx/pull/5420) boards: arm: stm32: b-g431b-esc1/nucleo-g431rb: add SocketCAN examples 
+* [#5237](https://github.com/apache/nuttx/pull/5237) boards: arm: stm32: b-g431b-esc1/nucleo-g431rb: add CAN example for 
+* [#5238](https://github.com/apache/nuttx/pull/5238) boards: arm: stm32: nucleo-f302r8: nucleo-f446re: add SocketCAN example 
+* [#4785](https://github.com/apache/nuttx/pull/4785) boards: arm: stm32: nucleo-f302r8: disable NSH commands for FOC configs to save FLASH 
+* [#4938](https://github.com/apache/nuttx/pull/4938) boards: arm: stm32: nucleo-f302r8: add 3ph Hall sensor support 
+* [#5166](https://github.com/apache/nuttx/pull/5166) boards: arm: stm32: nucleo-f446re: add procfs support 
+* [#5614](https://github.com/apache/nuttx/pull/5614) boards: arm: stm32: nucleo-l152re: Added registering logic SPI on /dev.
+* [#5439](https://github.com/apache/nuttx/pull/5439) boards: arm: stm32: nucleo-l152re: Test/i2c 
+* [#5009](https://github.com/apache/nuttx/pull/5009) boards: arm: stm32: nucleo-f4x1re: Correct issues with userled support on the Nucleo F4x1RE. 
+* [#5130](https://github.com/apache/nuttx/pull/5130) boards: arm: stm32: photon: added configuration to measure wlan performance 
 
 #### STM32H7
 
-* [#5697](https://github.com/apache/incubator-nuttx/pull/5697) boards: arm: stm32[f7|l4]: fix SPI chip select GPIO access 
-* [#4827](https://github.com/apache/incubator-nuttx/pull/4827) boards: arm: stm32h7: nucleo-h743zi: add board_reset function 
+* [#5697](https://github.com/apache/nuttx/pull/5697) boards: arm: stm32[f7|l4]: fix SPI chip select GPIO access 
+* [#4827](https://github.com/apache/nuttx/pull/4827) boards: arm: stm32h7: nucleo-h743zi: add board_reset function 
 
 #### TIVA
 
-* [#5664](https://github.com/apache/incubator-nuttx/pull/5664) boards: arm: tiva: ekk-lm3s9b96: Remove unused mmcsd option 
-* [#5595](https://github.com/apache/incubator-nuttx/pull/5595) boards: arm: tiva: lm3s6965-ek: Add qemu-kostest  
-* [#5597](https://github.com/apache/incubator-nuttx/pull/5597) boards: arm: tiva: lm3s6965-ek: Fix qemu-kostest 
-* [#5597](https://github.com/apache/incubator-nuttx/pull/5597) boards: arm: tiva: lm3s6965-ek: Fix qemu-kostest 
+* [#5664](https://github.com/apache/nuttx/pull/5664) boards: arm: tiva: ekk-lm3s9b96: Remove unused mmcsd option 
+* [#5595](https://github.com/apache/nuttx/pull/5595) boards: arm: tiva: lm3s6965-ek: Add qemu-kostest  
+* [#5597](https://github.com/apache/nuttx/pull/5597) boards: arm: tiva: lm3s6965-ek: Fix qemu-kostest 
+* [#5597](https://github.com/apache/nuttx/pull/5597) boards: arm: tiva: lm3s6965-ek: Fix qemu-kostest 
 
 #### RISC-V
 
-* [#5134](https://github.com/apache/incubator-nuttx/pull/5134) boards: risc-v: hifive1-revb: Enable some nsh commands in nsh/defconfig 
-* [#4675](https://github.com/apache/incubator-nuttx/pull/4675) boards: risc-v: k210: Add initial gpio user space support 
-* [#4665](https://github.com/apache/incubator-nuttx/pull/4665) boards: risc-v: k210: Fix -march and -mabi 
-* [#5067](https://github.com/apache/incubator-nuttx/pull/5067) boards: risc-v: mpfs: update m100pfsevp board info 
-* [#5688](https://github.com/apache/incubator-nuttx/pull/5688) boards: risc-v: mpfs: MPFS USB driver 
-* [#5111](https://github.com/apache/incubator-nuttx/pull/5111) boards: risc-v: m100pfsevp: Decrease DDR lane temination values to 40 ohm and … 
-* [#5500](https://github.com/apache/incubator-nuttx/pull/5500) boards: risc-v: bl602: Remove -D__NuttX__ from Makefile 
-* [#5515](https://github.com/apache/incubator-nuttx/pull/5515) boards: risc-v: rv-virt: Supports FPU test and ostest in both rv32/rv64 
+* [#5134](https://github.com/apache/nuttx/pull/5134) boards: risc-v: hifive1-revb: Enable some nsh commands in nsh/defconfig 
+* [#4675](https://github.com/apache/nuttx/pull/4675) boards: risc-v: k210: Add initial gpio user space support 
+* [#4665](https://github.com/apache/nuttx/pull/4665) boards: risc-v: k210: Fix -march and -mabi 
+* [#5067](https://github.com/apache/nuttx/pull/5067) boards: risc-v: mpfs: update m100pfsevp board info 
+* [#5688](https://github.com/apache/nuttx/pull/5688) boards: risc-v: mpfs: MPFS USB driver 
+* [#5111](https://github.com/apache/nuttx/pull/5111) boards: risc-v: m100pfsevp: Decrease DDR lane temination values to 40 ohm and … 
+* [#5500](https://github.com/apache/nuttx/pull/5500) boards: risc-v: bl602: Remove -D__NuttX__ from Makefile 
+* [#5515](https://github.com/apache/nuttx/pull/5515) boards: risc-v: rv-virt: Supports FPU test and ostest in both rv32/rv64 
 
 #### SIM
 
-* [#5544](https://github.com/apache/incubator-nuttx/pull/5544) boards: sim: Add missing options to sim:vncserver 
-* [#5559](https://github.com/apache/incubator-nuttx/pull/5559) boards: sim: Rename ARCHCPUFLAGS[XX] to ARCHC[XX]FLAGS 
-* [#5739](https://github.com/apache/incubator-nuttx/pull/5739) boards: sim: add support of custom optimization level 
-* [#5186](https://github.com/apache/incubator-nuttx/pull/5186) boards: sim: Turn on more rpmsg drivers in rpserver config 
-* [#5101](https://github.com/apache/incubator-nuttx/pull/5101) boards: sim: Remove sim_tsc_setup 
-* [#5561](https://github.com/apache/incubator-nuttx/pull/5561) boards: sim: defconfig for hello_rust 
-* [#5535](https://github.com/apache/incubator-nuttx/pull/5535) boards: sim: Enable Rust suppport for hello_rust application. 
-* [#5640](https://github.com/apache/incubator-nuttx/pull/5640) boards: sim: Remove CCLINKFLAGS, use CFLAGS/CXXFLAGS instead 
-* [#5501](https://github.com/apache/incubator-nuttx/pull/5501) boards: sim: Add adb config for test 
-* [#5121](https://github.com/apache/incubator-nuttx/pull/5121) boards: sim: recovered eth0 interface in sim:tcpblaster configuration 
-* [#5383](https://github.com/apache/incubator-nuttx/pull/5383) boards: sim: Make.defs: CELFFLAGS += -mcmodel=large 
+* [#5544](https://github.com/apache/nuttx/pull/5544) boards: sim: Add missing options to sim:vncserver 
+* [#5559](https://github.com/apache/nuttx/pull/5559) boards: sim: Rename ARCHCPUFLAGS[XX] to ARCHC[XX]FLAGS 
+* [#5739](https://github.com/apache/nuttx/pull/5739) boards: sim: add support of custom optimization level 
+* [#5186](https://github.com/apache/nuttx/pull/5186) boards: sim: Turn on more rpmsg drivers in rpserver config 
+* [#5101](https://github.com/apache/nuttx/pull/5101) boards: sim: Remove sim_tsc_setup 
+* [#5561](https://github.com/apache/nuttx/pull/5561) boards: sim: defconfig for hello_rust 
+* [#5535](https://github.com/apache/nuttx/pull/5535) boards: sim: Enable Rust suppport for hello_rust application. 
+* [#5640](https://github.com/apache/nuttx/pull/5640) boards: sim: Remove CCLINKFLAGS, use CFLAGS/CXXFLAGS instead 
+* [#5501](https://github.com/apache/nuttx/pull/5501) boards: sim: Add adb config for test 
+* [#5121](https://github.com/apache/nuttx/pull/5121) boards: sim: recovered eth0 interface in sim:tcpblaster configuration 
+* [#5383](https://github.com/apache/nuttx/pull/5383) boards: sim: Make.defs: CELFFLAGS += -mcmodel=large 
 
 #### SPARC
 
-* [#5644](https://github.com/apache/incubator-nuttx/pull/5644) boards: sparc: Remove HOSTCC related flags from Make.defs 
+* [#5644](https://github.com/apache/nuttx/pull/5644) boards: sparc: Remove HOSTCC related flags from Make.defs 
 
 #### XTENSA
 
-* [#4719](https://github.com/apache/incubator-nuttx/pull/4719) boards: xtensa: esp32: Refactor SPI Flash File system mount options on menuconfig 
-* [#5596](https://github.com/apache/incubator-nuttx/pull/5596) boards: xtensa: esp32: Update esp-wireless-drivers-3rdparty 
-* [#5074](https://github.com/apache/incubator-nuttx/pull/5074) boards: xtensa: esp32: Add board support to SHT3X sensor 
-* [#5051](https://github.com/apache/incubator-nuttx/pull/5051) boards: xtensa: esp32: Enable canaries stack protection to ESP32 chips 
-* [#5617](https://github.com/apache/incubator-nuttx/pull/5617) boards: xtensa: esp32-devkitc: Fix boot failure on tickless defconfig 
-* [#5654](https://github.com/apache/incubator-nuttx/pull/5654) boards: xtensa: esp32-devkitc: Increase INIT_STACKSIZE to 3072 in smp/defconfig 
-* [#5075](https://github.com/apache/incubator-nuttx/pull/5075) boards: xtensa: esp32-devkitc: Change CONFIG_USER_ENTRYPOINT to CONFIG_INIT_ENTRYPOINT 
+* [#4719](https://github.com/apache/nuttx/pull/4719) boards: xtensa: esp32: Refactor SPI Flash File system mount options on menuconfig 
+* [#5596](https://github.com/apache/nuttx/pull/5596) boards: xtensa: esp32: Update esp-wireless-drivers-3rdparty 
+* [#5074](https://github.com/apache/nuttx/pull/5074) boards: xtensa: esp32: Add board support to SHT3X sensor 
+* [#5051](https://github.com/apache/nuttx/pull/5051) boards: xtensa: esp32: Enable canaries stack protection to ESP32 chips 
+* [#5617](https://github.com/apache/nuttx/pull/5617) boards: xtensa: esp32-devkitc: Fix boot failure on tickless defconfig 
+* [#5654](https://github.com/apache/nuttx/pull/5654) boards: xtensa: esp32-devkitc: Increase INIT_STACKSIZE to 3072 in smp/defconfig 
+* [#5075](https://github.com/apache/nuttx/pull/5075) boards: xtensa: esp32-devkitc: Change CONFIG_USER_ENTRYPOINT to CONFIG_INIT_ENTRYPOINT 
 
 ## File System
 
 ### Bug Fixes
 
-* [#4694](https://github.com/apache/incubator-nuttx/pull/4694) fs: littlefs: fix rmdir can remove a file
-* [#4722](https://github.com/apache/incubator-nuttx/pull/4722) fs: mqueue: fix memory leak cause by lost inode_release 
-* [#5214](https://github.com/apache/incubator-nuttx/pull/5214) fs: partition: Fix compilation errors when CONFIG_FS_LARGEFIL… 
-* [#5279](https://github.com/apache/incubator-nuttx/pull/5279) fs: partition: Fix an overflow in blkcnt_t gpt_last_lba
-* [#5653](https://github.com/apache/incubator-nuttx/pull/5653) fs: romfs: fix read file mismatch when the length of file name is 16 
-* [#5257](https://github.com/apache/incubator-nuttx/pull/5257) fs: smartfs: Fix file size corruption when opening with truncate mode 
-* [#4811](https://github.com/apache/incubator-nuttx/pull/4811) fs: procfs: fix ps can't log out Group id 
-* [#5172](https://github.com/apache/incubator-nuttx/pull/5172) fs: procfs: fix readdir loss last character
-* [#4968](https://github.com/apache/incubator-nuttx/pull/4968) fs: fat: Use uint16_t instead of wchar_t 
+* [#4694](https://github.com/apache/nuttx/pull/4694) fs: littlefs: fix rmdir can remove a file
+* [#4722](https://github.com/apache/nuttx/pull/4722) fs: mqueue: fix memory leak cause by lost inode_release 
+* [#5214](https://github.com/apache/nuttx/pull/5214) fs: partition: Fix compilation errors when CONFIG_FS_LARGEFIL… 
+* [#5279](https://github.com/apache/nuttx/pull/5279) fs: partition: Fix an overflow in blkcnt_t gpt_last_lba
+* [#5653](https://github.com/apache/nuttx/pull/5653) fs: romfs: fix read file mismatch when the length of file name is 16 
+* [#5257](https://github.com/apache/nuttx/pull/5257) fs: smartfs: Fix file size corruption when opening with truncate mode 
+* [#4811](https://github.com/apache/nuttx/pull/4811) fs: procfs: fix ps can't log out Group id 
+* [#5172](https://github.com/apache/nuttx/pull/5172) fs: procfs: fix readdir loss last character
+* [#4968](https://github.com/apache/nuttx/pull/4968) fs: fat: Use uint16_t instead of wchar_t 
 
 ### Significant Improvements
 
-* [#5108](https://github.com/apache/incubator-nuttx/pull/5108) fs: change fs strncpy to strlcpy to avoid losing'\0' 
-* [#5460](https://github.com/apache/incubator-nuttx/pull/5460) fs: epoll_fd: support dup file descriptor
-* [#5345](https://github.com/apache/incubator-nuttx/pull/5345) fs: fs_automount: add options for signaling when volume is mounted and unmounted 
-* [#4934](https://github.com/apache/incubator-nuttx/pull/4934) fs: hosfs_rpmsg: merge hostfs_rpmsg to rpmsgfs 
-* [#4986](https://github.com/apache/incubator-nuttx/pull/4986) fs: hostfs: add lock to hostfs_rewinddir 
-* [#4718](https://github.com/apache/incubator-nuttx/pull/4718) fs: mount: Properly handle missing FS on the supported list 
-* [#4721](https://github.com/apache/incubator-nuttx/pull/4721) fs: mqueue: Change MAX_MQUEUE_PATH to 64 
-* [#4734](https://github.com/apache/incubator-nuttx/pull/4734) fs: partition: support mbr and gpt partition parsing 
-* [#4687](https://github.com/apache/incubator-nuttx/pull/4687) fs: partition: Make read_partition_block callable outside ptable 
-* [#5207](https://github.com/apache/incubator-nuttx/pull/5207) fs: procfs: Remove the unnecessary strcmp 
-* [#5554](https://github.com/apache/incubator-nuttx/pull/5554) fs: procfs: add newline /proc/*/loadavg snprintf format 
-* [#5157](https://github.com/apache/incubator-nuttx/pull/5157) fs: romfs: remove the error single list and using reference 
-* [#5461](https://github.com/apache/incubator-nuttx/pull/5461) fs: romfs: add FAR for all pointer and optimize some code 
-* [#5635](https://github.com/apache/incubator-nuttx/pull/5635) fs: romfs: optimize romfs_open speed and get path by cmd FIOC_FILEPATH 
-* [#5022](https://github.com/apache/incubator-nuttx/pull/5022) fs: tmpfs: support fsync always successful 
-* [#5014](https://github.com/apache/incubator-nuttx/pull/5014) fs: vfs: Add file descriptor based timers support 
-* [#5028](https://github.com/apache/incubator-nuttx/pull/5028) fs: vfs: eventfd: Remove the unused and private eventfd_get_minor 
-* [#5224](https://github.com/apache/incubator-nuttx/pull/5224) fs: vfs: Do not require write-access for fsync 
-* [#4767](https://github.com/apache/incubator-nuttx/pull/4767) fs: vfs: sanity check for parameter:length 
+* [#5108](https://github.com/apache/nuttx/pull/5108) fs: change fs strncpy to strlcpy to avoid losing'\0' 
+* [#5460](https://github.com/apache/nuttx/pull/5460) fs: epoll_fd: support dup file descriptor
+* [#5345](https://github.com/apache/nuttx/pull/5345) fs: fs_automount: add options for signaling when volume is mounted and unmounted 
+* [#4934](https://github.com/apache/nuttx/pull/4934) fs: hosfs_rpmsg: merge hostfs_rpmsg to rpmsgfs 
+* [#4986](https://github.com/apache/nuttx/pull/4986) fs: hostfs: add lock to hostfs_rewinddir 
+* [#4718](https://github.com/apache/nuttx/pull/4718) fs: mount: Properly handle missing FS on the supported list 
+* [#4721](https://github.com/apache/nuttx/pull/4721) fs: mqueue: Change MAX_MQUEUE_PATH to 64 
+* [#4734](https://github.com/apache/nuttx/pull/4734) fs: partition: support mbr and gpt partition parsing 
+* [#4687](https://github.com/apache/nuttx/pull/4687) fs: partition: Make read_partition_block callable outside ptable 
+* [#5207](https://github.com/apache/nuttx/pull/5207) fs: procfs: Remove the unnecessary strcmp 
+* [#5554](https://github.com/apache/nuttx/pull/5554) fs: procfs: add newline /proc/*/loadavg snprintf format 
+* [#5157](https://github.com/apache/nuttx/pull/5157) fs: romfs: remove the error single list and using reference 
+* [#5461](https://github.com/apache/nuttx/pull/5461) fs: romfs: add FAR for all pointer and optimize some code 
+* [#5635](https://github.com/apache/nuttx/pull/5635) fs: romfs: optimize romfs_open speed and get path by cmd FIOC_FILEPATH 
+* [#5022](https://github.com/apache/nuttx/pull/5022) fs: tmpfs: support fsync always successful 
+* [#5014](https://github.com/apache/nuttx/pull/5014) fs: vfs: Add file descriptor based timers support 
+* [#5028](https://github.com/apache/nuttx/pull/5028) fs: vfs: eventfd: Remove the unused and private eventfd_get_minor 
+* [#5224](https://github.com/apache/nuttx/pull/5224) fs: vfs: Do not require write-access for fsync 
+* [#4767](https://github.com/apache/nuttx/pull/4767) fs: vfs: sanity check for parameter:length 
 
 ## Networking
 
 ### Improvements
 
-* [#5254](https://github.com/apache/incubator-nuttx/pull/5254) net: unify FAR keyword usage for all net buffer memory mapped buffers 
-* [#5049](https://github.com/apache/incubator-nuttx/pull/5049) net: Update IFF_RUNNING flag by netdev_carrier_on and netdev_carrier_off 
-* [#4895](https://github.com/apache/incubator-nuttx/pull/4895) net: arp: clean the arp table when netdev carrier off 
-* [#5168](https://github.com/apache/incubator-nuttx/pull/5168) net: can: add CAN error definitions 
-* [#4814](https://github.com/apache/incubator-nuttx/pull/4814) net: can: can_recvmsg.c : put can_readahead in critical section 
-* [#5467](https://github.com/apache/incubator-nuttx/pull/5467) net: can: remove psock reference from can connect 
-* [#5110](https://github.com/apache/incubator-nuttx/pull/5110) net: devif: allocate devif callback dynamically 
-* [#5181](https://github.com/apache/incubator-nuttx/pull/5181) net: devif: devif_callback_free() call is not needed anymore in devif_callback_alloc() 
-* [#5136](https://github.com/apache/incubator-nuttx/pull/5136) net: icmp: post the semaphore if multiple references 
-* [#5525](https://github.com/apache/incubator-nuttx/pull/5525) net: ioballoc: add support of alloc with timeout net_iobtimedalloc() 
-* [#5426](https://github.com/apache/incubator-nuttx/pull/5426) net: local: Rename NET_LOCAL_PATH_PREFIX to NET_LOCAL_VFS_PATH 
-* [#4987](https://github.com/apache/incubator-nuttx/pull/4987) net: local_socket: filename use "/var/socket/xx" instead of "/var/socketxx" 
-* [#5150](https://github.com/apache/incubator-nuttx/pull/5150) net: misc: add support for CONFIG_NET_ALLOC_CONNS 
-* [#5725](https://github.com/apache/incubator-nuttx/pull/5725) net: optimize network subsystem initialization 
-* [#4973](https://github.com/apache/incubator-nuttx/pull/4973) net: rpmsg: add ioctl & fix unblock connect crash 
-* [#4760](https://github.com/apache/incubator-nuttx/pull/4760) net: socket: rpmsg related bug fix & update 
-* [#5337](https://github.com/apache/incubator-nuttx/pull/5337) net: tcbinfo: Update tcbinfo struct, Fix the compile warning 
-* [#5526](https://github.com/apache/incubator-nuttx/pull/5526) net: tcp: add support for send timeout on buffer mode 
-* [#5373](https://github.com/apache/incubator-nuttx/pull/5373) net: tcp: add debug asserts and logging to investigate the rare (conn->dev == NULL) bug in callback handlers 
-* [#5462](https://github.com/apache/incubator-nuttx/pull/5462) net: tcp: monitor: do not migrate the state to close 
-* [#5405](https://github.com/apache/incubator-nuttx/pull/5405) net: tcp: netdev/mld: correct the netlock handling 
-* [#4660](https://github.com/apache/incubator-nuttx/pull/4660) net: tcp: Remove NET_TCP_SPLIT 
-* [#5469](https://github.com/apache/incubator-nuttx/pull/5469) net: tcp: support for FIN+ACK case in tcp send event handlers 
-* [#5341](https://github.com/apache/incubator-nuttx/pull/5341) net: tcp: transformed NET_TCP_FAST_RETRANSMIT_WATERMARK option to boolean. 
-* [#5434](https://github.com/apache/incubator-nuttx/pull/5434) net: tcp: udp: remove psock hook to avoid invalid reference 
-* [#5339](https://github.com/apache/incubator-nuttx/pull/5339) net: tcp/tcp_sendfile: optimized out sendfile_txnotify() function 
-* [#5252](https://github.com/apache/incubator-nuttx/pull/5252) net: tcp/tcp_send*: reliably obtain the TCP connection pointer in TCP event handlers 
-* [#5268](https://github.com/apache/incubator-nuttx/pull/5268) net: tcp/tcp_send*: added debug asserts for TCP_ACKDATA, TCP_REXMIT and TCP_DISCONN_EVENTS flags 
-* [#5262](https://github.com/apache/incubator-nuttx/pull/5262) net: tcp/sendfile: swapped the location of TCP_DISCONN_EVENTS and TCP_ACKDATA conditions 
-* [#5340](https://github.com/apache/incubator-nuttx/pull/5340) net: tcp/sendfile: notify the device driver of the availability of TX data on TCP retransmission 
-* [#5311](https://github.com/apache/incubator-nuttx/pull/5311) net: tcp/sendfile: fast retransmit on duplicate acknowledgments (RFC 5681) 
-* [#5242](https://github.com/apache/incubator-nuttx/pull/5242) net: tcp/sendfile: TCP retransmission could not start because of incorrect snd_ackcb callback handling 
-* [#5104](https://github.com/apache/incubator-nuttx/pull/5104) net: tcp/udp: allocate tcp/udp connect dynamically 
-* [#5156](https://github.com/apache/incubator-nuttx/pull/5156) net: usrsock: add support for CONFIG_NET_ALLOC_CONNS 
-* [#5045](https://github.com/apache/incubator-nuttx/pull/5045) net: usrsock: increase the sendto() length limit to UINT32_MAX 
+* [#5254](https://github.com/apache/nuttx/pull/5254) net: unify FAR keyword usage for all net buffer memory mapped buffers 
+* [#5049](https://github.com/apache/nuttx/pull/5049) net: Update IFF_RUNNING flag by netdev_carrier_on and netdev_carrier_off 
+* [#4895](https://github.com/apache/nuttx/pull/4895) net: arp: clean the arp table when netdev carrier off 
+* [#5168](https://github.com/apache/nuttx/pull/5168) net: can: add CAN error definitions 
+* [#4814](https://github.com/apache/nuttx/pull/4814) net: can: can_recvmsg.c : put can_readahead in critical section 
+* [#5467](https://github.com/apache/nuttx/pull/5467) net: can: remove psock reference from can connect 
+* [#5110](https://github.com/apache/nuttx/pull/5110) net: devif: allocate devif callback dynamically 
+* [#5181](https://github.com/apache/nuttx/pull/5181) net: devif: devif_callback_free() call is not needed anymore in devif_callback_alloc() 
+* [#5136](https://github.com/apache/nuttx/pull/5136) net: icmp: post the semaphore if multiple references 
+* [#5525](https://github.com/apache/nuttx/pull/5525) net: ioballoc: add support of alloc with timeout net_iobtimedalloc() 
+* [#5426](https://github.com/apache/nuttx/pull/5426) net: local: Rename NET_LOCAL_PATH_PREFIX to NET_LOCAL_VFS_PATH 
+* [#4987](https://github.com/apache/nuttx/pull/4987) net: local_socket: filename use "/var/socket/xx" instead of "/var/socketxx" 
+* [#5150](https://github.com/apache/nuttx/pull/5150) net: misc: add support for CONFIG_NET_ALLOC_CONNS 
+* [#5725](https://github.com/apache/nuttx/pull/5725) net: optimize network subsystem initialization 
+* [#4973](https://github.com/apache/nuttx/pull/4973) net: rpmsg: add ioctl & fix unblock connect crash 
+* [#4760](https://github.com/apache/nuttx/pull/4760) net: socket: rpmsg related bug fix & update 
+* [#5337](https://github.com/apache/nuttx/pull/5337) net: tcbinfo: Update tcbinfo struct, Fix the compile warning 
+* [#5526](https://github.com/apache/nuttx/pull/5526) net: tcp: add support for send timeout on buffer mode 
+* [#5373](https://github.com/apache/nuttx/pull/5373) net: tcp: add debug asserts and logging to investigate the rare (conn->dev == NULL) bug in callback handlers 
+* [#5462](https://github.com/apache/nuttx/pull/5462) net: tcp: monitor: do not migrate the state to close 
+* [#5405](https://github.com/apache/nuttx/pull/5405) net: tcp: netdev/mld: correct the netlock handling 
+* [#4660](https://github.com/apache/nuttx/pull/4660) net: tcp: Remove NET_TCP_SPLIT 
+* [#5469](https://github.com/apache/nuttx/pull/5469) net: tcp: support for FIN+ACK case in tcp send event handlers 
+* [#5341](https://github.com/apache/nuttx/pull/5341) net: tcp: transformed NET_TCP_FAST_RETRANSMIT_WATERMARK option to boolean. 
+* [#5434](https://github.com/apache/nuttx/pull/5434) net: tcp: udp: remove psock hook to avoid invalid reference 
+* [#5339](https://github.com/apache/nuttx/pull/5339) net: tcp/tcp_sendfile: optimized out sendfile_txnotify() function 
+* [#5252](https://github.com/apache/nuttx/pull/5252) net: tcp/tcp_send*: reliably obtain the TCP connection pointer in TCP event handlers 
+* [#5268](https://github.com/apache/nuttx/pull/5268) net: tcp/tcp_send*: added debug asserts for TCP_ACKDATA, TCP_REXMIT and TCP_DISCONN_EVENTS flags 
+* [#5262](https://github.com/apache/nuttx/pull/5262) net: tcp/sendfile: swapped the location of TCP_DISCONN_EVENTS and TCP_ACKDATA conditions 
+* [#5340](https://github.com/apache/nuttx/pull/5340) net: tcp/sendfile: notify the device driver of the availability of TX data on TCP retransmission 
+* [#5311](https://github.com/apache/nuttx/pull/5311) net: tcp/sendfile: fast retransmit on duplicate acknowledgments (RFC 5681) 
+* [#5242](https://github.com/apache/nuttx/pull/5242) net: tcp/sendfile: TCP retransmission could not start because of incorrect snd_ackcb callback handling 
+* [#5104](https://github.com/apache/nuttx/pull/5104) net: tcp/udp: allocate tcp/udp connect dynamically 
+* [#5156](https://github.com/apache/nuttx/pull/5156) net: usrsock: add support for CONFIG_NET_ALLOC_CONNS 
+* [#5045](https://github.com/apache/nuttx/pull/5045) net: usrsock: increase the sendto() length limit to UINT32_MAX 
 
 ### Bug Fixes
 
-* [#5480](https://github.com/apache/incubator-nuttx/pull/5480) net: can: can_setsockopt.c: fix assertion, value can be NULL 
-* [#5141](https://github.com/apache/incubator-nuttx/pull/5141) net: can: SocketCAN: minor fixes 
-* [#4575](https://github.com/apache/incubator-nuttx/pull/4575) net: devif: Fix the memory leak in case of netdev isn't alive 
-* [#5437](https://github.com/apache/incubator-nuttx/pull/5437) net: devif: remove invalid NET_IPv4_REASSEMBLY definition  
-* [#5090](https://github.com/apache/incubator-nuttx/pull/5090) net: fix unaligned memory access when creating ICMP Port Unreachable messages 
-* [#5245](https://github.com/apache/incubator-nuttx/pull/5245) net: icmp: fix build break if enable NET_ALLOC_CONNS 
-* [#4761](https://github.com/apache/incubator-nuttx/pull/4761) net: local: socket bug fix & update 
-* [#5436](https://github.com/apache/incubator-nuttx/pull/5436) net: netdev: lladdrsize: remove invalid duplicate case 
-* [#5466](https://github.com/apache/incubator-nuttx/pull/5466) net: rpmsg: fix the NULL pointer reference on nonblock accept 
-* [#5531](https://github.com/apache/incubator-nuttx/pull/5531) net: socket: fix shadow variable 
-* [#5006](https://github.com/apache/incubator-nuttx/pull/5006) net: tcp: fix send deadlock if disconnect 
-* [#5296](https://github.com/apache/incubator-nuttx/pull/5296) net: tcp: fixed warning: ISO C90 forbids mixed declarations and code 
-* [#4639](https://github.com/apache/incubator-nuttx/pull/4639) net: tcp_timer: eliminated false decrements of conn->timer in case of multiple network adapters. 
-* [#4659](https://github.com/apache/incubator-nuttx/pull/4659) net: tcp(unbuffered): retransmit only one the earliest not acknowledged segment 
-* [#4656](https://github.com/apache/incubator-nuttx/pull/4656) net: tcp(unbuffered): fixed an issue with unackseq calculation. 
-* [#5138](https://github.com/apache/incubator-nuttx/pull/5138) net: tcp(unbuffered): advance sndseq by +1 because SYN and FIN occupy one sequence number 
-* [#5137](https://github.com/apache/incubator-nuttx/pull/5137) net: tcp(unbuffered): fast retransmit on duplicate acknowledgments 
-* [#5078](https://github.com/apache/incubator-nuttx/pull/5078) net: tcp(unbuffered): tx_unacked overflow occurred if NET_TCP_WINDOW_SCALE option was enabled. 
-* [#5102](https://github.com/apache/incubator-nuttx/pull/5102) net: tcp(unbuffered): removed excessive overwrites of conn->sndseq 
-* [#5297](https://github.com/apache/incubator-nuttx/pull/5297) net: tcp/sendfile: removed excessive overwrites of conn->sndseq 
-* [#5239](https://github.com/apache/incubator-nuttx/pull/5239) net: tcp/sendfile: NET_TCP_WRITE_BUFFERS and NET_SENDFILE were inconsistent with each other 
-* [#5293](https://github.com/apache/incubator-nuttx/pull/5293) net: tcp/sendfile: fixed an issue with unackseq calculation. 
-* [#5272](https://github.com/apache/incubator-nuttx/pull/5272) net: tcp/sendfile: retransmit only one the earliest not acknowledged segment 
-* [#5013](https://github.com/apache/incubator-nuttx/pull/5013) net: udp: fix the invaild udp destination address 
-* [#4890](https://github.com/apache/incubator-nuttx/pull/4890) net: udp/icmp: correct the unreadchable handling 
-* [#5154](https://github.com/apache/incubator-nuttx/pull/5154) net: usrsock: replace xid type to uint64_t to avoid limitation of connections 
+* [#5480](https://github.com/apache/nuttx/pull/5480) net: can: can_setsockopt.c: fix assertion, value can be NULL 
+* [#5141](https://github.com/apache/nuttx/pull/5141) net: can: SocketCAN: minor fixes 
+* [#4575](https://github.com/apache/nuttx/pull/4575) net: devif: Fix the memory leak in case of netdev isn't alive 
+* [#5437](https://github.com/apache/nuttx/pull/5437) net: devif: remove invalid NET_IPv4_REASSEMBLY definition  
+* [#5090](https://github.com/apache/nuttx/pull/5090) net: fix unaligned memory access when creating ICMP Port Unreachable messages 
+* [#5245](https://github.com/apache/nuttx/pull/5245) net: icmp: fix build break if enable NET_ALLOC_CONNS 
+* [#4761](https://github.com/apache/nuttx/pull/4761) net: local: socket bug fix & update 
+* [#5436](https://github.com/apache/nuttx/pull/5436) net: netdev: lladdrsize: remove invalid duplicate case 
+* [#5466](https://github.com/apache/nuttx/pull/5466) net: rpmsg: fix the NULL pointer reference on nonblock accept 
+* [#5531](https://github.com/apache/nuttx/pull/5531) net: socket: fix shadow variable 
+* [#5006](https://github.com/apache/nuttx/pull/5006) net: tcp: fix send deadlock if disconnect 
+* [#5296](https://github.com/apache/nuttx/pull/5296) net: tcp: fixed warning: ISO C90 forbids mixed declarations and code 
+* [#4639](https://github.com/apache/nuttx/pull/4639) net: tcp_timer: eliminated false decrements of conn->timer in case of multiple network adapters. 
+* [#4659](https://github.com/apache/nuttx/pull/4659) net: tcp(unbuffered): retransmit only one the earliest not acknowledged segment 
+* [#4656](https://github.com/apache/nuttx/pull/4656) net: tcp(unbuffered): fixed an issue with unackseq calculation. 
+* [#5138](https://github.com/apache/nuttx/pull/5138) net: tcp(unbuffered): advance sndseq by +1 because SYN and FIN occupy one sequence number 
+* [#5137](https://github.com/apache/nuttx/pull/5137) net: tcp(unbuffered): fast retransmit on duplicate acknowledgments 
+* [#5078](https://github.com/apache/nuttx/pull/5078) net: tcp(unbuffered): tx_unacked overflow occurred if NET_TCP_WINDOW_SCALE option was enabled. 
+* [#5102](https://github.com/apache/nuttx/pull/5102) net: tcp(unbuffered): removed excessive overwrites of conn->sndseq 
+* [#5297](https://github.com/apache/nuttx/pull/5297) net: tcp/sendfile: removed excessive overwrites of conn->sndseq 
+* [#5239](https://github.com/apache/nuttx/pull/5239) net: tcp/sendfile: NET_TCP_WRITE_BUFFERS and NET_SENDFILE were inconsistent with each other 
+* [#5293](https://github.com/apache/nuttx/pull/5293) net: tcp/sendfile: fixed an issue with unackseq calculation. 
+* [#5272](https://github.com/apache/nuttx/pull/5272) net: tcp/sendfile: retransmit only one the earliest not acknowledged segment 
+* [#5013](https://github.com/apache/nuttx/pull/5013) net: udp: fix the invaild udp destination address 
+* [#4890](https://github.com/apache/nuttx/pull/4890) net: udp/icmp: correct the unreadchable handling 
+* [#5154](https://github.com/apache/nuttx/pull/5154) net: usrsock: replace xid type to uint64_t to avoid limitation of connections 
 
 ## Security Issues Fixed In This Release
 

--- a/_releases/11.0.0.md
+++ b/_releases/11.0.0.md
@@ -50,860 +50,860 @@ limitations under the License.
 
 ## Bug Fixes and Improvements
 
-* [#5978](https://github.com/apache/incubator-nuttx/pull/5978) nuttx: unify FAR attribute usage across the code
-* [#6064](https://github.com/apache/incubator-nuttx/pull/6064) sched/environ: Ensure tg_envp terminated by double
-* [#6038](https://github.com/apache/incubator-nuttx/pull/6038) sched/pthread_create:fix bug,delete data_sem
-* [#6035](https://github.com/apache/incubator-nuttx/pull/6035) sched/init: drivers_initialize() should be late than up_initialize()
-* [#6026](https://github.com/apache/incubator-nuttx/pull/6026) sched/note: include-able from C++ files
-* [#6083](https://github.com/apache/incubator-nuttx/pull/6083) sched/environ: Refine the environment variables storage layout
-* [#5992](https://github.com/apache/incubator-nuttx/pull/5992) sched/note: correct flatten format
-* [#6271](https://github.com/apache/incubator-nuttx/pull/6271) sched: Replace pthread_sem_take with nxsem_wait_uninterruptible
-* [#6220](https://github.com/apache/incubator-nuttx/pull/6220) sched/note: fix build break
-* [#6215](https://github.com/apache/incubator-nuttx/pull/6215) sched/group: addrenv: allocate current group for each cpu
-* [#6153](https://github.com/apache/incubator-nuttx/pull/6153) sched:fix mq_timedsend describe
-* [#6135](https://github.com/apache/incubator-nuttx/pull/6135) sched: cpuload: add pm callbacks for cpuidle and time compensate for idle task
-* [#5986](https://github.com/apache/incubator-nuttx/pull/5986) sched/irq: Fix array overrun in coverity check
-* [#5859](https://github.com/apache/incubator-nuttx/pull/5859) sched/sched_timerexpiration.c: change from sched_time to eventtime
-* [#6137](https://github.com/apache/incubator-nuttx/pull/6137) sched: remove DEBUGASSERT from nx_waitpid
-* [#5929](https://github.com/apache/incubator-nuttx/pull/5929) sched/pthread:need check pthread is DETACHED
-* [#5915](https://github.com/apache/incubator-nuttx/pull/5915) sched/note: add support of trace section mark
-* [#6328](https://github.com/apache/incubator-nuttx/pull/6328) sched: Move the call of pthread_mutex_inconsistent to nxtask_recover
-* [#6329](https://github.com/apache/incubator-nuttx/pull/6329) sched/pthread: Should call up_exit in pthread_exit
-* [#6296](https://github.com/apache/incubator-nuttx/pull/6296) sched/wqueue: Add work_timeleft macro to get the left time to start
-* [#5753](https://github.com/apache/incubator-nuttx/pull/5753) Fix the initial idle tasks environment
-* [#5793](https://github.com/apache/incubator-nuttx/pull/5793) sched/module: correct the check condition
-* [#6716](https://github.com/apache/incubator-nuttx/pull/6716) sched/Makefile: move task_reparent.c to appropriate Makefile
-* [#6707](https://github.com/apache/incubator-nuttx/pull/6707) sched: Remove the not really used cmptime
-* [#6679](https://github.com/apache/incubator-nuttx/pull/6679) sched_critmonitor: remove check zero in sched_critmonitor
-* [#6677](https://github.com/apache/incubator-nuttx/pull/6677) sched: handle nxtask_setup_arguments return values
-* [#6628](https://github.com/apache/incubator-nuttx/pull/6628) sched/timer: timer_settime not fully satisfy IEEE 1003.1
-* [#6423](https://github.com/apache/incubator-nuttx/pull/6423) sched/env: Fix the return value of unsetenv()
-* [#6410](https://github.com/apache/incubator-nuttx/pull/6410) sched/mqueue: do sanity check if DEBUG_FEATURES is enabled
-* [#6403](https://github.com/apache/incubator-nuttx/pull/6403) sched/mqueue: configurable mqueue notification
-* [#6402](https://github.com/apache/incubator-nuttx/pull/6402) sched/mqueue: minor code tuning of message queue
-* [#6393](https://github.com/apache/incubator-nuttx/pull/6393) sched/mqueue: replace inline linklist to improve performance
-* [#6392](https://github.com/apache/incubator-nuttx/pull/6392) sched/mqueue: remove sched_lock to improve performance
-* [#6377](https://github.com/apache/incubator-nuttx/pull/6377) sched/tls: Shouldn't get tls info directly from sp in kernel space
-* [#6365](https://github.com/apache/incubator-nuttx/pull/6365) sched/tls: Wrap up_info_size into tls_info_size
-* [#6340](https://github.com/apache/incubator-nuttx/pull/6340) Change dpends on SCHED_[L|H]PWORK to SCHED_WORKQUEUE
-* [#6250](https://github.com/apache/incubator-nuttx/pull/6250) sched: Remove task_restart in case of CONFIG_BUILD_KERNEL
-* [#6236](https://github.com/apache/incubator-nuttx/pull/6236) sched: Remove task_delete in case of CONFIG_BUILD_KERNEL
-* [#5822](https://github.com/apache/incubator-nuttx/pull/5822) sched/dumpstack: Print "backtrace:" only in the first iteration
-* [#5925](https://github.com/apache/incubator-nuttx/pull/5925) sigact: get free sigact from freelist always successful
-* [#6227](https://github.com/apache/incubator-nuttx/pull/6227) Replace all sem_wait with nxsem_wait
-* [#5931](https://github.com/apache/incubator-nuttx/pull/5931) fix: pthread_rwlock_timedwrlock.
-* [#6348](https://github.com/apache/incubator-nuttx/pull/6348) cpuload: use correct pm cpuload tick
-* [#5888](https://github.com/apache/incubator-nuttx/pull/5888) workqueue: add work_foreach support
-* [#6226](https://github.com/apache/incubator-nuttx/pull/6226) Replace nxsem_timedwait_uninterruptible with nxsem_tickwait_uninterruptible
-* [#6085](https://github.com/apache/incubator-nuttx/pull/6085) semaphore: fix usage of NXSEM_INITIALIZER
-* [#5819](https://github.com/apache/incubator-nuttx/pull/5819) pid_t: unify usage of special task IDs
-* [#6611](https://github.com/apache/incubator-nuttx/pull/6611) include: Declare nxtask_delete function
-* [#5960](https://github.com/apache/incubator-nuttx/pull/5960) timerexpiration:fix DEADCODE when RR_INTERVAL or SCHED_SPORADIC not select
-* [#6745](https://github.com/apache/incubator-nuttx/pull/6745) Remove the private NULL, TRUE and FALSE macros
-* [#6489](https://github.com/apache/incubator-nuttx/pull/6489) syscall: Remove exit() call gate
-* [#5887](https://github.com/apache/incubator-nuttx/pull/5887) signal: Don't do schedule_sigaction when there is no action
-* [#6359](https://github.com/apache/incubator-nuttx/pull/6359) signal: add define of SIGHUP/SIGTTIN
-* [#6283](https://github.com/apache/incubator-nuttx/pull/6283) pthread/spinlock: Call up_testsest directly in the flat build
-* [#6282](https://github.com/apache/incubator-nuttx/pull/6282) timers/watchdog: Ensure it's the idle domain before keepalive
-* [#6133](https://github.com/apache/incubator-nuttx/pull/6133) syscall: Fix prototype of exec() to syscall.csv
-* [#6616](https://github.com/apache/incubator-nuttx/pull/6616) syscall: Add socketpair to syscall.csv
-* [#6120](https://github.com/apache/incubator-nuttx/pull/6120) Implement execle, execve, execvp, execlp and execvpe
-* [#5814](https://github.com/apache/incubator-nuttx/pull/5814) env_dup: Allocate memory from the correct memory pool
+* [#5978](https://github.com/apache/nuttx/pull/5978) nuttx: unify FAR attribute usage across the code
+* [#6064](https://github.com/apache/nuttx/pull/6064) sched/environ: Ensure tg_envp terminated by double
+* [#6038](https://github.com/apache/nuttx/pull/6038) sched/pthread_create:fix bug,delete data_sem
+* [#6035](https://github.com/apache/nuttx/pull/6035) sched/init: drivers_initialize() should be late than up_initialize()
+* [#6026](https://github.com/apache/nuttx/pull/6026) sched/note: include-able from C++ files
+* [#6083](https://github.com/apache/nuttx/pull/6083) sched/environ: Refine the environment variables storage layout
+* [#5992](https://github.com/apache/nuttx/pull/5992) sched/note: correct flatten format
+* [#6271](https://github.com/apache/nuttx/pull/6271) sched: Replace pthread_sem_take with nxsem_wait_uninterruptible
+* [#6220](https://github.com/apache/nuttx/pull/6220) sched/note: fix build break
+* [#6215](https://github.com/apache/nuttx/pull/6215) sched/group: addrenv: allocate current group for each cpu
+* [#6153](https://github.com/apache/nuttx/pull/6153) sched:fix mq_timedsend describe
+* [#6135](https://github.com/apache/nuttx/pull/6135) sched: cpuload: add pm callbacks for cpuidle and time compensate for idle task
+* [#5986](https://github.com/apache/nuttx/pull/5986) sched/irq: Fix array overrun in coverity check
+* [#5859](https://github.com/apache/nuttx/pull/5859) sched/sched_timerexpiration.c: change from sched_time to eventtime
+* [#6137](https://github.com/apache/nuttx/pull/6137) sched: remove DEBUGASSERT from nx_waitpid
+* [#5929](https://github.com/apache/nuttx/pull/5929) sched/pthread:need check pthread is DETACHED
+* [#5915](https://github.com/apache/nuttx/pull/5915) sched/note: add support of trace section mark
+* [#6328](https://github.com/apache/nuttx/pull/6328) sched: Move the call of pthread_mutex_inconsistent to nxtask_recover
+* [#6329](https://github.com/apache/nuttx/pull/6329) sched/pthread: Should call up_exit in pthread_exit
+* [#6296](https://github.com/apache/nuttx/pull/6296) sched/wqueue: Add work_timeleft macro to get the left time to start
+* [#5753](https://github.com/apache/nuttx/pull/5753) Fix the initial idle tasks environment
+* [#5793](https://github.com/apache/nuttx/pull/5793) sched/module: correct the check condition
+* [#6716](https://github.com/apache/nuttx/pull/6716) sched/Makefile: move task_reparent.c to appropriate Makefile
+* [#6707](https://github.com/apache/nuttx/pull/6707) sched: Remove the not really used cmptime
+* [#6679](https://github.com/apache/nuttx/pull/6679) sched_critmonitor: remove check zero in sched_critmonitor
+* [#6677](https://github.com/apache/nuttx/pull/6677) sched: handle nxtask_setup_arguments return values
+* [#6628](https://github.com/apache/nuttx/pull/6628) sched/timer: timer_settime not fully satisfy IEEE 1003.1
+* [#6423](https://github.com/apache/nuttx/pull/6423) sched/env: Fix the return value of unsetenv()
+* [#6410](https://github.com/apache/nuttx/pull/6410) sched/mqueue: do sanity check if DEBUG_FEATURES is enabled
+* [#6403](https://github.com/apache/nuttx/pull/6403) sched/mqueue: configurable mqueue notification
+* [#6402](https://github.com/apache/nuttx/pull/6402) sched/mqueue: minor code tuning of message queue
+* [#6393](https://github.com/apache/nuttx/pull/6393) sched/mqueue: replace inline linklist to improve performance
+* [#6392](https://github.com/apache/nuttx/pull/6392) sched/mqueue: remove sched_lock to improve performance
+* [#6377](https://github.com/apache/nuttx/pull/6377) sched/tls: Shouldn't get tls info directly from sp in kernel space
+* [#6365](https://github.com/apache/nuttx/pull/6365) sched/tls: Wrap up_info_size into tls_info_size
+* [#6340](https://github.com/apache/nuttx/pull/6340) Change dpends on SCHED_[L|H]PWORK to SCHED_WORKQUEUE
+* [#6250](https://github.com/apache/nuttx/pull/6250) sched: Remove task_restart in case of CONFIG_BUILD_KERNEL
+* [#6236](https://github.com/apache/nuttx/pull/6236) sched: Remove task_delete in case of CONFIG_BUILD_KERNEL
+* [#5822](https://github.com/apache/nuttx/pull/5822) sched/dumpstack: Print "backtrace:" only in the first iteration
+* [#5925](https://github.com/apache/nuttx/pull/5925) sigact: get free sigact from freelist always successful
+* [#6227](https://github.com/apache/nuttx/pull/6227) Replace all sem_wait with nxsem_wait
+* [#5931](https://github.com/apache/nuttx/pull/5931) fix: pthread_rwlock_timedwrlock.
+* [#6348](https://github.com/apache/nuttx/pull/6348) cpuload: use correct pm cpuload tick
+* [#5888](https://github.com/apache/nuttx/pull/5888) workqueue: add work_foreach support
+* [#6226](https://github.com/apache/nuttx/pull/6226) Replace nxsem_timedwait_uninterruptible with nxsem_tickwait_uninterruptible
+* [#6085](https://github.com/apache/nuttx/pull/6085) semaphore: fix usage of NXSEM_INITIALIZER
+* [#5819](https://github.com/apache/nuttx/pull/5819) pid_t: unify usage of special task IDs
+* [#6611](https://github.com/apache/nuttx/pull/6611) include: Declare nxtask_delete function
+* [#5960](https://github.com/apache/nuttx/pull/5960) timerexpiration:fix DEADCODE when RR_INTERVAL or SCHED_SPORADIC not select
+* [#6745](https://github.com/apache/nuttx/pull/6745) Remove the private NULL, TRUE and FALSE macros
+* [#6489](https://github.com/apache/nuttx/pull/6489) syscall: Remove exit() call gate
+* [#5887](https://github.com/apache/nuttx/pull/5887) signal: Don't do schedule_sigaction when there is no action
+* [#6359](https://github.com/apache/nuttx/pull/6359) signal: add define of SIGHUP/SIGTTIN
+* [#6283](https://github.com/apache/nuttx/pull/6283) pthread/spinlock: Call up_testsest directly in the flat build
+* [#6282](https://github.com/apache/nuttx/pull/6282) timers/watchdog: Ensure it's the idle domain before keepalive
+* [#6133](https://github.com/apache/nuttx/pull/6133) syscall: Fix prototype of exec() to syscall.csv
+* [#6616](https://github.com/apache/nuttx/pull/6616) syscall: Add socketpair to syscall.csv
+* [#6120](https://github.com/apache/nuttx/pull/6120) Implement execle, execve, execvp, execlp and execvpe
+* [#5814](https://github.com/apache/nuttx/pull/5814) env_dup: Allocate memory from the correct memory pool
 
-* [#5914](https://github.com/apache/incubator-nuttx/pull/5914) mm/mm_heap: place alloc-bit at the LSB of node->preceeding
-* [#6685](https://github.com/apache/incubator-nuttx/pull/6685) mm/mm_heap: update MM_BACKTRACE and malloc failed output
-* [#6658](https://github.com/apache/incubator-nuttx/pull/6658) mm: Fixed the usage of CONFIG_MM_BACKTRACE & CONFIG_DEBUG_MM
-* [#5906](https://github.com/apache/incubator-nuttx/pull/5906) mm_heap: heapsize align with MM_MIN_CHUNK
-* [#6409](https://github.com/apache/incubator-nuttx/pull/6409) mm: Add mm_uninitialize to release the resource
-* [#6385](https://github.com/apache/incubator-nuttx/pull/6385) mm: Log name of the Heap to which the new region is being added
-* [#5855](https://github.com/apache/incubator-nuttx/pull/5855) mm/memdump: dynamic turn on backtrace in heap when enable DEBUG_MM
-* [#6749](https://github.com/apache/incubator-nuttx/pull/6749) mm/kasan: node header should updated from unpoisoning memory
-* [#6697](https://github.com/apache/incubator-nuttx/pull/6697) mm/circbuf: support circbuf_is_init and circ_peekat
-* [#6011](https://github.com/apache/incubator-nuttx/pull/6011) mm_initialize: malloc() return aligend pointer
-* [#6750](https://github.com/apache/incubator-nuttx/pull/6750) mm_heap/kasan: poison free node after return back the heap list
-* [#6305](https://github.com/apache/incubator-nuttx/pull/6305) Separate a few debug stuff from CONFIG_DEBUG_MM
-* [#5982](https://github.com/apache/incubator-nuttx/pull/5982) openamp: Change the dependence from OPENAMP to RPTUN
-* [#6762](https://github.com/apache/incubator-nuttx/pull/6762) merge openamp to newest version (2022.04.0)
+* [#5914](https://github.com/apache/nuttx/pull/5914) mm/mm_heap: place alloc-bit at the LSB of node->preceeding
+* [#6685](https://github.com/apache/nuttx/pull/6685) mm/mm_heap: update MM_BACKTRACE and malloc failed output
+* [#6658](https://github.com/apache/nuttx/pull/6658) mm: Fixed the usage of CONFIG_MM_BACKTRACE & CONFIG_DEBUG_MM
+* [#5906](https://github.com/apache/nuttx/pull/5906) mm_heap: heapsize align with MM_MIN_CHUNK
+* [#6409](https://github.com/apache/nuttx/pull/6409) mm: Add mm_uninitialize to release the resource
+* [#6385](https://github.com/apache/nuttx/pull/6385) mm: Log name of the Heap to which the new region is being added
+* [#5855](https://github.com/apache/nuttx/pull/5855) mm/memdump: dynamic turn on backtrace in heap when enable DEBUG_MM
+* [#6749](https://github.com/apache/nuttx/pull/6749) mm/kasan: node header should updated from unpoisoning memory
+* [#6697](https://github.com/apache/nuttx/pull/6697) mm/circbuf: support circbuf_is_init and circ_peekat
+* [#6011](https://github.com/apache/nuttx/pull/6011) mm_initialize: malloc() return aligend pointer
+* [#6750](https://github.com/apache/nuttx/pull/6750) mm_heap/kasan: poison free node after return back the heap list
+* [#6305](https://github.com/apache/nuttx/pull/6305) Separate a few debug stuff from CONFIG_DEBUG_MM
+* [#5982](https://github.com/apache/nuttx/pull/5982) openamp: Change the dependence from OPENAMP to RPTUN
+* [#6762](https://github.com/apache/nuttx/pull/6762) merge openamp to newest version (2022.04.0)
 
-* [#6067](https://github.com/apache/incubator-nuttx/pull/6067) libc/string: Use Byte-Shift algorithm for very long needles
-* [#6047](https://github.com/apache/incubator-nuttx/pull/6047) libc/lib_glob:use strlcpy instead of memcpy
-* [#6044](https://github.com/apache/incubator-nuttx/pull/6044) libc/net:use strlcpy instead of strncpy
-* [#5995](https://github.com/apache/incubator-nuttx/pull/5995) lib_lib_vsprintf/backtrace: fix the type issue
-* [#6168](https://github.com/apache/incubator-nuttx/pull/6168) Implement preadv and pwritev
-* [#5737](https://github.com/apache/incubator-nuttx/pull/5737) Add dn resolution function
-* [#6210](https://github.com/apache/incubator-nuttx/pull/6210) Optimize bool type handling in c
-* [#6029](https://github.com/apache/incubator-nuttx/pull/6029) libc:add strptime support
-* [#6445](https://github.com/apache/incubator-nuttx/pull/6445) nuttx/lib: remove dependency on BUILD_FLAT for library memory allocation interface
-* [#6389](https://github.com/apache/incubator-nuttx/pull/6389) libc/ipc: add ftok(3) support
-* [#6384](https://github.com/apache/incubator-nuttx/pull/6384) libc/stdio: Generate the dummy atexit and on_exit
-* [#6371](https://github.com/apache/incubator-nuttx/pull/6371) libc:xtensa:arch_memmove: fix warning
-* [#6370](https://github.com/apache/incubator-nuttx/pull/6370) libc:Optimize the behavior of fwrite
-* [#6360](https://github.com/apache/incubator-nuttx/pull/6360) libc/time: rearrange itimerspec struct elements
-* [#6357](https://github.com/apache/incubator-nuttx/pull/6357) libc/stdio: Support 'e'(O_CLOEXEC) in lib_mode2oflags
-* [#6248](https://github.com/apache/incubator-nuttx/pull/6248) libc: Rename lib_Exit lib__Exit
-* [#5971](https://github.com/apache/incubator-nuttx/pull/5971) libc: Avoid the compiler generate code call self(memcpy/memmove/memset/memcmp) recursively
-* [#6240](https://github.com/apache/incubator-nuttx/pull/6240) libs: Move aeabi_atexit from libxx/ to libc/machine/arm/
-* [#6229](https://github.com/apache/incubator-nuttx/pull/6229) libc/string: simplify strrchr
-* [#6197](https://github.com/apache/incubator-nuttx/pull/6197) libc: Implement userland implementations of exit functions
-* [#6196](https://github.com/apache/incubator-nuttx/pull/6196) libxx: Make HAVE_CXXINITIALIZE workable even HAVE_CXX isn't enabled
-* [#6175](https://github.com/apache/incubator-nuttx/pull/6175) libc: Remove the redundant seek in writev
-* [#6184](https://github.com/apache/incubator-nuttx/pull/6184) libc/assert: let CONFIG_NDEBUG default to !CONFIG_DEBUG_ASSERTIONS
-* [#6169](https://github.com/apache/incubator-nuttx/pull/6169) libc/arch_atomic: add gcc legacy __sync buitins support and add FAR to pointers
-* [#6140](https://github.com/apache/incubator-nuttx/pull/6140) libs/libc/string: unify implementation across the functions
-* [#5948](https://github.com/apache/incubator-nuttx/pull/5948) libc/lib_localtime:fix deadcode
-* [#5861](https://github.com/apache/incubator-nuttx/pull/5861) libs/libc/time: update description of strftime
-* [#5837](https://github.com/apache/incubator-nuttx/pull/5837) libc: Implement getrandom on top of "/dev/[u]random"
-* [#5806](https://github.com/apache/incubator-nuttx/pull/5806) libc: Change the return type of strerror from "const char*" to "char*"
-* [#5798](https://github.com/apache/incubator-nuttx/pull/5798) libc/err: fix unpaired va_end()
-* [#6139](https://github.com/apache/incubator-nuttx/pull/6139) libc/string: strcmp/strncmp cast unsigned char
-* [#6130](https://github.com/apache/incubator-nuttx/pull/6130) libc: Fix typo error in execle
-* [#6124](https://github.com/apache/incubator-nuttx/pull/6124) libc/fixedmatch: Avoid "divide by zero" error
-* [#6066](https://github.com/apache/incubator-nuttx/pull/6066) libc/blockstream: add block out stream backend
-* [#6087](https://github.com/apache/incubator-nuttx/pull/6087) libc: Don't duplicate string in chdir and lib_restoredir
-* [#5950](https://github.com/apache/incubator-nuttx/pull/5950) libs/libc/lib_err.c:add va_end to vwarn
-* [#5949](https://github.com/apache/incubator-nuttx/pull/5949) lib_chdir:change ret judgment method
-* [#5976](https://github.com/apache/incubator-nuttx/pull/5976) modlib_bind.c: Restore "Relocation address out of range" checks
-* [#5951](https://github.com/apache/incubator-nuttx/pull/5951) modlib/modlib_bind:fix unsigned_compare with zero
-* [#5952](https://github.com/apache/incubator-nuttx/pull/5952) libc/netdb: Support the recursive lock
-* [#6027](https://github.com/apache/incubator-nuttx/pull/6027) netdb/lib_dnsaddserver.c: Do not insert the duplicate DNS address
-* [#6714](https://github.com/apache/incubator-nuttx/pull/6714) libc: Remove the unnecessary include from wchar and wctype
-* [#6613](https://github.com/apache/incubator-nuttx/pull/6613) libc/stdio: Support "long long" type if CONFIG_HAVE_LONG_LONG is enabled
-* [#6607](https://github.com/apache/incubator-nuttx/pull/6607) libc/stdio: Enable LIBC_FLOATINGPOINT by default if ARCH_FPU is enabled
-* [#6606](https://github.com/apache/incubator-nuttx/pull/6606) libc/stdio: enable long long formating by CONFIG_HAVE_LONG_LONG
-* [#6547](https://github.com/apache/incubator-nuttx/pull/6547) libc: Fix getrandom() bug: Didn't propagate read error
-* [#6241](https://github.com/apache/incubator-nuttx/pull/6241) libs: risc-v: Add R_RISCV_JAL support to arch_elf.c
-* [#6667](https://github.com/apache/incubator-nuttx/pull/6667) libs/libc/string: add memmem
-* [#6666](https://github.com/apache/incubator-nuttx/pull/6666) libc/wchar: support wchar
-* [#6652](https://github.com/apache/incubator-nuttx/pull/6652) libc/impure: Fix the inconsistence from the different toolchain
-* [#6337](https://github.com/apache/incubator-nuttx/pull/6337) Refine the implementation of TLS
-* [#6434](https://github.com/apache/incubator-nuttx/pull/6434) include/cxx: Remove all non standard c++ header files
-* [#6108](https://github.com/apache/incubator-nuttx/pull/6108) assert: static_assert is not support in c standard C89,C99
-* [#5851](https://github.com/apache/incubator-nuttx/pull/5851) libxx: Add CXX_RTTI for enabling RTTI support for C++ applications
-* [#6791](https://github.com/apache/incubator-nuttx/pull/6791) Add Embedded Template Library (ETL) support
-* [#6720](https://github.com/apache/incubator-nuttx/pull/6720) libs/libc: correct config name
-* [#5890](https://github.com/apache/incubator-nuttx/pull/5890) rexec: fix free error in error handing
-* [#6709](https://github.com/apache/incubator-nuttx/pull/6709) Imx6 adb
-* [#6586](https://github.com/apache/incubator-nuttx/pull/6586) Sabre6quad netknsh
-* [#6482](https://github.com/apache/incubator-nuttx/pull/6482) Use builtins for byteswapping
-* [#6421](https://github.com/apache/incubator-nuttx/pull/6421) getrandom: use _NX_XXXX interface to remove cancelation point for kernel
+* [#6067](https://github.com/apache/nuttx/pull/6067) libc/string: Use Byte-Shift algorithm for very long needles
+* [#6047](https://github.com/apache/nuttx/pull/6047) libc/lib_glob:use strlcpy instead of memcpy
+* [#6044](https://github.com/apache/nuttx/pull/6044) libc/net:use strlcpy instead of strncpy
+* [#5995](https://github.com/apache/nuttx/pull/5995) lib_lib_vsprintf/backtrace: fix the type issue
+* [#6168](https://github.com/apache/nuttx/pull/6168) Implement preadv and pwritev
+* [#5737](https://github.com/apache/nuttx/pull/5737) Add dn resolution function
+* [#6210](https://github.com/apache/nuttx/pull/6210) Optimize bool type handling in c
+* [#6029](https://github.com/apache/nuttx/pull/6029) libc:add strptime support
+* [#6445](https://github.com/apache/nuttx/pull/6445) nuttx/lib: remove dependency on BUILD_FLAT for library memory allocation interface
+* [#6389](https://github.com/apache/nuttx/pull/6389) libc/ipc: add ftok(3) support
+* [#6384](https://github.com/apache/nuttx/pull/6384) libc/stdio: Generate the dummy atexit and on_exit
+* [#6371](https://github.com/apache/nuttx/pull/6371) libc:xtensa:arch_memmove: fix warning
+* [#6370](https://github.com/apache/nuttx/pull/6370) libc:Optimize the behavior of fwrite
+* [#6360](https://github.com/apache/nuttx/pull/6360) libc/time: rearrange itimerspec struct elements
+* [#6357](https://github.com/apache/nuttx/pull/6357) libc/stdio: Support 'e'(O_CLOEXEC) in lib_mode2oflags
+* [#6248](https://github.com/apache/nuttx/pull/6248) libc: Rename lib_Exit lib__Exit
+* [#5971](https://github.com/apache/nuttx/pull/5971) libc: Avoid the compiler generate code call self(memcpy/memmove/memset/memcmp) recursively
+* [#6240](https://github.com/apache/nuttx/pull/6240) libs: Move aeabi_atexit from libxx/ to libc/machine/arm/
+* [#6229](https://github.com/apache/nuttx/pull/6229) libc/string: simplify strrchr
+* [#6197](https://github.com/apache/nuttx/pull/6197) libc: Implement userland implementations of exit functions
+* [#6196](https://github.com/apache/nuttx/pull/6196) libxx: Make HAVE_CXXINITIALIZE workable even HAVE_CXX isn't enabled
+* [#6175](https://github.com/apache/nuttx/pull/6175) libc: Remove the redundant seek in writev
+* [#6184](https://github.com/apache/nuttx/pull/6184) libc/assert: let CONFIG_NDEBUG default to !CONFIG_DEBUG_ASSERTIONS
+* [#6169](https://github.com/apache/nuttx/pull/6169) libc/arch_atomic: add gcc legacy __sync buitins support and add FAR to pointers
+* [#6140](https://github.com/apache/nuttx/pull/6140) libs/libc/string: unify implementation across the functions
+* [#5948](https://github.com/apache/nuttx/pull/5948) libc/lib_localtime:fix deadcode
+* [#5861](https://github.com/apache/nuttx/pull/5861) libs/libc/time: update description of strftime
+* [#5837](https://github.com/apache/nuttx/pull/5837) libc: Implement getrandom on top of "/dev/[u]random"
+* [#5806](https://github.com/apache/nuttx/pull/5806) libc: Change the return type of strerror from "const char*" to "char*"
+* [#5798](https://github.com/apache/nuttx/pull/5798) libc/err: fix unpaired va_end()
+* [#6139](https://github.com/apache/nuttx/pull/6139) libc/string: strcmp/strncmp cast unsigned char
+* [#6130](https://github.com/apache/nuttx/pull/6130) libc: Fix typo error in execle
+* [#6124](https://github.com/apache/nuttx/pull/6124) libc/fixedmatch: Avoid "divide by zero" error
+* [#6066](https://github.com/apache/nuttx/pull/6066) libc/blockstream: add block out stream backend
+* [#6087](https://github.com/apache/nuttx/pull/6087) libc: Don't duplicate string in chdir and lib_restoredir
+* [#5950](https://github.com/apache/nuttx/pull/5950) libs/libc/lib_err.c:add va_end to vwarn
+* [#5949](https://github.com/apache/nuttx/pull/5949) lib_chdir:change ret judgment method
+* [#5976](https://github.com/apache/nuttx/pull/5976) modlib_bind.c: Restore "Relocation address out of range" checks
+* [#5951](https://github.com/apache/nuttx/pull/5951) modlib/modlib_bind:fix unsigned_compare with zero
+* [#5952](https://github.com/apache/nuttx/pull/5952) libc/netdb: Support the recursive lock
+* [#6027](https://github.com/apache/nuttx/pull/6027) netdb/lib_dnsaddserver.c: Do not insert the duplicate DNS address
+* [#6714](https://github.com/apache/nuttx/pull/6714) libc: Remove the unnecessary include from wchar and wctype
+* [#6613](https://github.com/apache/nuttx/pull/6613) libc/stdio: Support "long long" type if CONFIG_HAVE_LONG_LONG is enabled
+* [#6607](https://github.com/apache/nuttx/pull/6607) libc/stdio: Enable LIBC_FLOATINGPOINT by default if ARCH_FPU is enabled
+* [#6606](https://github.com/apache/nuttx/pull/6606) libc/stdio: enable long long formating by CONFIG_HAVE_LONG_LONG
+* [#6547](https://github.com/apache/nuttx/pull/6547) libc: Fix getrandom() bug: Didn't propagate read error
+* [#6241](https://github.com/apache/nuttx/pull/6241) libs: risc-v: Add R_RISCV_JAL support to arch_elf.c
+* [#6667](https://github.com/apache/nuttx/pull/6667) libs/libc/string: add memmem
+* [#6666](https://github.com/apache/nuttx/pull/6666) libc/wchar: support wchar
+* [#6652](https://github.com/apache/nuttx/pull/6652) libc/impure: Fix the inconsistence from the different toolchain
+* [#6337](https://github.com/apache/nuttx/pull/6337) Refine the implementation of TLS
+* [#6434](https://github.com/apache/nuttx/pull/6434) include/cxx: Remove all non standard c++ header files
+* [#6108](https://github.com/apache/nuttx/pull/6108) assert: static_assert is not support in c standard C89,C99
+* [#5851](https://github.com/apache/nuttx/pull/5851) libxx: Add CXX_RTTI for enabling RTTI support for C++ applications
+* [#6791](https://github.com/apache/nuttx/pull/6791) Add Embedded Template Library (ETL) support
+* [#6720](https://github.com/apache/nuttx/pull/6720) libs/libc: correct config name
+* [#5890](https://github.com/apache/nuttx/pull/5890) rexec: fix free error in error handing
+* [#6709](https://github.com/apache/nuttx/pull/6709) Imx6 adb
+* [#6586](https://github.com/apache/nuttx/pull/6586) Sabre6quad netknsh
+* [#6482](https://github.com/apache/nuttx/pull/6482) Use builtins for byteswapping
+* [#6421](https://github.com/apache/nuttx/pull/6421) getrandom: use _NX_XXXX interface to remove cancelation point for kernel
 
-* [#6205](https://github.com/apache/incubator-nuttx/pull/6205) binfmt/libelf: Fix function description field
-* [#6190](https://github.com/apache/incubator-nuttx/pull/6190) binfmt_execmodule: Use heap size getter for print
+* [#6205](https://github.com/apache/nuttx/pull/6205) binfmt/libelf: Fix function description field
+* [#6190](https://github.com/apache/nuttx/pull/6190) binfmt_execmodule: Use heap size getter for print
 
 # Major Changes to the Build System
 
 ## Bug Fixes and Improvements
 
-* [#6015](https://github.com/apache/incubator-nuttx/pull/6015) configure.sh: Make top Make.defs symlink to board Make.defs instead
-* [#6014](https://github.com/apache/incubator-nuttx/pull/6014) checkpatch.sh: add -m option to enable/disable Change-Id check
-* [#6013](https://github.com/apache/incubator-nuttx/pull/6013) tools/mkdeps: Extend MAX_SHQUOTE to 3072
-* [#6094](https://github.com/apache/incubator-nuttx/pull/6094) tools/cibuild.sh: Migrate risc-v toolchian from 8.3.0 to 10.2.0
-* [#5836](https://github.com/apache/incubator-nuttx/pull/5836) tools:use dump log creat a gdbsever to debug
-* [#6350](https://github.com/apache/incubator-nuttx/pull/6350) tools/gencromfs: add attribute to set minimum 4 bytes aignment for cromfs image data
-* [#6520](https://github.com/apache/incubator-nuttx/pull/6520) tools/jlink-nuttx: Move the register index check to setget_reg
-* [#5826](https://github.com/apache/incubator-nuttx/pull/5826) tools/jlink: Change the type of pid from uint16_t to uint32_t
-* [#5808](https://github.com/apache/incubator-nuttx/pull/5808) tools/nxstyle: Order g_white_prefix by alphanum
-* [#6128](https://github.com/apache/incubator-nuttx/pull/6128) tools:fix parsememdump.py match error
-* [#6245](https://github.com/apache/incubator-nuttx/pull/6245) tools/mkallsyms.sh: Make it work with llvm
-* [#6129](https://github.com/apache/incubator-nuttx/pull/6129) tools:minidumpserver.py support xtensa
-* [#6132](https://github.com/apache/incubator-nuttx/pull/6132) compiler.h: optimization option is not supported before GCC 4.6
-* [#6232](https://github.com/apache/incubator-nuttx/pull/6232) tools/nxstyle: Add the suffix white list
-* [#6180](https://github.com/apache/incubator-nuttx/pull/6180) tools/testbuild.sh: Don't skip configure and distclean
+* [#6015](https://github.com/apache/nuttx/pull/6015) configure.sh: Make top Make.defs symlink to board Make.defs instead
+* [#6014](https://github.com/apache/nuttx/pull/6014) checkpatch.sh: add -m option to enable/disable Change-Id check
+* [#6013](https://github.com/apache/nuttx/pull/6013) tools/mkdeps: Extend MAX_SHQUOTE to 3072
+* [#6094](https://github.com/apache/nuttx/pull/6094) tools/cibuild.sh: Migrate risc-v toolchian from 8.3.0 to 10.2.0
+* [#5836](https://github.com/apache/nuttx/pull/5836) tools:use dump log creat a gdbsever to debug
+* [#6350](https://github.com/apache/nuttx/pull/6350) tools/gencromfs: add attribute to set minimum 4 bytes aignment for cromfs image data
+* [#6520](https://github.com/apache/nuttx/pull/6520) tools/jlink-nuttx: Move the register index check to setget_reg
+* [#5826](https://github.com/apache/nuttx/pull/5826) tools/jlink: Change the type of pid from uint16_t to uint32_t
+* [#5808](https://github.com/apache/nuttx/pull/5808) tools/nxstyle: Order g_white_prefix by alphanum
+* [#6128](https://github.com/apache/nuttx/pull/6128) tools:fix parsememdump.py match error
+* [#6245](https://github.com/apache/nuttx/pull/6245) tools/mkallsyms.sh: Make it work with llvm
+* [#6129](https://github.com/apache/nuttx/pull/6129) tools:minidumpserver.py support xtensa
+* [#6132](https://github.com/apache/nuttx/pull/6132) compiler.h: optimization option is not supported before GCC 4.6
+* [#6232](https://github.com/apache/nuttx/pull/6232) tools/nxstyle: Add the suffix white list
+* [#6180](https://github.com/apache/nuttx/pull/6180) tools/testbuild.sh: Don't skip configure and distclean
 
 # Architectural Support
 
 ## New Architecture Support
 
-* [#6179](https://github.com/apache/incubator-nuttx/pull/6179) tlsr82: first commit of telink tlsr82xx chip port
-* [#6687](https://github.com/apache/incubator-nuttx/pull/6687) Add support for NXP S32K3XX MCU family and boards
-* [#6375](https://github.com/apache/incubator-nuttx/pull/6375) stm32wl5: add new chip family
-* [#6422](https://github.com/apache/incubator-nuttx/pull/6422) New stm32wb chip family
-* [#6418](https://github.com/apache/incubator-nuttx/pull/6418) Eps32 Lilygo t5v2 BSP
-* [#6478](https://github.com/apache/incubator-nuttx/pull/6478) arch: arm64: ARMv8-A support for NuttX
+* [#6179](https://github.com/apache/nuttx/pull/6179) tlsr82: first commit of telink tlsr82xx chip port
+* [#6687](https://github.com/apache/nuttx/pull/6687) Add support for NXP S32K3XX MCU family and boards
+* [#6375](https://github.com/apache/nuttx/pull/6375) stm32wl5: add new chip family
+* [#6422](https://github.com/apache/nuttx/pull/6422) New stm32wb chip family
+* [#6418](https://github.com/apache/nuttx/pull/6418) Eps32 Lilygo t5v2 BSP
+* [#6478](https://github.com/apache/nuttx/pull/6478) arch: arm64: ARMv8-A support for NuttX
 
 ## Bug Fixes and Improvements
 
-* [#6188](https://github.com/apache/incubator-nuttx/pull/6188) arch: Move -fstack-protector-all and -finstrument-functions from Make.defs to Toolchain.defs
-* [#6200](https://github.com/apache/incubator-nuttx/pull/6200) arch: Add gcov related config for arm/risc-v/xtensa
-* [#6063](https://github.com/apache/incubator-nuttx/pull/6063) arch/stack_color: correct the stack top of running task
-* [#6056](https://github.com/apache/incubator-nuttx/pull/6056) arch/stack_color: correct the end address of stack color
-* [#5966](https://github.com/apache/incubator-nuttx/pull/5966) arch:tcbinfo: update tcbinfo as xcpcontext update
-* [#5865](https://github.com/apache/incubator-nuttx/pull/5865) arch: Add -fsanitize=kernel-address to ARCHCPUFLAGS if CONFIG_MM_KASAN=y
-* [#5864](https://github.com/apache/incubator-nuttx/pull/5864) arch/Toolchain.defs: add wildcard for EXTRA_LIBS
-* [#5920](https://github.com/apache/incubator-nuttx/pull/5920) ARCH_ADDRENV: Add guard against mis-configuration 
-* [#6105](https://github.com/apache/incubator-nuttx/pull/6105) arch/clang: add support for Clang LTO
-* [#6089](https://github.com/apache/incubator-nuttx/pull/6089) arch: Move group_addrenv to common place
-* [#6183](https://github.com/apache/incubator-nuttx/pull/6183) arch: Remvoe the error message when toolchain can't find
-* [#6080](https://github.com/apache/incubator-nuttx/pull/6080) arch/ostest: remove CONFIG_TESTING_OSTEST_FPUSIZE & board level implement
-* [#6086](https://github.com/apache/incubator-nuttx/pull/6086) Remove FAR from the arch and board files of ceva/mips/misoc/or1k/sim/sparc/x86_64/xtensa
-* [#6778](https://github.com/apache/incubator-nuttx/pull/6778) arch: common: Fix up_check_tcbstack() for CONFIG_ARCH_ADDRENV=y
-* [#6665](https://github.com/apache/incubator-nuttx/pull/6665) arch/stack: get correct stack remain and limit dump size when sp is not within stack
-* [#6717](https://github.com/apache/incubator-nuttx/pull/6717) arch: Call board_reset before up_irq_save and spin_trylock
-* [#6252](https://github.com/apache/incubator-nuttx/pull/6252) arch/addrenv: Change text write enable/disable to generic mprot
-* [#6254](https://github.com/apache/incubator-nuttx/pull/6254) arch: Remove board/libboard$(LIBEXT) from the rerequest of export_startup
-* [#6276](https://github.com/apache/incubator-nuttx/pull/6276) arch: Move "-nostartfiles -nodefaultlibs" from Make.defs to Toolchian.defs
-* [#6351](https://github.com/apache/incubator-nuttx/pull/6351) arch: Define WCHAR_[MIN|MAX] in arch/include/limits.h
-* [#6286](https://github.com/apache/incubator-nuttx/pull/6286) arch: inline up_interrupt_context() 
-* [#6284](https://github.com/apache/incubator-nuttx/pull/6284) arch/addrenv: Add missing FAR qualifier to addrenv_mprot
-* [#6277](https://github.com/apache/incubator-nuttx/pull/6277) arch/i2c: Change xxx_i2c_tousecs to xxx_i2c_toticks
-* [#6416](https://github.com/apache/incubator-nuttx/pull/6416) Fix CONFIG_ALLSYMS for arm, risc-v and xtensa after #5496
-* [#6567](https://github.com/apache/incubator-nuttx/pull/6567) arch: Remove the inclusion of arch/irq.h from chip/irq.h
-* [#6550](https://github.com/apache/incubator-nuttx/pull/6550) arch: Move up_getsp from arch.h to irq.h
-* [#6452](https://github.com/apache/incubator-nuttx/pull/6452) arch/backtrace: correct the skip counter
-* [#6581](https://github.com/apache/incubator-nuttx/pull/6581) arch: Correct the order of stack related information in assert
-* [#5818](https://github.com/apache/incubator-nuttx/pull/5818) progmem: eliminate PROGMEM_ERASESTATE configuration option
-* [#5828](https://github.com/apache/incubator-nuttx/pull/5828) Show assigned cpu in dump task
-* [#6193](https://github.com/apache/incubator-nuttx/pull/6193) Elf loader: give temporary write access to user .text memory
-* [#6176](https://github.com/apache/incubator-nuttx/pull/6176) UMM: Implement getter for address environment heap start vaddr
-* [#6367](https://github.com/apache/incubator-nuttx/pull/6367) dump_task: also dump thread param when dump thread name
-* [#6062](https://github.com/apache/incubator-nuttx/pull/6062) SAM3X HSMCI DMA Fixes
+* [#6188](https://github.com/apache/nuttx/pull/6188) arch: Move -fstack-protector-all and -finstrument-functions from Make.defs to Toolchain.defs
+* [#6200](https://github.com/apache/nuttx/pull/6200) arch: Add gcov related config for arm/risc-v/xtensa
+* [#6063](https://github.com/apache/nuttx/pull/6063) arch/stack_color: correct the stack top of running task
+* [#6056](https://github.com/apache/nuttx/pull/6056) arch/stack_color: correct the end address of stack color
+* [#5966](https://github.com/apache/nuttx/pull/5966) arch:tcbinfo: update tcbinfo as xcpcontext update
+* [#5865](https://github.com/apache/nuttx/pull/5865) arch: Add -fsanitize=kernel-address to ARCHCPUFLAGS if CONFIG_MM_KASAN=y
+* [#5864](https://github.com/apache/nuttx/pull/5864) arch/Toolchain.defs: add wildcard for EXTRA_LIBS
+* [#5920](https://github.com/apache/nuttx/pull/5920) ARCH_ADDRENV: Add guard against mis-configuration 
+* [#6105](https://github.com/apache/nuttx/pull/6105) arch/clang: add support for Clang LTO
+* [#6089](https://github.com/apache/nuttx/pull/6089) arch: Move group_addrenv to common place
+* [#6183](https://github.com/apache/nuttx/pull/6183) arch: Remvoe the error message when toolchain can't find
+* [#6080](https://github.com/apache/nuttx/pull/6080) arch/ostest: remove CONFIG_TESTING_OSTEST_FPUSIZE & board level implement
+* [#6086](https://github.com/apache/nuttx/pull/6086) Remove FAR from the arch and board files of ceva/mips/misoc/or1k/sim/sparc/x86_64/xtensa
+* [#6778](https://github.com/apache/nuttx/pull/6778) arch: common: Fix up_check_tcbstack() for CONFIG_ARCH_ADDRENV=y
+* [#6665](https://github.com/apache/nuttx/pull/6665) arch/stack: get correct stack remain and limit dump size when sp is not within stack
+* [#6717](https://github.com/apache/nuttx/pull/6717) arch: Call board_reset before up_irq_save and spin_trylock
+* [#6252](https://github.com/apache/nuttx/pull/6252) arch/addrenv: Change text write enable/disable to generic mprot
+* [#6254](https://github.com/apache/nuttx/pull/6254) arch: Remove board/libboard$(LIBEXT) from the rerequest of export_startup
+* [#6276](https://github.com/apache/nuttx/pull/6276) arch: Move "-nostartfiles -nodefaultlibs" from Make.defs to Toolchian.defs
+* [#6351](https://github.com/apache/nuttx/pull/6351) arch: Define WCHAR_[MIN|MAX] in arch/include/limits.h
+* [#6286](https://github.com/apache/nuttx/pull/6286) arch: inline up_interrupt_context() 
+* [#6284](https://github.com/apache/nuttx/pull/6284) arch/addrenv: Add missing FAR qualifier to addrenv_mprot
+* [#6277](https://github.com/apache/nuttx/pull/6277) arch/i2c: Change xxx_i2c_tousecs to xxx_i2c_toticks
+* [#6416](https://github.com/apache/nuttx/pull/6416) Fix CONFIG_ALLSYMS for arm, risc-v and xtensa after #5496
+* [#6567](https://github.com/apache/nuttx/pull/6567) arch: Remove the inclusion of arch/irq.h from chip/irq.h
+* [#6550](https://github.com/apache/nuttx/pull/6550) arch: Move up_getsp from arch.h to irq.h
+* [#6452](https://github.com/apache/nuttx/pull/6452) arch/backtrace: correct the skip counter
+* [#6581](https://github.com/apache/nuttx/pull/6581) arch: Correct the order of stack related information in assert
+* [#5818](https://github.com/apache/nuttx/pull/5818) progmem: eliminate PROGMEM_ERASESTATE configuration option
+* [#5828](https://github.com/apache/nuttx/pull/5828) Show assigned cpu in dump task
+* [#6193](https://github.com/apache/nuttx/pull/6193) Elf loader: give temporary write access to user .text memory
+* [#6176](https://github.com/apache/nuttx/pull/6176) UMM: Implement getter for address environment heap start vaddr
+* [#6367](https://github.com/apache/nuttx/pull/6367) dump_task: also dump thread param when dump thread name
+* [#6062](https://github.com/apache/nuttx/pull/6062) SAM3X HSMCI DMA Fixes
 
-* [#6059](https://github.com/apache/incubator-nuttx/pull/6059) arch/risc-v/riscv_misaligned: Correct sw source register
-* [#6065](https://github.com/apache/incubator-nuttx/pull/6065) RISC-V: Support for mtimer in S-mode
-* [#6054](https://github.com/apache/incubator-nuttx/pull/6054) riscv/riscv_schedulesigaction.c: Remove the duplicate state saving
-* [#6051](https://github.com/apache/incubator-nuttx/pull/6051) arch/risc-v: Add missing DMB to mtimer / setmtimecmp
-* [#6050](https://github.com/apache/incubator-nuttx/pull/6050) RISC-V: Move mhartid to own assembly macro+function
-* [#6039](https://github.com/apache/incubator-nuttx/pull/6039) arch/riscv: Move toolchain config to arch/risc-v/Kconfig like xtensa
-* [#6034](https://github.com/apache/incubator-nuttx/pull/6034) arch/risc-v: Apply common mtime driver to mtime based chps
-* [#6022](https://github.com/apache/incubator-nuttx/pull/6022) arch/risc-v: Apply misaligned access handler for k210/bl602
-* [#6006](https://github.com/apache/incubator-nuttx/pull/6006) riscv/ESP32C3: Use the common exception handler
-* [#6468](https://github.com/apache/incubator-nuttx/pull/6468) Add I2C_M_NOSTART and I2C_M_NOSTOP support in esp32c3_i2c
-* [#6583](https://github.com/apache/incubator-nuttx/pull/6583) risc-v/esp32c3: Add the rest of the reset causes
-* [#6600](https://github.com/apache/incubator-nuttx/pull/6600) ESP32-C3: General improvements to Protected Mode infra
-* [#6487](https://github.com/apache/incubator-nuttx/pull/6487) risc-v/esp32c3: Implement up_perf_xxx API
-* [#6538](https://github.com/apache/incubator-nuttx/pull/6538) ESP32-S3: Add driver for I2C peripheral in Master mode
-* [#6552](https://github.com/apache/incubator-nuttx/pull/6552) esp32s3: Fix IOMUX function number for SPI
-* [#6522](https://github.com/apache/incubator-nuttx/pull/6522) Added configuration files for using BMP280 with ESP32-DevkitC
-* [#6549](https://github.com/apache/incubator-nuttx/pull/6549) Esp32 lilygo tty t5v2 bugfix
-* [#6540](https://github.com/apache/incubator-nuttx/pull/6540) ESP32-S2: Improvements to the GPIO driver
-* [#6539](https://github.com/apache/incubator-nuttx/pull/6539) ESP32-S2: Add driver for I2C peripheral in Master mode
-* [#6493](https://github.com/apache/incubator-nuttx/pull/6493) stm32xx: Fix RTC drift when using HSE
-* [#6492](https://github.com/apache/incubator-nuttx/pull/6492) Stm32wl55JC SPI driver
-* [#6579](https://github.com/apache/incubator-nuttx/pull/6579) Added ADC support to RP2040
-* [#6499](https://github.com/apache/incubator-nuttx/pull/6499) Added PWM for rp2040
-* [#6502](https://github.com/apache/incubator-nuttx/pull/6502) risc-v: Move common memory map to its own file from riscv_internal
-* [#6603](https://github.com/apache/incubator-nuttx/pull/6603) ESP32: Add support for Protected Mode
-* [#6516](https://github.com/apache/incubator-nuttx/pull/6516) arch/stm32_capture fix SMC register offset address and completion slave mode selection
-* [#6565](https://github.com/apache/incubator-nuttx/pull/6565) arch/risc-v: Move __XSTR, FLOAD/FSTORE and REGLOAD/REGSTORE to the right place
-* [#6020](https://github.com/apache/incubator-nuttx/pull/6020) arch/riscv: Add mtimer driver
-* [#6008](https://github.com/apache/incubator-nuttx/pull/6008) arch/risc-v: Attach exception handler in common place
-* [#5998](https://github.com/apache/incubator-nuttx/pull/5998) arch/riscv: Minor style change and text correction
-* [#6003](https://github.com/apache/incubator-nuttx/pull/6003) esp32c3: Simplify irq dispatch logic
-* [#5989](https://github.com/apache/incubator-nuttx/pull/5989) arch/risc-v: Replace riscv_fault with riscv_exception
-* [#5970](https://github.com/apache/incubator-nuttx/pull/5970) b-u585i-iot02a:nsh: Drop TrustedFirmware-M dependency
-* [#5974](https://github.com/apache/incubator-nuttx/pull/5974) arch/risc-v: use STACK_FRAME_SIZE for in S-mode syscall asm
-* [#5980](https://github.com/apache/incubator-nuttx/pull/5980) RISC-V: Fix file name of riscv_dispatch_syscall
-* [#5985](https://github.com/apache/incubator-nuttx/pull/5985) RISC-V: Combine 3 variables that depend on CPU amount into one
-* [#5981](https://github.com/apache/incubator-nuttx/pull/5981) RISC-V: Fix usage of static_assert in riscv_percpu.c
-* [#5983](https://github.com/apache/incubator-nuttx/pull/5983) arch/risc-v: Remove the unnecessary inclusion of board header files
-* [#5754](https://github.com/apache/incubator-nuttx/pull/5754) arch/risc-v: Correct stack coloration in riscv_cpu_boot
-* [#5758](https://github.com/apache/incubator-nuttx/pull/5758) RISC-V: Prepare CONFIG_BUILD_KERNEL part 1
-* [#5760](https://github.com/apache/incubator-nuttx/pull/5760) ESP32-S3: Fix UART IRQ setup hardcoded to CPU 0 
-* [#5766](https://github.com/apache/incubator-nuttx/pull/5766) arch/risc-v: Rework riscv_get_newintctx
-* [#5773](https://github.com/apache/incubator-nuttx/pull/5773) risc-v/esp32c3: Remove deprecated option for disabling atomics support
-* [#5775](https://github.com/apache/incubator-nuttx/pull/5775) arch/risc-v: Merge riscv_getnewintctx into common
-* [#5781](https://github.com/apache/incubator-nuttx/pull/5781) phy62xx_exception: using armv6-m exception_common code
-* [#5782](https://github.com/apache/incubator-nuttx/pull/5782) RISC-V: Implement option to run NuttX in supervisor mode (S-mode)
-* [#5809](https://github.com/apache/incubator-nuttx/pull/5809) fixed mpu9250 not work on i2c bus issue.
-* [#5765](https://github.com/apache/incubator-nuttx/pull/5765) esp32 efuse build fix
-* [#5772](https://github.com/apache/incubator-nuttx/pull/5772) arch/Kconfig: Don't depend on Xtensa for the SUPPRESS_CLOCK_CONFIG option
-* [#5825](https://github.com/apache/incubator-nuttx/pull/5825) ESP32-S3: Enable GPIO read/write operations and interrupts support
-* [#5827](https://github.com/apache/incubator-nuttx/pull/5827) Add SPIRAM to ESP32-S2
-* [#5829](https://github.com/apache/incubator-nuttx/pull/5829) RISC-V: Add/fix implementation for arch_elf.c
-* [#5830](https://github.com/apache/incubator-nuttx/pull/5830) risc-v/qemu-rv: Restore FPU context after context switch
-* [#5831](https://github.com/apache/incubator-nuttx/pull/5831) RISC-V: Add kernel stack
-* [#5833](https://github.com/apache/incubator-nuttx/pull/5833) ESP32-S2: Remove unused and unsupported configs from Kconfig
-* [#5834](https://github.com/apache/incubator-nuttx/pull/5834) ESP32-S2: Initialize instruction cache on startup
-* [#5878](https://github.com/apache/incubator-nuttx/pull/5878) arch/risc-v: Use riscv_fpuconfig to enable FPU
-* [#5898](https://github.com/apache/incubator-nuttx/pull/5898) riscv/bl602: Implement SPI Cmd/Data
-* [#5957](https://github.com/apache/incubator-nuttx/pull/5957) risc-v/esp32c3: Fix regression on IRQ handling for ECALL instruction
-* [#5905](https://github.com/apache/incubator-nuttx/pull/5905) arch/risc-v: Store/Restore FPU register in exception_common
-* [#5795](https://github.com/apache/incubator-nuttx/pull/5795) ESP32-S3: Clean up and improve GPIO driver interface
-* [#6604](https://github.com/apache/incubator-nuttx/pull/6604) esp32s3: Add DMA support
-* [#5838](https://github.com/apache/incubator-nuttx/pull/5838) esp32/Make.defs: Organise common arch files and chip files appropriately
-* [#5868](https://github.com/apache/incubator-nuttx/pull/5868) arch/risc-v: Move fpu [re]store to common place
-* [#5869](https://github.com/apache/incubator-nuttx/pull/5869) riscv/bl602: Enable SPI Master in SPI Poll Send
-* [#5907](https://github.com/apache/incubator-nuttx/pull/5907) riscv/bl602: Remove check for LCD driver
-* [#5908](https://github.com/apache/incubator-nuttx/pull/5908) riscv/esp32c3: Remove check for LCD driver
-* [#5746](https://github.com/apache/incubator-nuttx/pull/5746) RISCV: Fix nasty bug in PMP region test
-* [#5842](https://github.com/apache/incubator-nuttx/pull/5842) arch/risc-v: improve style consistency accross chip variants
-* [#5913](https://github.com/apache/incubator-nuttx/pull/5913) arch/risc-v: Move group_addrenv to correct place
-* [#5922](https://github.com/apache/incubator-nuttx/pull/5922) arch/risc-v: get wider visibility for arch instruction macros
-* [#5940](https://github.com/apache/incubator-nuttx/pull/5940) arch/risc-v: Add handler for misaligned load/store
-* [#5917](https://github.com/apache/incubator-nuttx/pull/5917) arch/risc-v: move REGLOAD/REGSTORE macro to riscv_internal.h
-* [#6217](https://github.com/apache/incubator-nuttx/pull/6217) riscv/pmp: fix bug: PMP_CFG_FLAG_MASK makes pmp cfg fail
-* [#6192](https://github.com/apache/incubator-nuttx/pull/6192) Riscv hostfs
-* [#6235](https://github.com/apache/incubator-nuttx/pull/6235) RISC-V: add C++ support to crt0
-* [#5731](https://github.com/apache/incubator-nuttx/pull/5731) arch/risc-v: Improve speed of context switch
-* [#6255](https://github.com/apache/incubator-nuttx/pull/6255) arch/riscv: Remove & ~1 before assign signal_handler to REG_EPC
-* [#6237](https://github.com/apache/incubator-nuttx/pull/6237) arch: risc-v: Enable FPU for qemu-rv only if EXPERIMENTAL=y
-* [#6242](https://github.com/apache/incubator-nuttx/pull/6242) rv-virt:knsh64
-* [#6690](https://github.com/apache/incubator-nuttx/pull/6690) Ability to use newer pico-sdk with RP2040 builds (Issue #4919)
-* [#6249](https://github.com/apache/incubator-nuttx/pull/6249) risc-v/mpfs: introduce IHC driver
-* [#6776](https://github.com/apache/incubator-nuttx/pull/6776) risc-v/mpfs: usb: configure fifos properly
-* [#6077](https://github.com/apache/incubator-nuttx/pull/6077) arch/risc-v: Use fs status definition from csr.h
-* [#6095](https://github.com/apache/incubator-nuttx/pull/6095) arch/risc-v: Remove FAR from chip and board folder
-* [#6101](https://github.com/apache/incubator-nuttx/pull/6101) arch/risc-v: Change riscv_savefpu/riscv_loadfpu to macro
-* [#6102](https://github.com/apache/incubator-nuttx/pull/6102) ARM/RISC-V: Fix xxx_assert from IRQ context
-* [#6115](https://github.com/apache/incubator-nuttx/pull/6115) arch/risc-v: Don't clear reserved bits in fcsr in riscv_fpuconfig
-* [#6116](https://github.com/apache/incubator-nuttx/pull/6116) arch/risc-v: Enable FPU for K210
-* [#6117](https://github.com/apache/incubator-nuttx/pull/6117) arch/risc-v/riscv_misaligned: Implement float load/store support
-* [#6125](https://github.com/apache/incubator-nuttx/pull/6125) arch: risc-v: Do not enable FPU for K210 with QEMU
-* [#6126](https://github.com/apache/incubator-nuttx/pull/6126) arch/risc-v: add support for GCC LTO
-* [#6156](https://github.com/apache/incubator-nuttx/pull/6156) riscv/Makefile: Delete old target used for debugging
-* [#6162](https://github.com/apache/incubator-nuttx/pull/6162) RISC-V PMP: Restrict Fence instruction for chips that support S-mode
-* [#6191](https://github.com/apache/incubator-nuttx/pull/6191) RISC-V: Fix crt0 file compilation
-* [#6194](https://github.com/apache/incubator-nuttx/pull/6194) RISC-V: Fix bug in riscv_addrenv.c
-* [#6052](https://github.com/apache/incubator-nuttx/pull/6052) arch/riscv: Jump instead call riscv_dispatch_syscall
-* [#6131](https://github.com/apache/incubator-nuttx/pull/6131) RISC-V: Add implementation for vfork
-* [#6134](https://github.com/apache/incubator-nuttx/pull/6134) RISC-V: Fix system crash when FPU is in use
-* [#6145](https://github.com/apache/incubator-nuttx/pull/6145) RISC-V: Add syscall support for vfork
-* [#6151](https://github.com/apache/incubator-nuttx/pull/6151) RISC-V: workaround for the RV64 SoC which does not has mem mapped MTI...
-* [#6069](https://github.com/apache/incubator-nuttx/pull/6069) RISC-V: Add support for CONFIG_BUILD_KERNEL
-* [#6005](https://github.com/apache/incubator-nuttx/pull/6005) ESP32C3 TWAI (CAN) controller support.
-* [#5740](https://github.com/apache/incubator-nuttx/pull/5740) Add ethernet support for risc-v/MPFS
-* [#5749](https://github.com/apache/incubator-nuttx/pull/5749) risc-v/mpfs: usb: fix ep0 stall/resume and rx reads 
-* [#5783](https://github.com/apache/incubator-nuttx/pull/5783) risc-v/mpfs: usb: fix ep0 read done
-* [#5881](https://github.com/apache/incubator-nuttx/pull/5881) MPFS: Fix issue with external interrupt detection
-* [#5875](https://github.com/apache/incubator-nuttx/pull/5875) MPFS: Fix error in flat build linker script
-* [#5912](https://github.com/apache/incubator-nuttx/pull/5912) arch/risc-v/mpfs: Remove duplicated riscv_restorefpu
-* [#6060](https://github.com/apache/incubator-nuttx/pull/6060) MPFS: Fix timer and exception/fault handling
-* [#6070](https://github.com/apache/incubator-nuttx/pull/6070) MPFS: Set correct interrupt per mode (M-/S-mode) for mtimer
-* [#5993](https://github.com/apache/incubator-nuttx/pull/5993) MPFS: Prepare support for S-mode
-* [#5780](https://github.com/apache/incubator-nuttx/pull/5780) MPFS: Add board_memorymap.h
-* [#6160](https://github.com/apache/incubator-nuttx/pull/6160) MPFS: Remove # CONFIG_ARCH_FPU is not set from defconfigs
-* [#6177](https://github.com/apache/incubator-nuttx/pull/6177) MPFS: Add support for CONFIG_BUILD_KERNEL, adds icicle:knsh
-* [#6303](https://github.com/apache/incubator-nuttx/pull/6303) MPFS: Implement S-mode head and start function
-* [#6304](https://github.com/apache/incubator-nuttx/pull/6304) risc-v/mpfs: amend OpenSBI to utilize IHC
-* [#6260](https://github.com/apache/incubator-nuttx/pull/6260) risc-v/mpfs: apply IHC review fixes
-* [#6396](https://github.com/apache/incubator-nuttx/pull/6396) Mpfs fix ddr training failures
-* [#6395](https://github.com/apache/incubator-nuttx/pull/6395) risc-v/mpfs: composite usb driver
-* [#6261](https://github.com/apache/incubator-nuttx/pull/6261) risc-v/mpfs: IHC: clarify semaphore usage
-* [#6285](https://github.com/apache/incubator-nuttx/pull/6285) risc-v/mpfs: IHC: allow hart configuration
-* [#6437](https://github.com/apache/incubator-nuttx/pull/6437) risc-v/mpfs: update clock configuration parameters
-* [#6405](https://github.com/apache/incubator-nuttx/pull/6405) risc-v/mpfs: Move the entry point to .start section
-* [#6496](https://github.com/apache/incubator-nuttx/pull/6496) risc-v/mpfs: emmcsd: fix two issues
-* [#6326](https://github.com/apache/incubator-nuttx/pull/6326) mpfs/knsh: Add C++ support
-* [#6450](https://github.com/apache/incubator-nuttx/pull/6450) arch/riscv/mpfs: Add a config flag to select SD mux state
-* [#6503](https://github.com/apache/incubator-nuttx/pull/6503) arch/risc-v/src/mpfs: Add mpfs_gpiosetevent and gpio irq handling fun…
-* [#6530](https://github.com/apache/incubator-nuttx/pull/6530) mpfs: Fix IHC memory locations to native width type
-* [#6490](https://github.com/apache/incubator-nuttx/pull/6490) mpfs: Allow mapping of RAM/ROM regions from different memory areas
-* [#6602](https://github.com/apache/incubator-nuttx/pull/6602) risc-v/mpfs: usb: fix illegal reads
-* [#6535](https://github.com/apache/incubator-nuttx/pull/6535) risc-v/mpfs: ihc: don't start rptun automatically 
-* [#6361](https://github.com/apache/incubator-nuttx/pull/6361) arch/risc-v: re-add missing riscv_udelay source
-* [#6343](https://github.com/apache/incubator-nuttx/pull/6343) Some cleanup for risc-v
-* [#6342](https://github.com/apache/incubator-nuttx/pull/6342) arch/risc-v: Unify common source include
-* [#6292](https://github.com/apache/incubator-nuttx/pull/6292) risc-v/opensbi: Generalize the SBI variable handling in makefile
-* [#6291](https://github.com/apache/incubator-nuttx/pull/6291) ESP32-C3: Add support for Protected Mode
-* [#6400](https://github.com/apache/incubator-nuttx/pull/6400) ESP32-C3: Disable access to invalid memory regions using MPU
-* [#6336](https://github.com/apache/incubator-nuttx/pull/6336) esp32*: Disable CONFIG_RAW_BINARY and make Config.mk update nuttx.manifest for nuttx.bin
-* [#6325](https://github.com/apache/incubator-nuttx/pull/6325) esp32:wamr_wasi_debug: Remove CONFIG_SCHED_ONEXIT
-* [#6324](https://github.com/apache/incubator-nuttx/pull/6324) Fix stm32 pwm HAVE_ADVTIM
-* [#6323](https://github.com/apache/incubator-nuttx/pull/6323) esp32: Add an example config for wamr and littlefs
-* [#6322](https://github.com/apache/incubator-nuttx/pull/6322) ESP32/ESP32-C3: Fix leak of semaphores created by Wi-Fi kernel thread
-* [#6317](https://github.com/apache/incubator-nuttx/pull/6317) esp32_cpuidlestack.c: Remove unnecessary code.
-* [#6313](https://github.com/apache/incubator-nuttx/pull/6313) arch: risc-v: Fix crt0.c if CONFIG_HAVE_CXX is not set
-* [#6300](https://github.com/apache/incubator-nuttx/pull/6300) risc-v/vfork: FPU was not saved correctly
-* [#6299](https://github.com/apache/incubator-nuttx/pull/6299) risc-v/vfork: Fix saved register set and add FPU registers
-* [#6415](https://github.com/apache/incubator-nuttx/pull/6415) arch: k210: Add a workaround for clock stabilization
-* [#6688](https://github.com/apache/incubator-nuttx/pull/6688) OpenSBI: Add configurable support for domain init
-* [#6285](https://github.com/apache/incubator-nuttx/pull/6285) risc-v/mpfs: IHC: allow hart configuration
-* [#6645](https://github.com/apache/incubator-nuttx/pull/6645) arch/esp32: Introduce the ESP32_RTC option
+* [#6059](https://github.com/apache/nuttx/pull/6059) arch/risc-v/riscv_misaligned: Correct sw source register
+* [#6065](https://github.com/apache/nuttx/pull/6065) RISC-V: Support for mtimer in S-mode
+* [#6054](https://github.com/apache/nuttx/pull/6054) riscv/riscv_schedulesigaction.c: Remove the duplicate state saving
+* [#6051](https://github.com/apache/nuttx/pull/6051) arch/risc-v: Add missing DMB to mtimer / setmtimecmp
+* [#6050](https://github.com/apache/nuttx/pull/6050) RISC-V: Move mhartid to own assembly macro+function
+* [#6039](https://github.com/apache/nuttx/pull/6039) arch/riscv: Move toolchain config to arch/risc-v/Kconfig like xtensa
+* [#6034](https://github.com/apache/nuttx/pull/6034) arch/risc-v: Apply common mtime driver to mtime based chps
+* [#6022](https://github.com/apache/nuttx/pull/6022) arch/risc-v: Apply misaligned access handler for k210/bl602
+* [#6006](https://github.com/apache/nuttx/pull/6006) riscv/ESP32C3: Use the common exception handler
+* [#6468](https://github.com/apache/nuttx/pull/6468) Add I2C_M_NOSTART and I2C_M_NOSTOP support in esp32c3_i2c
+* [#6583](https://github.com/apache/nuttx/pull/6583) risc-v/esp32c3: Add the rest of the reset causes
+* [#6600](https://github.com/apache/nuttx/pull/6600) ESP32-C3: General improvements to Protected Mode infra
+* [#6487](https://github.com/apache/nuttx/pull/6487) risc-v/esp32c3: Implement up_perf_xxx API
+* [#6538](https://github.com/apache/nuttx/pull/6538) ESP32-S3: Add driver for I2C peripheral in Master mode
+* [#6552](https://github.com/apache/nuttx/pull/6552) esp32s3: Fix IOMUX function number for SPI
+* [#6522](https://github.com/apache/nuttx/pull/6522) Added configuration files for using BMP280 with ESP32-DevkitC
+* [#6549](https://github.com/apache/nuttx/pull/6549) Esp32 lilygo tty t5v2 bugfix
+* [#6540](https://github.com/apache/nuttx/pull/6540) ESP32-S2: Improvements to the GPIO driver
+* [#6539](https://github.com/apache/nuttx/pull/6539) ESP32-S2: Add driver for I2C peripheral in Master mode
+* [#6493](https://github.com/apache/nuttx/pull/6493) stm32xx: Fix RTC drift when using HSE
+* [#6492](https://github.com/apache/nuttx/pull/6492) Stm32wl55JC SPI driver
+* [#6579](https://github.com/apache/nuttx/pull/6579) Added ADC support to RP2040
+* [#6499](https://github.com/apache/nuttx/pull/6499) Added PWM for rp2040
+* [#6502](https://github.com/apache/nuttx/pull/6502) risc-v: Move common memory map to its own file from riscv_internal
+* [#6603](https://github.com/apache/nuttx/pull/6603) ESP32: Add support for Protected Mode
+* [#6516](https://github.com/apache/nuttx/pull/6516) arch/stm32_capture fix SMC register offset address and completion slave mode selection
+* [#6565](https://github.com/apache/nuttx/pull/6565) arch/risc-v: Move __XSTR, FLOAD/FSTORE and REGLOAD/REGSTORE to the right place
+* [#6020](https://github.com/apache/nuttx/pull/6020) arch/riscv: Add mtimer driver
+* [#6008](https://github.com/apache/nuttx/pull/6008) arch/risc-v: Attach exception handler in common place
+* [#5998](https://github.com/apache/nuttx/pull/5998) arch/riscv: Minor style change and text correction
+* [#6003](https://github.com/apache/nuttx/pull/6003) esp32c3: Simplify irq dispatch logic
+* [#5989](https://github.com/apache/nuttx/pull/5989) arch/risc-v: Replace riscv_fault with riscv_exception
+* [#5970](https://github.com/apache/nuttx/pull/5970) b-u585i-iot02a:nsh: Drop TrustedFirmware-M dependency
+* [#5974](https://github.com/apache/nuttx/pull/5974) arch/risc-v: use STACK_FRAME_SIZE for in S-mode syscall asm
+* [#5980](https://github.com/apache/nuttx/pull/5980) RISC-V: Fix file name of riscv_dispatch_syscall
+* [#5985](https://github.com/apache/nuttx/pull/5985) RISC-V: Combine 3 variables that depend on CPU amount into one
+* [#5981](https://github.com/apache/nuttx/pull/5981) RISC-V: Fix usage of static_assert in riscv_percpu.c
+* [#5983](https://github.com/apache/nuttx/pull/5983) arch/risc-v: Remove the unnecessary inclusion of board header files
+* [#5754](https://github.com/apache/nuttx/pull/5754) arch/risc-v: Correct stack coloration in riscv_cpu_boot
+* [#5758](https://github.com/apache/nuttx/pull/5758) RISC-V: Prepare CONFIG_BUILD_KERNEL part 1
+* [#5760](https://github.com/apache/nuttx/pull/5760) ESP32-S3: Fix UART IRQ setup hardcoded to CPU 0 
+* [#5766](https://github.com/apache/nuttx/pull/5766) arch/risc-v: Rework riscv_get_newintctx
+* [#5773](https://github.com/apache/nuttx/pull/5773) risc-v/esp32c3: Remove deprecated option for disabling atomics support
+* [#5775](https://github.com/apache/nuttx/pull/5775) arch/risc-v: Merge riscv_getnewintctx into common
+* [#5781](https://github.com/apache/nuttx/pull/5781) phy62xx_exception: using armv6-m exception_common code
+* [#5782](https://github.com/apache/nuttx/pull/5782) RISC-V: Implement option to run NuttX in supervisor mode (S-mode)
+* [#5809](https://github.com/apache/nuttx/pull/5809) fixed mpu9250 not work on i2c bus issue.
+* [#5765](https://github.com/apache/nuttx/pull/5765) esp32 efuse build fix
+* [#5772](https://github.com/apache/nuttx/pull/5772) arch/Kconfig: Don't depend on Xtensa for the SUPPRESS_CLOCK_CONFIG option
+* [#5825](https://github.com/apache/nuttx/pull/5825) ESP32-S3: Enable GPIO read/write operations and interrupts support
+* [#5827](https://github.com/apache/nuttx/pull/5827) Add SPIRAM to ESP32-S2
+* [#5829](https://github.com/apache/nuttx/pull/5829) RISC-V: Add/fix implementation for arch_elf.c
+* [#5830](https://github.com/apache/nuttx/pull/5830) risc-v/qemu-rv: Restore FPU context after context switch
+* [#5831](https://github.com/apache/nuttx/pull/5831) RISC-V: Add kernel stack
+* [#5833](https://github.com/apache/nuttx/pull/5833) ESP32-S2: Remove unused and unsupported configs from Kconfig
+* [#5834](https://github.com/apache/nuttx/pull/5834) ESP32-S2: Initialize instruction cache on startup
+* [#5878](https://github.com/apache/nuttx/pull/5878) arch/risc-v: Use riscv_fpuconfig to enable FPU
+* [#5898](https://github.com/apache/nuttx/pull/5898) riscv/bl602: Implement SPI Cmd/Data
+* [#5957](https://github.com/apache/nuttx/pull/5957) risc-v/esp32c3: Fix regression on IRQ handling for ECALL instruction
+* [#5905](https://github.com/apache/nuttx/pull/5905) arch/risc-v: Store/Restore FPU register in exception_common
+* [#5795](https://github.com/apache/nuttx/pull/5795) ESP32-S3: Clean up and improve GPIO driver interface
+* [#6604](https://github.com/apache/nuttx/pull/6604) esp32s3: Add DMA support
+* [#5838](https://github.com/apache/nuttx/pull/5838) esp32/Make.defs: Organise common arch files and chip files appropriately
+* [#5868](https://github.com/apache/nuttx/pull/5868) arch/risc-v: Move fpu [re]store to common place
+* [#5869](https://github.com/apache/nuttx/pull/5869) riscv/bl602: Enable SPI Master in SPI Poll Send
+* [#5907](https://github.com/apache/nuttx/pull/5907) riscv/bl602: Remove check for LCD driver
+* [#5908](https://github.com/apache/nuttx/pull/5908) riscv/esp32c3: Remove check for LCD driver
+* [#5746](https://github.com/apache/nuttx/pull/5746) RISCV: Fix nasty bug in PMP region test
+* [#5842](https://github.com/apache/nuttx/pull/5842) arch/risc-v: improve style consistency accross chip variants
+* [#5913](https://github.com/apache/nuttx/pull/5913) arch/risc-v: Move group_addrenv to correct place
+* [#5922](https://github.com/apache/nuttx/pull/5922) arch/risc-v: get wider visibility for arch instruction macros
+* [#5940](https://github.com/apache/nuttx/pull/5940) arch/risc-v: Add handler for misaligned load/store
+* [#5917](https://github.com/apache/nuttx/pull/5917) arch/risc-v: move REGLOAD/REGSTORE macro to riscv_internal.h
+* [#6217](https://github.com/apache/nuttx/pull/6217) riscv/pmp: fix bug: PMP_CFG_FLAG_MASK makes pmp cfg fail
+* [#6192](https://github.com/apache/nuttx/pull/6192) Riscv hostfs
+* [#6235](https://github.com/apache/nuttx/pull/6235) RISC-V: add C++ support to crt0
+* [#5731](https://github.com/apache/nuttx/pull/5731) arch/risc-v: Improve speed of context switch
+* [#6255](https://github.com/apache/nuttx/pull/6255) arch/riscv: Remove & ~1 before assign signal_handler to REG_EPC
+* [#6237](https://github.com/apache/nuttx/pull/6237) arch: risc-v: Enable FPU for qemu-rv only if EXPERIMENTAL=y
+* [#6242](https://github.com/apache/nuttx/pull/6242) rv-virt:knsh64
+* [#6690](https://github.com/apache/nuttx/pull/6690) Ability to use newer pico-sdk with RP2040 builds (Issue #4919)
+* [#6249](https://github.com/apache/nuttx/pull/6249) risc-v/mpfs: introduce IHC driver
+* [#6776](https://github.com/apache/nuttx/pull/6776) risc-v/mpfs: usb: configure fifos properly
+* [#6077](https://github.com/apache/nuttx/pull/6077) arch/risc-v: Use fs status definition from csr.h
+* [#6095](https://github.com/apache/nuttx/pull/6095) arch/risc-v: Remove FAR from chip and board folder
+* [#6101](https://github.com/apache/nuttx/pull/6101) arch/risc-v: Change riscv_savefpu/riscv_loadfpu to macro
+* [#6102](https://github.com/apache/nuttx/pull/6102) ARM/RISC-V: Fix xxx_assert from IRQ context
+* [#6115](https://github.com/apache/nuttx/pull/6115) arch/risc-v: Don't clear reserved bits in fcsr in riscv_fpuconfig
+* [#6116](https://github.com/apache/nuttx/pull/6116) arch/risc-v: Enable FPU for K210
+* [#6117](https://github.com/apache/nuttx/pull/6117) arch/risc-v/riscv_misaligned: Implement float load/store support
+* [#6125](https://github.com/apache/nuttx/pull/6125) arch: risc-v: Do not enable FPU for K210 with QEMU
+* [#6126](https://github.com/apache/nuttx/pull/6126) arch/risc-v: add support for GCC LTO
+* [#6156](https://github.com/apache/nuttx/pull/6156) riscv/Makefile: Delete old target used for debugging
+* [#6162](https://github.com/apache/nuttx/pull/6162) RISC-V PMP: Restrict Fence instruction for chips that support S-mode
+* [#6191](https://github.com/apache/nuttx/pull/6191) RISC-V: Fix crt0 file compilation
+* [#6194](https://github.com/apache/nuttx/pull/6194) RISC-V: Fix bug in riscv_addrenv.c
+* [#6052](https://github.com/apache/nuttx/pull/6052) arch/riscv: Jump instead call riscv_dispatch_syscall
+* [#6131](https://github.com/apache/nuttx/pull/6131) RISC-V: Add implementation for vfork
+* [#6134](https://github.com/apache/nuttx/pull/6134) RISC-V: Fix system crash when FPU is in use
+* [#6145](https://github.com/apache/nuttx/pull/6145) RISC-V: Add syscall support for vfork
+* [#6151](https://github.com/apache/nuttx/pull/6151) RISC-V: workaround for the RV64 SoC which does not has mem mapped MTI...
+* [#6069](https://github.com/apache/nuttx/pull/6069) RISC-V: Add support for CONFIG_BUILD_KERNEL
+* [#6005](https://github.com/apache/nuttx/pull/6005) ESP32C3 TWAI (CAN) controller support.
+* [#5740](https://github.com/apache/nuttx/pull/5740) Add ethernet support for risc-v/MPFS
+* [#5749](https://github.com/apache/nuttx/pull/5749) risc-v/mpfs: usb: fix ep0 stall/resume and rx reads 
+* [#5783](https://github.com/apache/nuttx/pull/5783) risc-v/mpfs: usb: fix ep0 read done
+* [#5881](https://github.com/apache/nuttx/pull/5881) MPFS: Fix issue with external interrupt detection
+* [#5875](https://github.com/apache/nuttx/pull/5875) MPFS: Fix error in flat build linker script
+* [#5912](https://github.com/apache/nuttx/pull/5912) arch/risc-v/mpfs: Remove duplicated riscv_restorefpu
+* [#6060](https://github.com/apache/nuttx/pull/6060) MPFS: Fix timer and exception/fault handling
+* [#6070](https://github.com/apache/nuttx/pull/6070) MPFS: Set correct interrupt per mode (M-/S-mode) for mtimer
+* [#5993](https://github.com/apache/nuttx/pull/5993) MPFS: Prepare support for S-mode
+* [#5780](https://github.com/apache/nuttx/pull/5780) MPFS: Add board_memorymap.h
+* [#6160](https://github.com/apache/nuttx/pull/6160) MPFS: Remove # CONFIG_ARCH_FPU is not set from defconfigs
+* [#6177](https://github.com/apache/nuttx/pull/6177) MPFS: Add support for CONFIG_BUILD_KERNEL, adds icicle:knsh
+* [#6303](https://github.com/apache/nuttx/pull/6303) MPFS: Implement S-mode head and start function
+* [#6304](https://github.com/apache/nuttx/pull/6304) risc-v/mpfs: amend OpenSBI to utilize IHC
+* [#6260](https://github.com/apache/nuttx/pull/6260) risc-v/mpfs: apply IHC review fixes
+* [#6396](https://github.com/apache/nuttx/pull/6396) Mpfs fix ddr training failures
+* [#6395](https://github.com/apache/nuttx/pull/6395) risc-v/mpfs: composite usb driver
+* [#6261](https://github.com/apache/nuttx/pull/6261) risc-v/mpfs: IHC: clarify semaphore usage
+* [#6285](https://github.com/apache/nuttx/pull/6285) risc-v/mpfs: IHC: allow hart configuration
+* [#6437](https://github.com/apache/nuttx/pull/6437) risc-v/mpfs: update clock configuration parameters
+* [#6405](https://github.com/apache/nuttx/pull/6405) risc-v/mpfs: Move the entry point to .start section
+* [#6496](https://github.com/apache/nuttx/pull/6496) risc-v/mpfs: emmcsd: fix two issues
+* [#6326](https://github.com/apache/nuttx/pull/6326) mpfs/knsh: Add C++ support
+* [#6450](https://github.com/apache/nuttx/pull/6450) arch/riscv/mpfs: Add a config flag to select SD mux state
+* [#6503](https://github.com/apache/nuttx/pull/6503) arch/risc-v/src/mpfs: Add mpfs_gpiosetevent and gpio irq handling fun…
+* [#6530](https://github.com/apache/nuttx/pull/6530) mpfs: Fix IHC memory locations to native width type
+* [#6490](https://github.com/apache/nuttx/pull/6490) mpfs: Allow mapping of RAM/ROM regions from different memory areas
+* [#6602](https://github.com/apache/nuttx/pull/6602) risc-v/mpfs: usb: fix illegal reads
+* [#6535](https://github.com/apache/nuttx/pull/6535) risc-v/mpfs: ihc: don't start rptun automatically 
+* [#6361](https://github.com/apache/nuttx/pull/6361) arch/risc-v: re-add missing riscv_udelay source
+* [#6343](https://github.com/apache/nuttx/pull/6343) Some cleanup for risc-v
+* [#6342](https://github.com/apache/nuttx/pull/6342) arch/risc-v: Unify common source include
+* [#6292](https://github.com/apache/nuttx/pull/6292) risc-v/opensbi: Generalize the SBI variable handling in makefile
+* [#6291](https://github.com/apache/nuttx/pull/6291) ESP32-C3: Add support for Protected Mode
+* [#6400](https://github.com/apache/nuttx/pull/6400) ESP32-C3: Disable access to invalid memory regions using MPU
+* [#6336](https://github.com/apache/nuttx/pull/6336) esp32*: Disable CONFIG_RAW_BINARY and make Config.mk update nuttx.manifest for nuttx.bin
+* [#6325](https://github.com/apache/nuttx/pull/6325) esp32:wamr_wasi_debug: Remove CONFIG_SCHED_ONEXIT
+* [#6324](https://github.com/apache/nuttx/pull/6324) Fix stm32 pwm HAVE_ADVTIM
+* [#6323](https://github.com/apache/nuttx/pull/6323) esp32: Add an example config for wamr and littlefs
+* [#6322](https://github.com/apache/nuttx/pull/6322) ESP32/ESP32-C3: Fix leak of semaphores created by Wi-Fi kernel thread
+* [#6317](https://github.com/apache/nuttx/pull/6317) esp32_cpuidlestack.c: Remove unnecessary code.
+* [#6313](https://github.com/apache/nuttx/pull/6313) arch: risc-v: Fix crt0.c if CONFIG_HAVE_CXX is not set
+* [#6300](https://github.com/apache/nuttx/pull/6300) risc-v/vfork: FPU was not saved correctly
+* [#6299](https://github.com/apache/nuttx/pull/6299) risc-v/vfork: Fix saved register set and add FPU registers
+* [#6415](https://github.com/apache/nuttx/pull/6415) arch: k210: Add a workaround for clock stabilization
+* [#6688](https://github.com/apache/nuttx/pull/6688) OpenSBI: Add configurable support for domain init
+* [#6285](https://github.com/apache/nuttx/pull/6285) risc-v/mpfs: IHC: allow hart configuration
+* [#6645](https://github.com/apache/nuttx/pull/6645) arch/esp32: Introduce the ESP32_RTC option
 
-* [#5946](https://github.com/apache/incubator-nuttx/pull/5946) arch/xtensa: Add xtensa_tcbinfo struct that contains helpful offsets
-* [#5877](https://github.com/apache/incubator-nuttx/pull/5877) xtensa: add xtensa arch oneshot ops
-* [#5876](https://github.com/apache/incubator-nuttx/pull/5876) xtensa: add xtensa_spill_window declaration
-* [#5820](https://github.com/apache/incubator-nuttx/pull/5820) xtensa/esp32(s2)_user.c: Use macros defined in xtens_corebits.h
-* [#5771](https://github.com/apache/incubator-nuttx/pull/5771) arch/xtensa: Don't always reset the APP CPU on startup
-* [#5979](https://github.com/apache/incubator-nuttx/pull/5979) arch/xtensa: Build the xtensa_tcbinfo.c file for S2 and S3
-* [#5987](https://github.com/apache/incubator-nuttx/pull/5987) xtensa/esp32: Add support to TWAI/CANBus
-* [#5941](https://github.com/apache/incubator-nuttx/pull/5941) arch/xtensa: add syscall note support in the flat build
-* [#6167](https://github.com/apache/incubator-nuttx/pull/6167) arch/xtensa: Replace the xcp context with stack context to improve context switching
-* [#6148](https://github.com/apache/incubator-nuttx/pull/6148) arch/xtensa: Refactor assembly macros
-* [#6147](https://github.com/apache/incubator-nuttx/pull/6147) arch/xtensa: Simply use xtensa_createstack for CPU1 idle task.
-* [#6136](https://github.com/apache/incubator-nuttx/pull/6136) xtensa: Fix backtrace on exceptions
-* [#6122](https://github.com/apache/incubator-nuttx/pull/6122) arch/xtensa: Color the other CPUs task when they are created
-* [#6111](https://github.com/apache/incubator-nuttx/pull/6111) arch/xtensa: Use syscall interface for xtensa_save/restore_context
-* [#6109](https://github.com/apache/incubator-nuttx/pull/6109) arch/sparc,xtensa: Control output by $(Q) as other arch
-* [#6222](https://github.com/apache/incubator-nuttx/pull/6222) xtensa: move fpu register to XCPTCONTEXT_REGS
-* [#6231](https://github.com/apache/incubator-nuttx/pull/6231) xtensa_sigtramp.S: Remove unnecessary entry instruction
-* [#6203](https://github.com/apache/incubator-nuttx/pull/6203) xtensa/xtensa_coproc.S: Use the first allocated memory to save A0
-* [#5790](https://github.com/apache/incubator-nuttx/pull/5790) xtensa_coporc: Adjust stack frame for C callable coprocessor functions
-* [#6258](https://github.com/apache/incubator-nuttx/pull/6258) xtensa: Fix argument passing for sys_call5 and sys_call6 functions
-* [#6269](https://github.com/apache/incubator-nuttx/pull/6269) xtensa: use CONFIG_ARCH_FPU macro for coprocossor and add up_fpucmp
-* [#6270](https://github.com/apache/incubator-nuttx/pull/6270) xtensa: Implement syscalls required for Protected Mode
-* [#6278](https://github.com/apache/incubator-nuttx/pull/6278) xtensa.h: Remove old prototype
-* [#6293](https://github.com/apache/incubator-nuttx/pull/6293) Xtensa: Add missing input operand on sys_call6 inline ASM
-* [#6349](https://github.com/apache/incubator-nuttx/pull/6349) arch/xtensa: Remove the assembly signal trampoline
-* [#6312](https://github.com/apache/incubator-nuttx/pull/6312) xtensa/esp32s3: Add basic support to SPI
-* [#6372](https://github.com/apache/incubator-nuttx/pull/6372) arch/xtensa: Initialize the internal heap early with the rest of custom heaps
-* [#6352](https://github.com/apache/incubator-nuttx/pull/6352) esp32-devkitc:wamr_wasi_debug: pin WAMR version
-* [#6314](https://github.com/apache/incubator-nuttx/pull/6314) xtensa: esp32: enable cp processor of app core
-* [#6302](https://github.com/apache/incubator-nuttx/pull/6302) xtensa: coproc: modify coproc_save/restore to macro
-* [#6294](https://github.com/apache/incubator-nuttx/pull/6294) xtensa: add perf counter
-* [#6380](https://github.com/apache/incubator-nuttx/pull/6380) arch/xtensa/xtensa_coproc.S: Fix the condition to save the coprocessors state
-* [#6425](https://github.com/apache/incubator-nuttx/pull/6425) arch/xtensa: Don't build xtensa_coproc.S
-* [#6443](https://github.com/apache/incubator-nuttx/pull/6443) xtensa: Remove old references to co-processors
-* [#6440](https://github.com/apache/incubator-nuttx/pull/6440) arch/xtensa: Refactor assembly code
-* [#6436](https://github.com/apache/incubator-nuttx/pull/6436) xtensa/esp32_rtc_lowerhalf.c: Initialize ret variable
-* [#6532](https://github.com/apache/incubator-nuttx/pull/6532) Remove '-g' LDFLAG
-* [#6573](https://github.com/apache/incubator-nuttx/pull/6573) xtensa: Unify common options within a single Make.defs
+* [#5946](https://github.com/apache/nuttx/pull/5946) arch/xtensa: Add xtensa_tcbinfo struct that contains helpful offsets
+* [#5877](https://github.com/apache/nuttx/pull/5877) xtensa: add xtensa arch oneshot ops
+* [#5876](https://github.com/apache/nuttx/pull/5876) xtensa: add xtensa_spill_window declaration
+* [#5820](https://github.com/apache/nuttx/pull/5820) xtensa/esp32(s2)_user.c: Use macros defined in xtens_corebits.h
+* [#5771](https://github.com/apache/nuttx/pull/5771) arch/xtensa: Don't always reset the APP CPU on startup
+* [#5979](https://github.com/apache/nuttx/pull/5979) arch/xtensa: Build the xtensa_tcbinfo.c file for S2 and S3
+* [#5987](https://github.com/apache/nuttx/pull/5987) xtensa/esp32: Add support to TWAI/CANBus
+* [#5941](https://github.com/apache/nuttx/pull/5941) arch/xtensa: add syscall note support in the flat build
+* [#6167](https://github.com/apache/nuttx/pull/6167) arch/xtensa: Replace the xcp context with stack context to improve context switching
+* [#6148](https://github.com/apache/nuttx/pull/6148) arch/xtensa: Refactor assembly macros
+* [#6147](https://github.com/apache/nuttx/pull/6147) arch/xtensa: Simply use xtensa_createstack for CPU1 idle task.
+* [#6136](https://github.com/apache/nuttx/pull/6136) xtensa: Fix backtrace on exceptions
+* [#6122](https://github.com/apache/nuttx/pull/6122) arch/xtensa: Color the other CPUs task when they are created
+* [#6111](https://github.com/apache/nuttx/pull/6111) arch/xtensa: Use syscall interface for xtensa_save/restore_context
+* [#6109](https://github.com/apache/nuttx/pull/6109) arch/sparc,xtensa: Control output by $(Q) as other arch
+* [#6222](https://github.com/apache/nuttx/pull/6222) xtensa: move fpu register to XCPTCONTEXT_REGS
+* [#6231](https://github.com/apache/nuttx/pull/6231) xtensa_sigtramp.S: Remove unnecessary entry instruction
+* [#6203](https://github.com/apache/nuttx/pull/6203) xtensa/xtensa_coproc.S: Use the first allocated memory to save A0
+* [#5790](https://github.com/apache/nuttx/pull/5790) xtensa_coporc: Adjust stack frame for C callable coprocessor functions
+* [#6258](https://github.com/apache/nuttx/pull/6258) xtensa: Fix argument passing for sys_call5 and sys_call6 functions
+* [#6269](https://github.com/apache/nuttx/pull/6269) xtensa: use CONFIG_ARCH_FPU macro for coprocossor and add up_fpucmp
+* [#6270](https://github.com/apache/nuttx/pull/6270) xtensa: Implement syscalls required for Protected Mode
+* [#6278](https://github.com/apache/nuttx/pull/6278) xtensa.h: Remove old prototype
+* [#6293](https://github.com/apache/nuttx/pull/6293) Xtensa: Add missing input operand on sys_call6 inline ASM
+* [#6349](https://github.com/apache/nuttx/pull/6349) arch/xtensa: Remove the assembly signal trampoline
+* [#6312](https://github.com/apache/nuttx/pull/6312) xtensa/esp32s3: Add basic support to SPI
+* [#6372](https://github.com/apache/nuttx/pull/6372) arch/xtensa: Initialize the internal heap early with the rest of custom heaps
+* [#6352](https://github.com/apache/nuttx/pull/6352) esp32-devkitc:wamr_wasi_debug: pin WAMR version
+* [#6314](https://github.com/apache/nuttx/pull/6314) xtensa: esp32: enable cp processor of app core
+* [#6302](https://github.com/apache/nuttx/pull/6302) xtensa: coproc: modify coproc_save/restore to macro
+* [#6294](https://github.com/apache/nuttx/pull/6294) xtensa: add perf counter
+* [#6380](https://github.com/apache/nuttx/pull/6380) arch/xtensa/xtensa_coproc.S: Fix the condition to save the coprocessors state
+* [#6425](https://github.com/apache/nuttx/pull/6425) arch/xtensa: Don't build xtensa_coproc.S
+* [#6443](https://github.com/apache/nuttx/pull/6443) xtensa: Remove old references to co-processors
+* [#6440](https://github.com/apache/nuttx/pull/6440) arch/xtensa: Refactor assembly code
+* [#6436](https://github.com/apache/nuttx/pull/6436) xtensa/esp32_rtc_lowerhalf.c: Initialize ret variable
+* [#6532](https://github.com/apache/nuttx/pull/6532) Remove '-g' LDFLAG
+* [#6573](https://github.com/apache/nuttx/pull/6573) xtensa: Unify common options within a single Make.defs
 
-* [#6390](https://github.com/apache/incubator-nuttx/pull/6390) arch/sparc/bm3803: fix the using of uart1 and uart2
-* [#6327](https://github.com/apache/incubator-nuttx/pull/6327) arch/sparc: Remove FILE dump code from _up_dumponexit
+* [#6390](https://github.com/apache/nuttx/pull/6390) arch/sparc/bm3803: fix the using of uart1 and uart2
+* [#6327](https://github.com/apache/nuttx/pull/6327) arch/sparc: Remove FILE dump code from _up_dumponexit
 
-* [#6233](https://github.com/apache/incubator-nuttx/pull/6233) Tiva qemu
-* [#5151](https://github.com/apache/incubator-nuttx/pull/5151) Tiva CAN driver
-* [#6244](https://github.com/apache/incubator-nuttx/pull/6244) Fix broken tiva_gpioirqclear
-* [#6548](https://github.com/apache/incubator-nuttx/pull/6548) tiva: Add UART CTS/RTS support
+* [#6233](https://github.com/apache/nuttx/pull/6233) Tiva qemu
+* [#5151](https://github.com/apache/nuttx/pull/5151) Tiva CAN driver
+* [#6244](https://github.com/apache/nuttx/pull/6244) Fix broken tiva_gpioirqclear
+* [#6548](https://github.com/apache/nuttx/pull/6548) tiva: Add UART CTS/RTS support
 
-* [#5815](https://github.com/apache/incubator-nuttx/pull/5815) defconfig: add Lua configs for sim and teensy-4.x
+* [#5815](https://github.com/apache/nuttx/pull/5815) defconfig: add Lua configs for sim and teensy-4.x
 
-* [#6765](https://github.com/apache/incubator-nuttx/pull/6765) arm/backtrace: use sp unwind if FRAME_POINTER is enabled on thumb mode
-* [#6208](https://github.com/apache/incubator-nuttx/pull/6208) arm: Refine the common Make.defs
-* [#6309](https://github.com/apache/incubator-nuttx/pull/6309) Armv6-m LTO fix
-* [#6071](https://github.com/apache/incubator-nuttx/pull/6071) arm/rtl8720c: Remove up_getsp which is already implemented in arch/arm/arch.h
-* [#6072](https://github.com/apache/incubator-nuttx/pull/6072) arm/armv7-[a|r]: move fpu save/restore to assembly handler
-* [#6048](https://github.com/apache/incubator-nuttx/pull/6048) arm/armv8-m: indicating no low-overhead-loop predication by default
-* [#6042](https://github.com/apache/incubator-nuttx/pull/6042) arch/arm: Move FPU initialization to common place
-* [#6001](https://github.com/apache/incubator-nuttx/pull/6001) arm/armv[7|8]-m: skip the fpu save/restore if stack frame is integer-only
-* [#5752](https://github.com/apache/incubator-nuttx/pull/5752) arch: cxd56xx: Fix critical section in serial transmission
-* [#5761](https://github.com/apache/incubator-nuttx/pull/5761) arch/arm: Remove the code copy register from xcpt to stack
-* [#5774](https://github.com/apache/incubator-nuttx/pull/5774) arch/arm: set the SP to stack top
-* [#5824](https://github.com/apache/incubator-nuttx/pull/5824) arch/arm/src/stm32l4: peripheral voltage monitor support for vddio2
-* [#5863](https://github.com/apache/incubator-nuttx/pull/5863) arch/arm: Change arm_arch.h to arm_internal.h in arm_perf.c
-* [#5870](https://github.com/apache/incubator-nuttx/pull/5870) arch/armv7-a: Fix a typo in Toolchain.defs
-* [#5845](https://github.com/apache/incubator-nuttx/pull/5845) armv8-m: make the securefault handled by non-securefult
-* [#5850](https://github.com/apache/incubator-nuttx/pull/5850) armv7-m/armv8-m: move up_pref* api to common place
-* [#5745](https://github.com/apache/incubator-nuttx/pull/5745) arch/arm/samv7/sam_tc: implement timer driver support
-* [#5896](https://github.com/apache/incubator-nuttx/pull/5896) arm/cortex-[a|r]: IRQ Switch return should with shadow SPSR
-* [#5897](https://github.com/apache/incubator-nuttx/pull/5897) ESP32{S2/S3/C3}: Enable support for C++ applications
-* [#5918](https://github.com/apache/incubator-nuttx/pull/5918) arm/chip: add backtrace support for all chips that support thumb instruction set
-* [#6079](https://github.com/apache/incubator-nuttx/pull/6079) arm/arch: using __builtin_frame_address(0) implement up_getsp()
-* [#6076](https://github.com/apache/incubator-nuttx/pull/6076) arch/armv[7|8]m: enhance the clang support
-* [#6073](https://github.com/apache/incubator-nuttx/pull/6073) arch/arm: Remove all lazy fpu related code
-* [#6057](https://github.com/apache/incubator-nuttx/pull/6057) arch/stm32h7: Add SocketCAN FDCAN driver
-* [#6091](https://github.com/apache/incubator-nuttx/pull/6091) arch/arm: Move arm_signal_dispatch.c to common folder
-* [#6165](https://github.com/apache/incubator-nuttx/pull/6165) arch/arm/Make.defs: unify common source include
-* [#6123](https://github.com/apache/incubator-nuttx/pull/6123) arch/arm: add support for GCC LTO
-* [#6114](https://github.com/apache/incubator-nuttx/pull/6114) arm/armv[7|8]m: compare of hardware fp registers should skip REG_FP_RESERVED
-* [#6107](https://github.com/apache/incubator-nuttx/pull/6107) armv7/r:cp15_cache_all: fix error in LineSize 'r5' mask
-* [#6099](https://github.com/apache/incubator-nuttx/pull/6099) arch/armv7-[a|r]: correct the handing of group env switch
-* [#6097](https://github.com/apache/incubator-nuttx/pull/6097) arch/armv[7|8]-m: Unify the toolchain definition of eabi/clang/iar for linux and windows
-* [#6096](https://github.com/apache/incubator-nuttx/pull/6096) arch/arm: Remove unneeded group_addrenv call which handled by arm_doirq
-* [#6093](https://github.com/apache/incubator-nuttx/pull/6093) arch/arm: Remove FAR and CODE from common/ and arm*/ folder
-* [#6092](https://github.com/apache/incubator-nuttx/pull/6092) arch/arm: Remove FAR and CODE from chip and board folder
-* [#6198](https://github.com/apache/incubator-nuttx/pull/6198) armv7-a: smp: fix stack coloration
-* [#6185](https://github.com/apache/incubator-nuttx/pull/6185) arm/cxd56xx/lc823450: replace arch testset to board implement
-* [#6178](https://github.com/apache/incubator-nuttx/pull/6178) armv7-a/r: use cps instruction to change cpu mode
-* [#6163](https://github.com/apache/incubator-nuttx/pull/6163) arm/arch_setjmp.S: armv6m support setjmp, longjmp
-* [#6103](https://github.com/apache/incubator-nuttx/pull/6103) arm: Remove or merge assembly code as much as possible
-* [#6214](https://github.com/apache/incubator-nuttx/pull/6214) armv7-a: smp: allocate page table for each cpu
-* [#6213](https://github.com/apache/incubator-nuttx/pull/6213) arm/cortex-m/toolchain: try print runtime library only in clang
-* [#6211](https://github.com/apache/incubator-nuttx/pull/6211) armv7-a: Inner Shareable TLB maintenance operations
-* [#6225](https://github.com/apache/incubator-nuttx/pull/6225) arm/tlsr82: pwm driver optimize and add pulse count support
-* [#6259](https://github.com/apache/incubator-nuttx/pull/6259) arm/tlsr82: add hardware aes encrypt and decrypt support
-* [#6354](https://github.com/apache/incubator-nuttx/pull/6354) arm/tlsr82: support flash protection and flash voltage calibration
-* [#6311](https://github.com/apache/incubator-nuttx/pull/6311) arm/tlsr82: optimize the adc driver
-* [#6424](https://github.com/apache/incubator-nuttx/pull/6424) arm/tlsr82: bugfix, tlsr82_flash_ioctl() return wrong value
-* [#6379](https://github.com/apache/incubator-nuttx/pull/6379) arm/tlsr82: gpio driver bug fix and optimize
-* [#6334](https://github.com/apache/incubator-nuttx/pull/6334) arm/tlsr82: ble performance optimize and problems solve
-* [#6238](https://github.com/apache/incubator-nuttx/pull/6238) tlsr82/tc32: optimize the irq process
-* [#6332](https://github.com/apache/incubator-nuttx/pull/6332) arch: imx6: add support kernel build and smp 
-* [#6429](https://github.com/apache/incubator-nuttx/pull/6429) arch: imx6: Enable imx_idle.c to reduce CPU load
-* [#6234](https://github.com/apache/incubator-nuttx/pull/6234) arm/tc32/Make.defs: filter-out arm_udelay.c
-* [#6736](https://github.com/apache/incubator-nuttx/pull/6736) arm/allocateheap: fix multiple definition of 'up_allocate_heap'
-* [#6659](https://github.com/apache/incubator-nuttx/pull/6659) arch/arm/samv7: fix SPI 16-bit transactions in DMA mode
-* [#6676](https://github.com/apache/incubator-nuttx/pull/6676) arm_secure_irq: fix NVIC_IRQ_DBGMONITOR un-secure set failed
-* [#5645](https://github.com/apache/incubator-nuttx/pull/5645) arch/arm: optimize context switch speed
-* [#5662](https://github.com/apache/incubator-nuttx/pull/5662) arch/arm: Move ARCHCPUFLAGS to Toolchain.defs
-* [#6228](https://github.com/apache/incubator-nuttx/pull/6228) arch/arm: Fix target 'arm_fpuconfig.o' given more than once in the same rule
-* [#6201](https://github.com/apache/incubator-nuttx/pull/6201) Restore lost flash define for stm32
-* [#3488](https://github.com/apache/incubator-nuttx/pull/3488) stm32h7: Adds tickless support
-* [#6772](https://github.com/apache/incubator-nuttx/pull/6772) arch/stm32f7/stm32_tim.c: include the missing RCC header
-* [#6771](https://github.com/apache/incubator-nuttx/pull/6771) arch/stm32xx/Kconfig: simplify and unify PWM options
-* [#6757](https://github.com/apache/incubator-nuttx/pull/6757) STM32L4 DAC: Implements basic support for low level operations
-* [#6741](https://github.com/apache/incubator-nuttx/pull/6741) stm32wb/mbox: fixing TX buffer queue
-* [#6732](https://github.com/apache/incubator-nuttx/pull/6732) Multiple stm32wl5jc flash usage improvements
-* [#6775](https://github.com/apache/incubator-nuttx/pull/6775) arch/stm32/stm32_foc.c: fix some ADC and PWM ifdefs
-* [#6769](https://github.com/apache/incubator-nuttx/pull/6769) arch/stm32f0l0g0: add SPI3 support (STM32G0B0 chips)
-* [#6218](https://github.com/apache/incubator-nuttx/pull/6218) STM32F746G-Disco, Audiosupport, Bugfix
-* [#6715](https://github.com/apache/incubator-nuttx/pull/6715) stm32wb: adding BLE support 
-* [#6729](https://github.com/apache/incubator-nuttx/pull/6729) stm32f7: add showprogress in __start
-* [#6078](https://github.com/apache/incubator-nuttx/pull/6078) Stm32f746 audio 
-* [#6413](https://github.com/apache/incubator-nuttx/pull/6413) stm32wl5: add gpio exti support
-* [#6426](https://github.com/apache/incubator-nuttx/pull/6426) stm32wl5: add flash progmem driver support
-* [#6788](https://github.com/apache/incubator-nuttx/pull/6788) LPC17xx_40xx PWM multichannel support
-* [#6758](https://github.com/apache/incubator-nuttx/pull/6758) LPC17_40 CAN driver SocketCAN support
-* [#6267](https://github.com/apache/incubator-nuttx/pull/6267) arch/arm/samv7/sam_afec: fix ADC pin for channel 9
-* [#6339](https://github.com/apache/incubator-nuttx/pull/6339) sama5d2: Fix sama5d2 Kconfig errors and add missing pin definitions
-* [#6268](https://github.com/apache/incubator-nuttx/pull/6268) arm/cortex-[a|r]: add performance counter implement based on PMU
-* [#6298](https://github.com/apache/incubator-nuttx/pull/6298) arch/arm/samv7: Fix PWM operation for single channel mode
-* [#6265](https://github.com/apache/incubator-nuttx/pull/6265) Fixes to imxRT and SAM E70 PWM drivers
-* [#6572](https://github.com/apache/incubator-nuttx/pull/6572) arch/arm/Kconfig: Add description for ARM_THUMB to make it configurable
-* [#6508](https://github.com/apache/incubator-nuttx/pull/6508) sama5: add config SAMA5_SYSTEMRESET in arch/arm/src/sama5/Kconfig
-* [#6534](https://github.com/apache/incubator-nuttx/pull/6534) arch/arm/armv7-m: Fix error link argument for compiler-rt
-* [#6497](https://github.com/apache/incubator-nuttx/pull/6497) samv7:mcan Fix can buffer calculation. Add two words to every msg buffer
-* [#6614](https://github.com/apache/incubator-nuttx/pull/6614) samv7: add support for RX DMA and RS-485 mode to serial driver
-* [#6599](https://github.com/apache/incubator-nuttx/pull/6599) arch/arm/samv7: EMAC bugfixes
-* [#6306](https://github.com/apache/incubator-nuttx/pull/6306) Add up_textheap_heapmember
-* [#6204](https://github.com/apache/incubator-nuttx/pull/6204) MCAN_INT_ACKE must be on the list of MCAN_TXERR_INTS to be properly h…
-* [#6121](https://github.com/apache/incubator-nuttx/pull/6121) compile/opt: add config DEBUG_LINK_MAP
-* [#6614](https://github.com/apache/incubator-nuttx/pull/6614) samv7: add support for RX DMA and RS-485 mode to serial driver
-* [#6615](https://github.com/apache/incubator-nuttx/pull/6615) Add I2C slave mode for RP2040
-* [#6617](https://github.com/apache/incubator-nuttx/pull/6617) Fix arm64 stack coloration
-* [#6682](https://github.com/apache/incubator-nuttx/pull/6682) Fixed path calculation in BBS RAM
+* [#6765](https://github.com/apache/nuttx/pull/6765) arm/backtrace: use sp unwind if FRAME_POINTER is enabled on thumb mode
+* [#6208](https://github.com/apache/nuttx/pull/6208) arm: Refine the common Make.defs
+* [#6309](https://github.com/apache/nuttx/pull/6309) Armv6-m LTO fix
+* [#6071](https://github.com/apache/nuttx/pull/6071) arm/rtl8720c: Remove up_getsp which is already implemented in arch/arm/arch.h
+* [#6072](https://github.com/apache/nuttx/pull/6072) arm/armv7-[a|r]: move fpu save/restore to assembly handler
+* [#6048](https://github.com/apache/nuttx/pull/6048) arm/armv8-m: indicating no low-overhead-loop predication by default
+* [#6042](https://github.com/apache/nuttx/pull/6042) arch/arm: Move FPU initialization to common place
+* [#6001](https://github.com/apache/nuttx/pull/6001) arm/armv[7|8]-m: skip the fpu save/restore if stack frame is integer-only
+* [#5752](https://github.com/apache/nuttx/pull/5752) arch: cxd56xx: Fix critical section in serial transmission
+* [#5761](https://github.com/apache/nuttx/pull/5761) arch/arm: Remove the code copy register from xcpt to stack
+* [#5774](https://github.com/apache/nuttx/pull/5774) arch/arm: set the SP to stack top
+* [#5824](https://github.com/apache/nuttx/pull/5824) arch/arm/src/stm32l4: peripheral voltage monitor support for vddio2
+* [#5863](https://github.com/apache/nuttx/pull/5863) arch/arm: Change arm_arch.h to arm_internal.h in arm_perf.c
+* [#5870](https://github.com/apache/nuttx/pull/5870) arch/armv7-a: Fix a typo in Toolchain.defs
+* [#5845](https://github.com/apache/nuttx/pull/5845) armv8-m: make the securefault handled by non-securefult
+* [#5850](https://github.com/apache/nuttx/pull/5850) armv7-m/armv8-m: move up_pref* api to common place
+* [#5745](https://github.com/apache/nuttx/pull/5745) arch/arm/samv7/sam_tc: implement timer driver support
+* [#5896](https://github.com/apache/nuttx/pull/5896) arm/cortex-[a|r]: IRQ Switch return should with shadow SPSR
+* [#5897](https://github.com/apache/nuttx/pull/5897) ESP32{S2/S3/C3}: Enable support for C++ applications
+* [#5918](https://github.com/apache/nuttx/pull/5918) arm/chip: add backtrace support for all chips that support thumb instruction set
+* [#6079](https://github.com/apache/nuttx/pull/6079) arm/arch: using __builtin_frame_address(0) implement up_getsp()
+* [#6076](https://github.com/apache/nuttx/pull/6076) arch/armv[7|8]m: enhance the clang support
+* [#6073](https://github.com/apache/nuttx/pull/6073) arch/arm: Remove all lazy fpu related code
+* [#6057](https://github.com/apache/nuttx/pull/6057) arch/stm32h7: Add SocketCAN FDCAN driver
+* [#6091](https://github.com/apache/nuttx/pull/6091) arch/arm: Move arm_signal_dispatch.c to common folder
+* [#6165](https://github.com/apache/nuttx/pull/6165) arch/arm/Make.defs: unify common source include
+* [#6123](https://github.com/apache/nuttx/pull/6123) arch/arm: add support for GCC LTO
+* [#6114](https://github.com/apache/nuttx/pull/6114) arm/armv[7|8]m: compare of hardware fp registers should skip REG_FP_RESERVED
+* [#6107](https://github.com/apache/nuttx/pull/6107) armv7/r:cp15_cache_all: fix error in LineSize 'r5' mask
+* [#6099](https://github.com/apache/nuttx/pull/6099) arch/armv7-[a|r]: correct the handing of group env switch
+* [#6097](https://github.com/apache/nuttx/pull/6097) arch/armv[7|8]-m: Unify the toolchain definition of eabi/clang/iar for linux and windows
+* [#6096](https://github.com/apache/nuttx/pull/6096) arch/arm: Remove unneeded group_addrenv call which handled by arm_doirq
+* [#6093](https://github.com/apache/nuttx/pull/6093) arch/arm: Remove FAR and CODE from common/ and arm*/ folder
+* [#6092](https://github.com/apache/nuttx/pull/6092) arch/arm: Remove FAR and CODE from chip and board folder
+* [#6198](https://github.com/apache/nuttx/pull/6198) armv7-a: smp: fix stack coloration
+* [#6185](https://github.com/apache/nuttx/pull/6185) arm/cxd56xx/lc823450: replace arch testset to board implement
+* [#6178](https://github.com/apache/nuttx/pull/6178) armv7-a/r: use cps instruction to change cpu mode
+* [#6163](https://github.com/apache/nuttx/pull/6163) arm/arch_setjmp.S: armv6m support setjmp, longjmp
+* [#6103](https://github.com/apache/nuttx/pull/6103) arm: Remove or merge assembly code as much as possible
+* [#6214](https://github.com/apache/nuttx/pull/6214) armv7-a: smp: allocate page table for each cpu
+* [#6213](https://github.com/apache/nuttx/pull/6213) arm/cortex-m/toolchain: try print runtime library only in clang
+* [#6211](https://github.com/apache/nuttx/pull/6211) armv7-a: Inner Shareable TLB maintenance operations
+* [#6225](https://github.com/apache/nuttx/pull/6225) arm/tlsr82: pwm driver optimize and add pulse count support
+* [#6259](https://github.com/apache/nuttx/pull/6259) arm/tlsr82: add hardware aes encrypt and decrypt support
+* [#6354](https://github.com/apache/nuttx/pull/6354) arm/tlsr82: support flash protection and flash voltage calibration
+* [#6311](https://github.com/apache/nuttx/pull/6311) arm/tlsr82: optimize the adc driver
+* [#6424](https://github.com/apache/nuttx/pull/6424) arm/tlsr82: bugfix, tlsr82_flash_ioctl() return wrong value
+* [#6379](https://github.com/apache/nuttx/pull/6379) arm/tlsr82: gpio driver bug fix and optimize
+* [#6334](https://github.com/apache/nuttx/pull/6334) arm/tlsr82: ble performance optimize and problems solve
+* [#6238](https://github.com/apache/nuttx/pull/6238) tlsr82/tc32: optimize the irq process
+* [#6332](https://github.com/apache/nuttx/pull/6332) arch: imx6: add support kernel build and smp 
+* [#6429](https://github.com/apache/nuttx/pull/6429) arch: imx6: Enable imx_idle.c to reduce CPU load
+* [#6234](https://github.com/apache/nuttx/pull/6234) arm/tc32/Make.defs: filter-out arm_udelay.c
+* [#6736](https://github.com/apache/nuttx/pull/6736) arm/allocateheap: fix multiple definition of 'up_allocate_heap'
+* [#6659](https://github.com/apache/nuttx/pull/6659) arch/arm/samv7: fix SPI 16-bit transactions in DMA mode
+* [#6676](https://github.com/apache/nuttx/pull/6676) arm_secure_irq: fix NVIC_IRQ_DBGMONITOR un-secure set failed
+* [#5645](https://github.com/apache/nuttx/pull/5645) arch/arm: optimize context switch speed
+* [#5662](https://github.com/apache/nuttx/pull/5662) arch/arm: Move ARCHCPUFLAGS to Toolchain.defs
+* [#6228](https://github.com/apache/nuttx/pull/6228) arch/arm: Fix target 'arm_fpuconfig.o' given more than once in the same rule
+* [#6201](https://github.com/apache/nuttx/pull/6201) Restore lost flash define for stm32
+* [#3488](https://github.com/apache/nuttx/pull/3488) stm32h7: Adds tickless support
+* [#6772](https://github.com/apache/nuttx/pull/6772) arch/stm32f7/stm32_tim.c: include the missing RCC header
+* [#6771](https://github.com/apache/nuttx/pull/6771) arch/stm32xx/Kconfig: simplify and unify PWM options
+* [#6757](https://github.com/apache/nuttx/pull/6757) STM32L4 DAC: Implements basic support for low level operations
+* [#6741](https://github.com/apache/nuttx/pull/6741) stm32wb/mbox: fixing TX buffer queue
+* [#6732](https://github.com/apache/nuttx/pull/6732) Multiple stm32wl5jc flash usage improvements
+* [#6775](https://github.com/apache/nuttx/pull/6775) arch/stm32/stm32_foc.c: fix some ADC and PWM ifdefs
+* [#6769](https://github.com/apache/nuttx/pull/6769) arch/stm32f0l0g0: add SPI3 support (STM32G0B0 chips)
+* [#6218](https://github.com/apache/nuttx/pull/6218) STM32F746G-Disco, Audiosupport, Bugfix
+* [#6715](https://github.com/apache/nuttx/pull/6715) stm32wb: adding BLE support 
+* [#6729](https://github.com/apache/nuttx/pull/6729) stm32f7: add showprogress in __start
+* [#6078](https://github.com/apache/nuttx/pull/6078) Stm32f746 audio 
+* [#6413](https://github.com/apache/nuttx/pull/6413) stm32wl5: add gpio exti support
+* [#6426](https://github.com/apache/nuttx/pull/6426) stm32wl5: add flash progmem driver support
+* [#6788](https://github.com/apache/nuttx/pull/6788) LPC17xx_40xx PWM multichannel support
+* [#6758](https://github.com/apache/nuttx/pull/6758) LPC17_40 CAN driver SocketCAN support
+* [#6267](https://github.com/apache/nuttx/pull/6267) arch/arm/samv7/sam_afec: fix ADC pin for channel 9
+* [#6339](https://github.com/apache/nuttx/pull/6339) sama5d2: Fix sama5d2 Kconfig errors and add missing pin definitions
+* [#6268](https://github.com/apache/nuttx/pull/6268) arm/cortex-[a|r]: add performance counter implement based on PMU
+* [#6298](https://github.com/apache/nuttx/pull/6298) arch/arm/samv7: Fix PWM operation for single channel mode
+* [#6265](https://github.com/apache/nuttx/pull/6265) Fixes to imxRT and SAM E70 PWM drivers
+* [#6572](https://github.com/apache/nuttx/pull/6572) arch/arm/Kconfig: Add description for ARM_THUMB to make it configurable
+* [#6508](https://github.com/apache/nuttx/pull/6508) sama5: add config SAMA5_SYSTEMRESET in arch/arm/src/sama5/Kconfig
+* [#6534](https://github.com/apache/nuttx/pull/6534) arch/arm/armv7-m: Fix error link argument for compiler-rt
+* [#6497](https://github.com/apache/nuttx/pull/6497) samv7:mcan Fix can buffer calculation. Add two words to every msg buffer
+* [#6614](https://github.com/apache/nuttx/pull/6614) samv7: add support for RX DMA and RS-485 mode to serial driver
+* [#6599](https://github.com/apache/nuttx/pull/6599) arch/arm/samv7: EMAC bugfixes
+* [#6306](https://github.com/apache/nuttx/pull/6306) Add up_textheap_heapmember
+* [#6204](https://github.com/apache/nuttx/pull/6204) MCAN_INT_ACKE must be on the list of MCAN_TXERR_INTS to be properly h…
+* [#6121](https://github.com/apache/nuttx/pull/6121) compile/opt: add config DEBUG_LINK_MAP
+* [#6614](https://github.com/apache/nuttx/pull/6614) samv7: add support for RX DMA and RS-485 mode to serial driver
+* [#6615](https://github.com/apache/nuttx/pull/6615) Add I2C slave mode for RP2040
+* [#6617](https://github.com/apache/nuttx/pull/6617) Fix arm64 stack coloration
+* [#6682](https://github.com/apache/nuttx/pull/6682) Fixed path calculation in BBS RAM
 
-* [#6790](https://github.com/apache/incubator-nuttx/pull/6790) Several IMXRT fixes
-* [#6786](https://github.com/apache/incubator-nuttx/pull/6786) IMX.RT EDMA Support
-* [#6787](https://github.com/apache/incubator-nuttx/pull/6787) imxrt: Ethernet Cleanup and extend support for ETH1 or ETH2 and LAN8742A
-* [#6794](https://github.com/apache/incubator-nuttx/pull/6794) IMX.RT Add DMA on LPSPI, LPUART, LPI2C
+* [#6790](https://github.com/apache/nuttx/pull/6790) Several IMXRT fixes
+* [#6786](https://github.com/apache/nuttx/pull/6786) IMX.RT EDMA Support
+* [#6787](https://github.com/apache/nuttx/pull/6787) imxrt: Ethernet Cleanup and extend support for ETH1 or ETH2 and LAN8742A
+* [#6794](https://github.com/apache/nuttx/pull/6794) IMX.RT Add DMA on LPSPI, LPUART, LPI2C
 
-* [#6675](https://github.com/apache/incubator-nuttx/pull/6675) sim: idle pm should do PM_RESOTRE in critical section
-* [#6689](https://github.com/apache/incubator-nuttx/pull/6689) sim: Increased priority of loop task
-* [#6792](https://github.com/apache/incubator-nuttx/pull/6792) sim/adb: Enable ping for test
-* [#5862](https://github.com/apache/incubator-nuttx/pull/5862) arch/sim: Remove the unused SIM_TCNWAITERS from Kconfig
-* [#5923](https://github.com/apache/incubator-nuttx/pull/5923) sim: Fix initialization of static C++ constructors when using glibc >= 2.34
-* [#5885](https://github.com/apache/incubator-nuttx/pull/5885) sim/rptun: rsc must set rpmsg_vdev.config_len
-* [#5756](https://github.com/apache/incubator-nuttx/pull/5756) sim: Enable garbage collection of unused input sections
-* [#5988](https://github.com/apache/incubator-nuttx/pull/5988) arch/sim: support simulator keyboard devices
-* [#6043](https://github.com/apache/incubator-nuttx/pull/6043) sim: bt: Add specific bluetooth HCI number id
+* [#6675](https://github.com/apache/nuttx/pull/6675) sim: idle pm should do PM_RESOTRE in critical section
+* [#6689](https://github.com/apache/nuttx/pull/6689) sim: Increased priority of loop task
+* [#6792](https://github.com/apache/nuttx/pull/6792) sim/adb: Enable ping for test
+* [#5862](https://github.com/apache/nuttx/pull/5862) arch/sim: Remove the unused SIM_TCNWAITERS from Kconfig
+* [#5923](https://github.com/apache/nuttx/pull/5923) sim: Fix initialization of static C++ constructors when using glibc >= 2.34
+* [#5885](https://github.com/apache/nuttx/pull/5885) sim/rptun: rsc must set rpmsg_vdev.config_len
+* [#5756](https://github.com/apache/nuttx/pull/5756) sim: Enable garbage collection of unused input sections
+* [#5988](https://github.com/apache/nuttx/pull/5988) arch/sim: support simulator keyboard devices
+* [#6043](https://github.com/apache/nuttx/pull/6043) sim: bt: Add specific bluetooth HCI number id
 
 # Driver Support
 
 ## New Driver Support
 
-* [#6030](https://github.com/apache/incubator-nuttx/pull/6030) Add Sensirion's SCD41 driver and minor fix
-* [#6412](https://github.com/apache/incubator-nuttx/pull/6412) drivers/sensors: add driver for as5048a magnetic encoder
-* [#6345](https://github.com/apache/incubator-nuttx/pull/6345) drivers: video: add isx019 camera sensor
-* [#6491](https://github.com/apache/incubator-nuttx/pull/6491) LITEETH peripheral driver support
-* [#6525](https://github.com/apache/incubator-nuttx/pull/6525) drivers: add support of pwm capture driver
-* [#6537](https://github.com/apache/incubator-nuttx/pull/6537) drivers/ipcc: add Inter Processor Communication driver
-* [#5835](https://github.com/apache/incubator-nuttx/pull/5835) LITESDCARD peripheral driver support
-* [#6510](https://github.com/apache/incubator-nuttx/pull/6510) Support for 2.13 inch display v2
-* [#6634](https://github.com/apache/incubator-nuttx/pull/6634) drivers/lcd: Add support to use APA102 LED Matrix as LCD Display
-* [#6408](https://github.com/apache/incubator-nuttx/pull/6408) e-ink ssd1680 driver
-* [#6353](https://github.com/apache/incubator-nuttx/pull/6353) Add driver for WIZnet W5500 Ethernet controller
+* [#6030](https://github.com/apache/nuttx/pull/6030) Add Sensirion's SCD41 driver and minor fix
+* [#6412](https://github.com/apache/nuttx/pull/6412) drivers/sensors: add driver for as5048a magnetic encoder
+* [#6345](https://github.com/apache/nuttx/pull/6345) drivers: video: add isx019 camera sensor
+* [#6491](https://github.com/apache/nuttx/pull/6491) LITEETH peripheral driver support
+* [#6525](https://github.com/apache/nuttx/pull/6525) drivers: add support of pwm capture driver
+* [#6537](https://github.com/apache/nuttx/pull/6537) drivers/ipcc: add Inter Processor Communication driver
+* [#5835](https://github.com/apache/nuttx/pull/5835) LITESDCARD peripheral driver support
+* [#6510](https://github.com/apache/nuttx/pull/6510) Support for 2.13 inch display v2
+* [#6634](https://github.com/apache/nuttx/pull/6634) drivers/lcd: Add support to use APA102 LED Matrix as LCD Display
+* [#6408](https://github.com/apache/nuttx/pull/6408) e-ink ssd1680 driver
+* [#6353](https://github.com/apache/nuttx/pull/6353) Add driver for WIZnet W5500 Ethernet controller
 
 ## Bug Fixes and Improvements
 
-* [#6068](https://github.com/apache/incubator-nuttx/pull/6068) driver/mmcsdio: do not hold the semaphore on interrupt context
-* [#6019](https://github.com/apache/incubator-nuttx/pull/6019) power/governor: Remove the duplicated function prototype
-* [#6021](https://github.com/apache/incubator-nuttx/pull/6021) Test/wm8904balance
-* [#6018](https://github.com/apache/incubator-nuttx/pull/6018) Increase audio_comp driver flexibility
-* [#5927](https://github.com/apache/incubator-nuttx/pull/5927) Minor improve for mmcsd
-* [#5747](https://github.com/apache/incubator-nuttx/pull/5747) drivers/timers: rename notification parameter oneshot to periodic
-* [#5849](https://github.com/apache/incubator-nuttx/pull/5849) pm: remove unnecessary depends on OSINIT_OS_READY
-* [#5853](https://github.com/apache/incubator-nuttx/pull/5853) driver/syslog: Add microseconds after date time
-* [#5901](https://github.com/apache/incubator-nuttx/pull/5901) power: unify lock sates and move pm_auto_update to outer dir
-* [#5990](https://github.com/apache/incubator-nuttx/pull/5990) fix uinput rpmsg logic error
-* [#5816](https://github.com/apache/incubator-nuttx/pull/5816) drivers/mtd/mtd_config: set different format versions for named and ID modes
-* [#5736](https://github.com/apache/incubator-nuttx/pull/5736) driver/uinput: add cross core control function
-* [#6127](https://github.com/apache/incubator-nuttx/pull/6127) pm: Move pm_initialize call from driver_initialize to xxx_pminitialize
-* [#6053](https://github.com/apache/incubator-nuttx/pull/6053) drivers: remove unimplemented open/close/ioctl interfaces
-* [#6157](https://github.com/apache/incubator-nuttx/pull/6157) drivers: mtd: fix null buffer reference
-* [#6159](https://github.com/apache/incubator-nuttx/pull/6159) driver/ioexpander: remove response about irq_handler
-* [#6186](https://github.com/apache/incubator-nuttx/pull/6186) Stm32f746 audio
-* [#6164](https://github.com/apache/incubator-nuttx/pull/6164) drivers/audio/cxd56: Workaround for HW issue of CXD56
-* [#6655](https://github.com/apache/incubator-nuttx/pull/6655) driver/syslog: support syslog_rpmsg client and server chardev
-* [#6657](https://github.com/apache/incubator-nuttx/pull/6657) drivers/lcd/st7789: update putarea() method
-* [#6661](https://github.com/apache/incubator-nuttx/pull/6661) drivers/syslog: Call up_nputs in syslog_default_write
-* [#6668](https://github.com/apache/incubator-nuttx/pull/6668) driver/ioe_rpmsg: split server and client ept_cb to simplify code
-* [#6246](https://github.com/apache/incubator-nuttx/pull/6246) drivers/sdio: Call SDIO_LOCK before and after the transaction
-* [#5736](https://github.com/apache/incubator-nuttx/pull/5736) driver/uinput: add cross core control function
-* [#5718](https://github.com/apache/incubator-nuttx/pull/5718) drivers/can: optimize can driver reader side
-* [#6789](https://github.com/apache/incubator-nuttx/pull/6789) drivers/net: make sure that net driver d_buf is 16-bit aligned
-* [#6708](https://github.com/apache/incubator-nuttx/pull/6708) driver/sensors[2]: enhance and update sensor driver
-* [#6703](https://github.com/apache/incubator-nuttx/pull/6703) driver/sensor: add calibrate interface for sensor driver
-* [#6704](https://github.com/apache/incubator-nuttx/pull/6704) driver/sensors: enhance sensor driver
-* [#6696](https://github.com/apache/incubator-nuttx/pull/6696) driver/sensor: add sensor type of cap and wake_gesture
-* [#6698](https://github.com/apache/incubator-nuttx/pull/6698) driver/power:add ioctl cmd for voltage info and protocol and add update event mask
-* [#6727](https://github.com/apache/incubator-nuttx/pull/6727) power: add PM_IDLE_DOMAIN to pm.h and remove definations
-* [#6759](https://github.com/apache/incubator-nuttx/pull/6759) drivers: Reorganize the power related code layout
-* [#6748](https://github.com/apache/incubator-nuttx/pull/6748) power/axp202: Replace battery_charger_operations_s* with battery_charger_dev_s
-* [#6761](https://github.com/apache/incubator-nuttx/pull/6761) drivers/wireless/gs2200m: Fix short bit length
-* [#6743](https://github.com/apache/incubator-nuttx/pull/6743) drivers/battery: Handle the early changed event correctly
-* [#6673](https://github.com/apache/incubator-nuttx/pull/6673) power related update
-* [#6653](https://github.com/apache/incubator-nuttx/pull/6653) Driver/sensor: enhance sensor driver to support uorb and multi core access sensor by rpmsg
-* [#6331](https://github.com/apache/incubator-nuttx/pull/6331) drivers/mtd/smart.c: Modify devname[] size to avoid overflow
-* [#6414](https://github.com/apache/incubator-nuttx/pull/6414) drivers/syslog: fix deadlock by reverting part of the changes from b88a8cf39ff1019ad787c4316b22ce29c7daa2dc
-* [#6435](https://github.com/apache/incubator-nuttx/pull/6435) drivers/syslog: reuse rmutex_t for the recursive check
-* [#6419](https://github.com/apache/incubator-nuttx/pull/6419) drvers/mmcsd/sdio: function enable should wait for CCCR_IORDY
-* [#6500](https://github.com/apache/incubator-nuttx/pull/6500) drivers: serial: Add error for insuff buffer
-* [#6526](https://github.com/apache/incubator-nuttx/pull/6526) drivers/lcd: getplaneinfo fix for ST7789,ST7565 and skeleton driver
-* [#6513](https://github.com/apache/incubator-nuttx/pull/6513) drivers/lcd: Fix regression on ILI9341 introduced after #6465
-* [#6544](https://github.com/apache/incubator-nuttx/pull/6544) Make sensor mpu60x0 more configurable in menuconfig
-* [#6564](https://github.com/apache/incubator-nuttx/pull/6564) drivers/lcd_framebuffer: Optimize updateearea for the full screan case
-* [#6577](https://github.com/apache/incubator-nuttx/pull/6577) drivers/segger: Support the customize SEGGER_RTT_[BUFFER_]SECTION
-* [#6113](https://github.com/apache/incubator-nuttx/pull/6113) pipe: Increase buffer size by one byte to ompensate the full indicator
-* [#6455](https://github.com/apache/incubator-nuttx/pull/6455) usbhost_cdcacm: fix error with interrupt IN endpoint
-* [#6369](https://github.com/apache/incubator-nuttx/pull/6369) Fix in default syslog date format
-* [#6601](https://github.com/apache/incubator-nuttx/pull/6601) usbdev/usbmsc: introduce USBMSC_WRMULTIPLE for faster writes
-* [#6571](https://github.com/apache/incubator-nuttx/pull/6571) fix sd can't usage when mult-block receive errro
-* [#6551](https://github.com/apache/incubator-nuttx/pull/6551) framebuffer for e-ink display. Added callback function to redraw
-* [#6456](https://github.com/apache/incubator-nuttx/pull/6456) mmcsd/sdio: correct return value of sdio_probe()
-* [#6363](https://github.com/apache/incubator-nuttx/pull/6363) Added color reset when a syslog channel is added
-* [#6362](https://github.com/apache/incubator-nuttx/pull/6362) syslog Fixed separation of log sessions
-* [#5886](https://github.com/apache/incubator-nuttx/pull/5886) syslog_rpmsg related update
-* [#5803](https://github.com/apache/incubator-nuttx/pull/5803) syslog: Change g_syslog_default_sem to static function variable
-* [#5801](https://github.com/apache/incubator-nuttx/pull/5801) syslog/channel: minor fix to avoid unreachabled return
-* [#6171](https://github.com/apache/incubator-nuttx/pull/6171) syslog: Fixed a potential buffer overflow issue
-* [#6618](https://github.com/apache/incubator-nuttx/pull/6618) Optimize syslog_write performance
-* [#6669](https://github.com/apache/incubator-nuttx/pull/6669) lcd/apa102: Fix APA102 RGB LED Matrix interleaving issue
-* [#6639](https://github.com/apache/incubator-nuttx/pull/6639) lcd/apa102: Add putarea() support for faster rendering
-* [#6633](https://github.com/apache/incubator-nuttx/pull/6633) drivers/bch: Adjust f_pos with the correct value
-* [#6621](https://github.com/apache/incubator-nuttx/pull/6621) mmcsd: Remove the not really used capacity field
-* [#5802](https://github.com/apache/incubator-nuttx/pull/5802) Refine the uinput implementation
-* [#5800](https://github.com/apache/incubator-nuttx/pull/5800) regulator/rpmsg: list delete should use safe version in loop
-* [#5893](https://github.com/apache/incubator-nuttx/pull/5893) ioe_rpmsg: use rptun_wait/post to resolve deadlock with usrsock
-* [#6699](https://github.com/apache/incubator-nuttx/pull/6699) rtc/rpmsg: when a client connection, server initiates time sync
-* [#6706](https://github.com/apache/incubator-nuttx/pull/6706) rptun related update 1
-* [#6713](https://github.com/apache/incubator-nuttx/pull/6713) rptun related update
-* [#5847](https://github.com/apache/incubator-nuttx/pull/5847) rptun related update
-* [#6678](https://github.com/apache/incubator-nuttx/pull/6678) stdio: need also flush stdio when flushall
-* [#6756](https://github.com/apache/incubator-nuttx/pull/6756) Minor update for sensor
-* [#5880](https://github.com/apache/incubator-nuttx/pull/5880) ramlog: support setting threshold value of ramlog for poll waiters
-* [#5857](https://github.com/apache/incubator-nuttx/pull/5857) c89: get rid of designated initializers in common code
-* [#6738](https://github.com/apache/incubator-nuttx/pull/6738) w25qxxxjv.c: Use PRIxOFF to format off_t
-* [#6728](https://github.com/apache/incubator-nuttx/pull/6728) w25qxxxjv.c: Ensure Quad SPI mode is enabled
-* [#6459](https://github.com/apache/incubator-nuttx/pull/6459) Adds device descriptor for the MB5RS2MTA 256KB FRAM part
-* [#6465](https://github.com/apache/incubator-nuttx/pull/6465) Add lcd_dev_s pointer to lcd_planeinfo_s to support multiple LCDs per board
-* [#6588](https://github.com/apache/incubator-nuttx/pull/6588) SSD1680 Landscape mode bugfix
-* [#6319](https://github.com/apache/incubator-nuttx/pull/6319) SSD1306: Added option to force reconfigure display after power off
-* [#6224](https://github.com/apache/incubator-nuttx/pull/6224) LCD SSD1306: Added custom configuration option
-* [#6223](https://github.com/apache/incubator-nuttx/pull/6223) LCD: Added existing FBIO_SETPOWER support to lcd_framebuffer.c
-* [#6344](https://github.com/apache/incubator-nuttx/pull/6344) Video: various updates
-* [#6320](https://github.com/apache/incubator-nuttx/pull/6320) use rmutex inside of all repeated implementation
+* [#6068](https://github.com/apache/nuttx/pull/6068) driver/mmcsdio: do not hold the semaphore on interrupt context
+* [#6019](https://github.com/apache/nuttx/pull/6019) power/governor: Remove the duplicated function prototype
+* [#6021](https://github.com/apache/nuttx/pull/6021) Test/wm8904balance
+* [#6018](https://github.com/apache/nuttx/pull/6018) Increase audio_comp driver flexibility
+* [#5927](https://github.com/apache/nuttx/pull/5927) Minor improve for mmcsd
+* [#5747](https://github.com/apache/nuttx/pull/5747) drivers/timers: rename notification parameter oneshot to periodic
+* [#5849](https://github.com/apache/nuttx/pull/5849) pm: remove unnecessary depends on OSINIT_OS_READY
+* [#5853](https://github.com/apache/nuttx/pull/5853) driver/syslog: Add microseconds after date time
+* [#5901](https://github.com/apache/nuttx/pull/5901) power: unify lock sates and move pm_auto_update to outer dir
+* [#5990](https://github.com/apache/nuttx/pull/5990) fix uinput rpmsg logic error
+* [#5816](https://github.com/apache/nuttx/pull/5816) drivers/mtd/mtd_config: set different format versions for named and ID modes
+* [#5736](https://github.com/apache/nuttx/pull/5736) driver/uinput: add cross core control function
+* [#6127](https://github.com/apache/nuttx/pull/6127) pm: Move pm_initialize call from driver_initialize to xxx_pminitialize
+* [#6053](https://github.com/apache/nuttx/pull/6053) drivers: remove unimplemented open/close/ioctl interfaces
+* [#6157](https://github.com/apache/nuttx/pull/6157) drivers: mtd: fix null buffer reference
+* [#6159](https://github.com/apache/nuttx/pull/6159) driver/ioexpander: remove response about irq_handler
+* [#6186](https://github.com/apache/nuttx/pull/6186) Stm32f746 audio
+* [#6164](https://github.com/apache/nuttx/pull/6164) drivers/audio/cxd56: Workaround for HW issue of CXD56
+* [#6655](https://github.com/apache/nuttx/pull/6655) driver/syslog: support syslog_rpmsg client and server chardev
+* [#6657](https://github.com/apache/nuttx/pull/6657) drivers/lcd/st7789: update putarea() method
+* [#6661](https://github.com/apache/nuttx/pull/6661) drivers/syslog: Call up_nputs in syslog_default_write
+* [#6668](https://github.com/apache/nuttx/pull/6668) driver/ioe_rpmsg: split server and client ept_cb to simplify code
+* [#6246](https://github.com/apache/nuttx/pull/6246) drivers/sdio: Call SDIO_LOCK before and after the transaction
+* [#5736](https://github.com/apache/nuttx/pull/5736) driver/uinput: add cross core control function
+* [#5718](https://github.com/apache/nuttx/pull/5718) drivers/can: optimize can driver reader side
+* [#6789](https://github.com/apache/nuttx/pull/6789) drivers/net: make sure that net driver d_buf is 16-bit aligned
+* [#6708](https://github.com/apache/nuttx/pull/6708) driver/sensors[2]: enhance and update sensor driver
+* [#6703](https://github.com/apache/nuttx/pull/6703) driver/sensor: add calibrate interface for sensor driver
+* [#6704](https://github.com/apache/nuttx/pull/6704) driver/sensors: enhance sensor driver
+* [#6696](https://github.com/apache/nuttx/pull/6696) driver/sensor: add sensor type of cap and wake_gesture
+* [#6698](https://github.com/apache/nuttx/pull/6698) driver/power:add ioctl cmd for voltage info and protocol and add update event mask
+* [#6727](https://github.com/apache/nuttx/pull/6727) power: add PM_IDLE_DOMAIN to pm.h and remove definations
+* [#6759](https://github.com/apache/nuttx/pull/6759) drivers: Reorganize the power related code layout
+* [#6748](https://github.com/apache/nuttx/pull/6748) power/axp202: Replace battery_charger_operations_s* with battery_charger_dev_s
+* [#6761](https://github.com/apache/nuttx/pull/6761) drivers/wireless/gs2200m: Fix short bit length
+* [#6743](https://github.com/apache/nuttx/pull/6743) drivers/battery: Handle the early changed event correctly
+* [#6673](https://github.com/apache/nuttx/pull/6673) power related update
+* [#6653](https://github.com/apache/nuttx/pull/6653) Driver/sensor: enhance sensor driver to support uorb and multi core access sensor by rpmsg
+* [#6331](https://github.com/apache/nuttx/pull/6331) drivers/mtd/smart.c: Modify devname[] size to avoid overflow
+* [#6414](https://github.com/apache/nuttx/pull/6414) drivers/syslog: fix deadlock by reverting part of the changes from b88a8cf39ff1019ad787c4316b22ce29c7daa2dc
+* [#6435](https://github.com/apache/nuttx/pull/6435) drivers/syslog: reuse rmutex_t for the recursive check
+* [#6419](https://github.com/apache/nuttx/pull/6419) drvers/mmcsd/sdio: function enable should wait for CCCR_IORDY
+* [#6500](https://github.com/apache/nuttx/pull/6500) drivers: serial: Add error for insuff buffer
+* [#6526](https://github.com/apache/nuttx/pull/6526) drivers/lcd: getplaneinfo fix for ST7789,ST7565 and skeleton driver
+* [#6513](https://github.com/apache/nuttx/pull/6513) drivers/lcd: Fix regression on ILI9341 introduced after #6465
+* [#6544](https://github.com/apache/nuttx/pull/6544) Make sensor mpu60x0 more configurable in menuconfig
+* [#6564](https://github.com/apache/nuttx/pull/6564) drivers/lcd_framebuffer: Optimize updateearea for the full screan case
+* [#6577](https://github.com/apache/nuttx/pull/6577) drivers/segger: Support the customize SEGGER_RTT_[BUFFER_]SECTION
+* [#6113](https://github.com/apache/nuttx/pull/6113) pipe: Increase buffer size by one byte to ompensate the full indicator
+* [#6455](https://github.com/apache/nuttx/pull/6455) usbhost_cdcacm: fix error with interrupt IN endpoint
+* [#6369](https://github.com/apache/nuttx/pull/6369) Fix in default syslog date format
+* [#6601](https://github.com/apache/nuttx/pull/6601) usbdev/usbmsc: introduce USBMSC_WRMULTIPLE for faster writes
+* [#6571](https://github.com/apache/nuttx/pull/6571) fix sd can't usage when mult-block receive errro
+* [#6551](https://github.com/apache/nuttx/pull/6551) framebuffer for e-ink display. Added callback function to redraw
+* [#6456](https://github.com/apache/nuttx/pull/6456) mmcsd/sdio: correct return value of sdio_probe()
+* [#6363](https://github.com/apache/nuttx/pull/6363) Added color reset when a syslog channel is added
+* [#6362](https://github.com/apache/nuttx/pull/6362) syslog Fixed separation of log sessions
+* [#5886](https://github.com/apache/nuttx/pull/5886) syslog_rpmsg related update
+* [#5803](https://github.com/apache/nuttx/pull/5803) syslog: Change g_syslog_default_sem to static function variable
+* [#5801](https://github.com/apache/nuttx/pull/5801) syslog/channel: minor fix to avoid unreachabled return
+* [#6171](https://github.com/apache/nuttx/pull/6171) syslog: Fixed a potential buffer overflow issue
+* [#6618](https://github.com/apache/nuttx/pull/6618) Optimize syslog_write performance
+* [#6669](https://github.com/apache/nuttx/pull/6669) lcd/apa102: Fix APA102 RGB LED Matrix interleaving issue
+* [#6639](https://github.com/apache/nuttx/pull/6639) lcd/apa102: Add putarea() support for faster rendering
+* [#6633](https://github.com/apache/nuttx/pull/6633) drivers/bch: Adjust f_pos with the correct value
+* [#6621](https://github.com/apache/nuttx/pull/6621) mmcsd: Remove the not really used capacity field
+* [#5802](https://github.com/apache/nuttx/pull/5802) Refine the uinput implementation
+* [#5800](https://github.com/apache/nuttx/pull/5800) regulator/rpmsg: list delete should use safe version in loop
+* [#5893](https://github.com/apache/nuttx/pull/5893) ioe_rpmsg: use rptun_wait/post to resolve deadlock with usrsock
+* [#6699](https://github.com/apache/nuttx/pull/6699) rtc/rpmsg: when a client connection, server initiates time sync
+* [#6706](https://github.com/apache/nuttx/pull/6706) rptun related update 1
+* [#6713](https://github.com/apache/nuttx/pull/6713) rptun related update
+* [#5847](https://github.com/apache/nuttx/pull/5847) rptun related update
+* [#6678](https://github.com/apache/nuttx/pull/6678) stdio: need also flush stdio when flushall
+* [#6756](https://github.com/apache/nuttx/pull/6756) Minor update for sensor
+* [#5880](https://github.com/apache/nuttx/pull/5880) ramlog: support setting threshold value of ramlog for poll waiters
+* [#5857](https://github.com/apache/nuttx/pull/5857) c89: get rid of designated initializers in common code
+* [#6738](https://github.com/apache/nuttx/pull/6738) w25qxxxjv.c: Use PRIxOFF to format off_t
+* [#6728](https://github.com/apache/nuttx/pull/6728) w25qxxxjv.c: Ensure Quad SPI mode is enabled
+* [#6459](https://github.com/apache/nuttx/pull/6459) Adds device descriptor for the MB5RS2MTA 256KB FRAM part
+* [#6465](https://github.com/apache/nuttx/pull/6465) Add lcd_dev_s pointer to lcd_planeinfo_s to support multiple LCDs per board
+* [#6588](https://github.com/apache/nuttx/pull/6588) SSD1680 Landscape mode bugfix
+* [#6319](https://github.com/apache/nuttx/pull/6319) SSD1306: Added option to force reconfigure display after power off
+* [#6224](https://github.com/apache/nuttx/pull/6224) LCD SSD1306: Added custom configuration option
+* [#6223](https://github.com/apache/nuttx/pull/6223) LCD: Added existing FBIO_SETPOWER support to lcd_framebuffer.c
+* [#6344](https://github.com/apache/nuttx/pull/6344) Video: various updates
+* [#6320](https://github.com/apache/nuttx/pull/6320) use rmutex inside of all repeated implementation
 
 # Board Support
 ## New Board Support
 
-* [#6216](https://github.com/apache/incubator-nuttx/pull/6216) Nucleo G474RE board support including USB Full Speed Device
-* [#6754](https://github.com/apache/incubator-nuttx/pull/6754) NXP S32K1XX: add initial support for NXP RDDRONE-BMS772 board
-* [#6730](https://github.com/apache/incubator-nuttx/pull/6730) boards/stm32f7: add intial support for ST steval-eth001v1 board
-* [#6691](https://github.com/apache/incubator-nuttx/pull/6691) boards: add initial support for ST steval-stlcs01v1
-* [#6383](https://github.com/apache/incubator-nuttx/pull/6383) boards/nucleo-wl55jc: add new board
-* [#6448](https://github.com/apache/incubator-nuttx/pull/6448) xtensa/esp32s3: Add esp32s3-eye board support
-* [#6592](https://github.com/apache/incubator-nuttx/pull/6592) boards: add initial support for stm32l0538-disco
-* [#6528](https://github.com/apache/incubator-nuttx/pull/6528) Added RP2040 Boards: Adafruit KB2040 and Adafruit Feather RP2040
-* [#6620](https://github.com/apache/incubator-nuttx/pull/6620) boards/stm32f0l0g0: common board logic support
-* [#6189](https://github.com/apache/incubator-nuttx/pull/6189) Sabre 6quad libcxx
-* [#6793](https://github.com/apache/incubator-nuttx/pull/6793) TTGO T-Display ESP32 V1.1 board support
-* [#6266](https://github.com/apache/incubator-nuttx/pull/6266) Nucleo f401 re oled
-* [#6592](https://github.com/apache/incubator-nuttx/pull/6592) boards: add initial support for stm32l0538-disco
+* [#6216](https://github.com/apache/nuttx/pull/6216) Nucleo G474RE board support including USB Full Speed Device
+* [#6754](https://github.com/apache/nuttx/pull/6754) NXP S32K1XX: add initial support for NXP RDDRONE-BMS772 board
+* [#6730](https://github.com/apache/nuttx/pull/6730) boards/stm32f7: add intial support for ST steval-eth001v1 board
+* [#6691](https://github.com/apache/nuttx/pull/6691) boards: add initial support for ST steval-stlcs01v1
+* [#6383](https://github.com/apache/nuttx/pull/6383) boards/nucleo-wl55jc: add new board
+* [#6448](https://github.com/apache/nuttx/pull/6448) xtensa/esp32s3: Add esp32s3-eye board support
+* [#6592](https://github.com/apache/nuttx/pull/6592) boards: add initial support for stm32l0538-disco
+* [#6528](https://github.com/apache/nuttx/pull/6528) Added RP2040 Boards: Adafruit KB2040 and Adafruit Feather RP2040
+* [#6620](https://github.com/apache/nuttx/pull/6620) boards/stm32f0l0g0: common board logic support
+* [#6189](https://github.com/apache/nuttx/pull/6189) Sabre 6quad libcxx
+* [#6793](https://github.com/apache/nuttx/pull/6793) TTGO T-Display ESP32 V1.1 board support
+* [#6266](https://github.com/apache/nuttx/pull/6266) Nucleo f401 re oled
+* [#6592](https://github.com/apache/nuttx/pull/6592) boards: add initial support for stm32l0538-disco
 
 ## Bug Fixes and Improvements
 
-* [#6684](https://github.com/apache/incubator-nuttx/pull/6684) Enable to test C++ static object in ELF
-* [#6036](https://github.com/apache/incubator-nuttx/pull/6036) arch, boards: cxd56xx: Minor update for spresense
-* [#6074](https://github.com/apache/incubator-nuttx/pull/6074) boards/arm/a1x: Remove the check CONFIG_ARCH_FPU around arm_fpuconfig
-* [#5964](https://github.com/apache/incubator-nuttx/pull/5964) boards/nucleo-f446re: support for SystemView
-* [#5964](https://github.com/apache/incubator-nuttx/pull/5964) boards/nucleo-f446re: support for SystemView
-* [#5788](https://github.com/apache/incubator-nuttx/pull/5788) boards/arm/samv7/same70-qmtech: add gpio driver support
-* [#5812](https://github.com/apache/incubator-nuttx/pull/5812) esp32s3-devkit/spiflash: Use SmartFS instead of LittleFS
-* [#5817](https://github.com/apache/incubator-nuttx/pull/5817) boards/arm/same70-qmtech: Remove dead code
-* [#5841](https://github.com/apache/incubator-nuttx/pull/5841) esp32s3-devkit: Fix the number of memory regions in some configurations
-* [#5909](https://github.com/apache/incubator-nuttx/pull/5909) boards/boardctl:common boardctl to read reset cause
-* [#5751](https://github.com/apache/incubator-nuttx/pull/5751) boards/sim/adb: Enable CONFIG_ADBD_SOCKET_SERVICE
-* [#5763](https://github.com/apache/incubator-nuttx/pull/5763) boards: sabre-6quad: Enable environ and path in knsh/defconfig
-* [#5839](https://github.com/apache/incubator-nuttx/pull/5839) boards: rv-virt: Fix stack corruption for rv64 config
-* [#5860](https://github.com/apache/incubator-nuttx/pull/5860) boards/arm/uid: fix pointer to int compare
-* [#5895](https://github.com/apache/incubator-nuttx/pull/5895) boards: correct path to RCRAWS files during file copy
-* [#5785](https://github.com/apache/incubator-nuttx/pull/5785) boards/arm/samv7: define MTD progmem partitions at board level
-* [#5787](https://github.com/apache/incubator-nuttx/pull/5787) boards/arm/samv7/same70-qmtech: add /dev/timer0 support
-* [#5804](https://github.com/apache/incubator-nuttx/pull/5804) boards/arm/samv7/samv71-xult: Fix mcuboot update example missing config
-* [#6142](https://github.com/apache/incubator-nuttx/pull/6142) boards: Switch the elf link script to binfmt/libelf/gnu-elf.ld
-* [#6199](https://github.com/apache/incubator-nuttx/pull/6199) boards/space: Remove the unneeded XXXEXT definition
-* [#6138](https://github.com/apache/incubator-nuttx/pull/6138) boards/boardctl: correct boarctl return value
-* [#6141](https://github.com/apache/incubator-nuttx/pull/6141) boards/risc-v: Remove "MAXOPTIMIZATION = -Os" from Make.defs
-* [#6143](https://github.com/apache/incubator-nuttx/pull/6143) boards: Move -fno-common from Make.defs to Toolchain.defs
-* [#6144](https://github.com/apache/incubator-nuttx/pull/6144) boards: Move -g from Make.defs to Toolchain.defs 
-* [#6146](https://github.com/apache/incubator-nuttx/pull/6146) boards: Move "-fno-exceptions -fcheck-new" from Make.defs to Toolchain.defs
-* [#6155](https://github.com/apache/incubator-nuttx/pull/6155) boards: Move -fno-strict-aliasing from Make.defs to Toolchain.defs
-* [#6195](https://github.com/apache/incubator-nuttx/pull/6195) boards: rv-virt: Add support ELF to nsh and nsh64 defconfigs
-* [#6075](https://github.com/apache/incubator-nuttx/pull/6075) boards/esp32_twai: Remove arm_arch.h from comment
-* [#6081](https://github.com/apache/incubator-nuttx/pull/6081) boards/sim: support rc.sysinit
-* [#6654](https://github.com/apache/incubator-nuttx/pull/6654) boardctl:add reset subreason restore factory
-* [#6744](https://github.com/apache/incubator-nuttx/pull/6744) boards/stm32wb/ble: adding nimble config
-* [#6752](https://github.com/apache/incubator-nuttx/pull/6752) NXP S32K1XX: fix LPI2C reset
-* [#6753](https://github.com/apache/incubator-nuttx/pull/6753) NXP S32K1XX boards: add up_perf_init to support SEGGER SystemView
-* [#6798](https://github.com/apache/incubator-nuttx/pull/6798) board/cxd56xx/audio: Fix CXD56 audio initialization
-* [#5033](https://github.com/apache/incubator-nuttx/pull/5033) boards/arm/samv7: Update mcuboot configs
-* [#6692](https://github.com/apache/incubator-nuttx/pull/6692) stm32f0l0g0: fixes for SPI half duplex
-* [#6693](https://github.com/apache/incubator-nuttx/pull/6693) boards/stm32g071b-disco: add ina230 support and gpio dev support
-* [#6694](https://github.com/apache/incubator-nuttx/pull/6694) esp32s3-devkit: Add support to discrete 5-way joystick
-* [#6764](https://github.com/apache/incubator-nuttx/pull/6764) boards: spresense: Reduce power consumption with LTE board
-* [#6777](https://github.com/apache/incubator-nuttx/pull/6777) boards: Enable thread local storage for some config
-* [#6391](https://github.com/apache/incubator-nuttx/pull/6391) esp32c3-devkit/knsh: Enable CONFIG_RAW_BINARY to convert the ELF file
-* [#6287](https://github.com/apache/incubator-nuttx/pull/6287) stm32h7: allow definition of HSI divider in board config
-* [#6373](https://github.com/apache/incubator-nuttx/pull/6373) board: nucleo-l432kc: Add missing nucleo 432kc spi driver setting
-* [#6275](https://github.com/apache/incubator-nuttx/pull/6275) boards/arm: Remove "LDFLAGS += -g" whichi is already added by Toolchain.defs
-* [#6439](https://github.com/apache/incubator-nuttx/pull/6439) boards/esp32: Increase the NTP deamon stack size as it was overflowing
-* [#6273](https://github.com/apache/incubator-nuttx/pull/6273) board/sim: Enable hellocxx in loadable config
-* [#6580](https://github.com/apache/incubator-nuttx/pull/6580) Add ws2812 bringup logic to all RP2040 boards
-* [#6511](https://github.com/apache/incubator-nuttx/pull/6511) esp32_board_spi:Missing Data Command pin support
-* [#6514](https://github.com/apache/incubator-nuttx/pull/6514) esp32-wrover-kit: Add board profile to support MMC/SDCard over SPI
-* [#6462](https://github.com/apache/incubator-nuttx/pull/6462) boards/risc-v/mpfs/m100pfsevp/include/board_liberodefs.h: Update memo…
-* [#6597](https://github.com/apache/incubator-nuttx/pull/6597) boards/xtensa: Remove outdated information
-* [#6582](https://github.com/apache/incubator-nuttx/pull/6582) boards: stm32f4discovery: Add iperf to rndis/defconfig
-* [#6626](https://github.com/apache/incubator-nuttx/pull/6626) stm32: hide STM32xx_SPI_DMA option and select it automatically
-* [#6627](https://github.com/apache/incubator-nuttx/pull/6627) stm32g071b-disco: add OLED support
-* [#6542](https://github.com/apache/incubator-nuttx/pull/6542) Nucleo Wl55JC board supports E-ink display
-* [#6622](https://github.com/apache/incubator-nuttx/pull/6622) arch/stm32f0l0g0: improvements for SPI and enable SPI for STM32G0
-* [#6623](https://github.com/apache/incubator-nuttx/pull/6623) stm32f0l0g0: improvements for ADC
-* [#6625](https://github.com/apache/incubator-nuttx/pull/6625) stm32f0l0g0/SPI: support for half duplex and simplex rx/tx modes
-* [#6646](https://github.com/apache/incubator-nuttx/pull/6646) esp32: Re-organise wireless options
-* [#6585](https://github.com/apache/incubator-nuttx/pull/6585) esp32s3-devkit: Add support to ST7735 SPI LCD
-* [#6648](https://github.com/apache/incubator-nuttx/pull/6648) Added Adafruit QT Py RP2040 board and made UART, SPI, and I2C configuration more flexible
+* [#6684](https://github.com/apache/nuttx/pull/6684) Enable to test C++ static object in ELF
+* [#6036](https://github.com/apache/nuttx/pull/6036) arch, boards: cxd56xx: Minor update for spresense
+* [#6074](https://github.com/apache/nuttx/pull/6074) boards/arm/a1x: Remove the check CONFIG_ARCH_FPU around arm_fpuconfig
+* [#5964](https://github.com/apache/nuttx/pull/5964) boards/nucleo-f446re: support for SystemView
+* [#5964](https://github.com/apache/nuttx/pull/5964) boards/nucleo-f446re: support for SystemView
+* [#5788](https://github.com/apache/nuttx/pull/5788) boards/arm/samv7/same70-qmtech: add gpio driver support
+* [#5812](https://github.com/apache/nuttx/pull/5812) esp32s3-devkit/spiflash: Use SmartFS instead of LittleFS
+* [#5817](https://github.com/apache/nuttx/pull/5817) boards/arm/same70-qmtech: Remove dead code
+* [#5841](https://github.com/apache/nuttx/pull/5841) esp32s3-devkit: Fix the number of memory regions in some configurations
+* [#5909](https://github.com/apache/nuttx/pull/5909) boards/boardctl:common boardctl to read reset cause
+* [#5751](https://github.com/apache/nuttx/pull/5751) boards/sim/adb: Enable CONFIG_ADBD_SOCKET_SERVICE
+* [#5763](https://github.com/apache/nuttx/pull/5763) boards: sabre-6quad: Enable environ and path in knsh/defconfig
+* [#5839](https://github.com/apache/nuttx/pull/5839) boards: rv-virt: Fix stack corruption for rv64 config
+* [#5860](https://github.com/apache/nuttx/pull/5860) boards/arm/uid: fix pointer to int compare
+* [#5895](https://github.com/apache/nuttx/pull/5895) boards: correct path to RCRAWS files during file copy
+* [#5785](https://github.com/apache/nuttx/pull/5785) boards/arm/samv7: define MTD progmem partitions at board level
+* [#5787](https://github.com/apache/nuttx/pull/5787) boards/arm/samv7/same70-qmtech: add /dev/timer0 support
+* [#5804](https://github.com/apache/nuttx/pull/5804) boards/arm/samv7/samv71-xult: Fix mcuboot update example missing config
+* [#6142](https://github.com/apache/nuttx/pull/6142) boards: Switch the elf link script to binfmt/libelf/gnu-elf.ld
+* [#6199](https://github.com/apache/nuttx/pull/6199) boards/space: Remove the unneeded XXXEXT definition
+* [#6138](https://github.com/apache/nuttx/pull/6138) boards/boardctl: correct boarctl return value
+* [#6141](https://github.com/apache/nuttx/pull/6141) boards/risc-v: Remove "MAXOPTIMIZATION = -Os" from Make.defs
+* [#6143](https://github.com/apache/nuttx/pull/6143) boards: Move -fno-common from Make.defs to Toolchain.defs
+* [#6144](https://github.com/apache/nuttx/pull/6144) boards: Move -g from Make.defs to Toolchain.defs 
+* [#6146](https://github.com/apache/nuttx/pull/6146) boards: Move "-fno-exceptions -fcheck-new" from Make.defs to Toolchain.defs
+* [#6155](https://github.com/apache/nuttx/pull/6155) boards: Move -fno-strict-aliasing from Make.defs to Toolchain.defs
+* [#6195](https://github.com/apache/nuttx/pull/6195) boards: rv-virt: Add support ELF to nsh and nsh64 defconfigs
+* [#6075](https://github.com/apache/nuttx/pull/6075) boards/esp32_twai: Remove arm_arch.h from comment
+* [#6081](https://github.com/apache/nuttx/pull/6081) boards/sim: support rc.sysinit
+* [#6654](https://github.com/apache/nuttx/pull/6654) boardctl:add reset subreason restore factory
+* [#6744](https://github.com/apache/nuttx/pull/6744) boards/stm32wb/ble: adding nimble config
+* [#6752](https://github.com/apache/nuttx/pull/6752) NXP S32K1XX: fix LPI2C reset
+* [#6753](https://github.com/apache/nuttx/pull/6753) NXP S32K1XX boards: add up_perf_init to support SEGGER SystemView
+* [#6798](https://github.com/apache/nuttx/pull/6798) board/cxd56xx/audio: Fix CXD56 audio initialization
+* [#5033](https://github.com/apache/nuttx/pull/5033) boards/arm/samv7: Update mcuboot configs
+* [#6692](https://github.com/apache/nuttx/pull/6692) stm32f0l0g0: fixes for SPI half duplex
+* [#6693](https://github.com/apache/nuttx/pull/6693) boards/stm32g071b-disco: add ina230 support and gpio dev support
+* [#6694](https://github.com/apache/nuttx/pull/6694) esp32s3-devkit: Add support to discrete 5-way joystick
+* [#6764](https://github.com/apache/nuttx/pull/6764) boards: spresense: Reduce power consumption with LTE board
+* [#6777](https://github.com/apache/nuttx/pull/6777) boards: Enable thread local storage for some config
+* [#6391](https://github.com/apache/nuttx/pull/6391) esp32c3-devkit/knsh: Enable CONFIG_RAW_BINARY to convert the ELF file
+* [#6287](https://github.com/apache/nuttx/pull/6287) stm32h7: allow definition of HSI divider in board config
+* [#6373](https://github.com/apache/nuttx/pull/6373) board: nucleo-l432kc: Add missing nucleo 432kc spi driver setting
+* [#6275](https://github.com/apache/nuttx/pull/6275) boards/arm: Remove "LDFLAGS += -g" whichi is already added by Toolchain.defs
+* [#6439](https://github.com/apache/nuttx/pull/6439) boards/esp32: Increase the NTP deamon stack size as it was overflowing
+* [#6273](https://github.com/apache/nuttx/pull/6273) board/sim: Enable hellocxx in loadable config
+* [#6580](https://github.com/apache/nuttx/pull/6580) Add ws2812 bringup logic to all RP2040 boards
+* [#6511](https://github.com/apache/nuttx/pull/6511) esp32_board_spi:Missing Data Command pin support
+* [#6514](https://github.com/apache/nuttx/pull/6514) esp32-wrover-kit: Add board profile to support MMC/SDCard over SPI
+* [#6462](https://github.com/apache/nuttx/pull/6462) boards/risc-v/mpfs/m100pfsevp/include/board_liberodefs.h: Update memo…
+* [#6597](https://github.com/apache/nuttx/pull/6597) boards/xtensa: Remove outdated information
+* [#6582](https://github.com/apache/nuttx/pull/6582) boards: stm32f4discovery: Add iperf to rndis/defconfig
+* [#6626](https://github.com/apache/nuttx/pull/6626) stm32: hide STM32xx_SPI_DMA option and select it automatically
+* [#6627](https://github.com/apache/nuttx/pull/6627) stm32g071b-disco: add OLED support
+* [#6542](https://github.com/apache/nuttx/pull/6542) Nucleo Wl55JC board supports E-ink display
+* [#6622](https://github.com/apache/nuttx/pull/6622) arch/stm32f0l0g0: improvements for SPI and enable SPI for STM32G0
+* [#6623](https://github.com/apache/nuttx/pull/6623) stm32f0l0g0: improvements for ADC
+* [#6625](https://github.com/apache/nuttx/pull/6625) stm32f0l0g0/SPI: support for half duplex and simplex rx/tx modes
+* [#6646](https://github.com/apache/nuttx/pull/6646) esp32: Re-organise wireless options
+* [#6585](https://github.com/apache/nuttx/pull/6585) esp32s3-devkit: Add support to ST7735 SPI LCD
+* [#6648](https://github.com/apache/nuttx/pull/6648) Added Adafruit QT Py RP2040 board and made UART, SPI, and I2C configuration more flexible
 
 # File System
 
 ## Bug Fixes and Improvements
 
-* [#6726](https://github.com/apache/incubator-nuttx/pull/6726) vfs: Remove the unnessary check when CONFIG_DEBUG_MM enable
-* [#6007](https://github.com/apache/incubator-nuttx/pull/6007) fs/vfs: fix st_mode mask check
-* [#6002](https://github.com/apache/incubator-nuttx/pull/6002) fs/poll: change format for type pollevent_t
-* [#5797](https://github.com/apache/incubator-nuttx/pull/5797) fs/rpmsgfs: minor refine the return value
-* [#6686](https://github.com/apache/incubator-nuttx/pull/6686) fs/hostfs: Change nuttx_dev_t from uint16_t to uint32_t
-* [#6674](https://github.com/apache/incubator-nuttx/pull/6674) procfs related update
-* [#6671](https://github.com/apache/incubator-nuttx/pull/6671) rpmsgfs related update
-* [#6663](https://github.com/apache/incubator-nuttx/pull/6663) fs/fs_sync/ioctl: update
-* [#6662](https://github.com/apache/incubator-nuttx/pull/6662) sys/sysmacros.h: support sysmacros header
-* [#6630](https://github.com/apache/incubator-nuttx/pull/6630) partition/gpt: Replace PRI?LBA with PRI?OFF
-* [#6629](https://github.com/apache/incubator-nuttx/pull/6629) procfs/mount: Unify uint[32|64]_t to fsblkcnt_t for the code simplification
-* [#6545](https://github.com/apache/incubator-nuttx/pull/6545) fs/fat: Fix a bug that long file name cannot be found
-* [#6401](https://github.com/apache/incubator-nuttx/pull/6401) fs/mqueue: skip nxmq_pollnotify() if no poll waiters
-* [#6347](https://github.com/apache/incubator-nuttx/pull/6347) fs/cromfs: Fixed a hardFault caused by unaligned memory access
-* [#6104](https://github.com/apache/incubator-nuttx/pull/6104) fs:oflag need consistent with psock
-* [#6100](https://github.com/apache/incubator-nuttx/pull/6100) fs/inode/fs_files:changes fd judgment method
-* [#5854](https://github.com/apache/incubator-nuttx/pull/5854) fs/romfs: fix bug about test case:examples/romfs
-* [#5867](https://github.com/apache/incubator-nuttx/pull/5867) fs/romfs: fix size of pointer during memory allocation
-* [#5879](https://github.com/apache/incubator-nuttx/pull/5879) littlefs: unify lfs error code to nuttx
-* [#5884](https://github.com/apache/incubator-nuttx/pull/5884) fs/files_allocate: assert when fd overflow
-* [#5894](https://github.com/apache/incubator-nuttx/pull/5894) fs:add _POSIX_OPEN_MAX limit to files_extend
-* [#5899](https://github.com/apache/incubator-nuttx/pull/5899) Fs/romfs: fix bug about compare path with same prefix
-* [#6049](https://github.com/apache/incubator-nuttx/pull/6049) fs/vfs/fs_truncate.c: Use ioctl to truncate on non-mountpoint inode
-* [#5891](https://github.com/apache/incubator-nuttx/pull/5891) opendir: use inode_find() instead when opendir()
-* [#6024](https://github.com/apache/incubator-nuttx/pull/6024) fs/fcntl: add O_APPEND flag judge in fcntl
-* [#6023](https://github.com/apache/incubator-nuttx/pull/6023) littelfs: deal with block devices w/o ioctl
-* [#6773](https://github.com/apache/incubator-nuttx/pull/6773) FS disable FS_LARGEFILE by default
-* [#5934](https://github.com/apache/incubator-nuttx/pull/5934) fs/unionfs: fix some warning and bug
-* [#5938](https://github.com/apache/incubator-nuttx/pull/5938) fs/procfstcbinfo: minor bug about print address
-* [#5883](https://github.com/apache/incubator-nuttx/pull/5883) lseek: use type:off_t for return value
-* [#5764](https://github.com/apache/incubator-nuttx/pull/5764) procfs: Remove mallinfo from struct procfs_meminfo_entry_s
-* [#5924](https://github.com/apache/incubator-nuttx/pull/5924) fs and unistd: increase OPEN_MAX by claiming a Kconfig
-* [#5937](https://github.com/apache/incubator-nuttx/pull/5937) fs/epoll: change type of eventset from uint8_t to uint32_t
-* [#5807](https://github.com/apache/incubator-nuttx/pull/5807) sys/type.h: Change pid_t from int16_t to int
-* [#6307](https://github.com/apache/incubator-nuttx/pull/6307) littlefs_stat: Fix directory size
-* [#6724](https://github.com/apache/incubator-nuttx/pull/6724) add heapcheck(memcheck) flag
-* [#5935](https://github.com/apache/incubator-nuttx/pull/5935) fs/rpmsgfs: fix bug about using uninit variable "times"
-* [#5936](https://github.com/apache/incubator-nuttx/pull/5936) fs/romfs: fix string overflow
-* [#5844](https://github.com/apache/incubator-nuttx/pull/5844) rpmsgfs: do NOT access the pointer when do remote ioctl
-* [#5856](https://github.com/apache/incubator-nuttx/pull/5856) rpmsgfs/rename: fix bug about pathname align with 8bytes
-* [#5892](https://github.com/apache/incubator-nuttx/pull/5892) rpmsgfs related update
-* [#5846](https://github.com/apache/incubator-nuttx/pull/5846) epoll: fix epoll close error, report by kasan
-* [#6680](https://github.com/apache/incubator-nuttx/pull/6680) poll: defalut set POLLERR POLLHUP to events
-* [#6681](https://github.com/apache/incubator-nuttx/pull/6681) unlink: don't do unlink with inode_semtake
-* [#6637](https://github.com/apache/incubator-nuttx/pull/6637) mtd/smartfs: Fix uninitialized variable
+* [#6726](https://github.com/apache/nuttx/pull/6726) vfs: Remove the unnessary check when CONFIG_DEBUG_MM enable
+* [#6007](https://github.com/apache/nuttx/pull/6007) fs/vfs: fix st_mode mask check
+* [#6002](https://github.com/apache/nuttx/pull/6002) fs/poll: change format for type pollevent_t
+* [#5797](https://github.com/apache/nuttx/pull/5797) fs/rpmsgfs: minor refine the return value
+* [#6686](https://github.com/apache/nuttx/pull/6686) fs/hostfs: Change nuttx_dev_t from uint16_t to uint32_t
+* [#6674](https://github.com/apache/nuttx/pull/6674) procfs related update
+* [#6671](https://github.com/apache/nuttx/pull/6671) rpmsgfs related update
+* [#6663](https://github.com/apache/nuttx/pull/6663) fs/fs_sync/ioctl: update
+* [#6662](https://github.com/apache/nuttx/pull/6662) sys/sysmacros.h: support sysmacros header
+* [#6630](https://github.com/apache/nuttx/pull/6630) partition/gpt: Replace PRI?LBA with PRI?OFF
+* [#6629](https://github.com/apache/nuttx/pull/6629) procfs/mount: Unify uint[32|64]_t to fsblkcnt_t for the code simplification
+* [#6545](https://github.com/apache/nuttx/pull/6545) fs/fat: Fix a bug that long file name cannot be found
+* [#6401](https://github.com/apache/nuttx/pull/6401) fs/mqueue: skip nxmq_pollnotify() if no poll waiters
+* [#6347](https://github.com/apache/nuttx/pull/6347) fs/cromfs: Fixed a hardFault caused by unaligned memory access
+* [#6104](https://github.com/apache/nuttx/pull/6104) fs:oflag need consistent with psock
+* [#6100](https://github.com/apache/nuttx/pull/6100) fs/inode/fs_files:changes fd judgment method
+* [#5854](https://github.com/apache/nuttx/pull/5854) fs/romfs: fix bug about test case:examples/romfs
+* [#5867](https://github.com/apache/nuttx/pull/5867) fs/romfs: fix size of pointer during memory allocation
+* [#5879](https://github.com/apache/nuttx/pull/5879) littlefs: unify lfs error code to nuttx
+* [#5884](https://github.com/apache/nuttx/pull/5884) fs/files_allocate: assert when fd overflow
+* [#5894](https://github.com/apache/nuttx/pull/5894) fs:add _POSIX_OPEN_MAX limit to files_extend
+* [#5899](https://github.com/apache/nuttx/pull/5899) Fs/romfs: fix bug about compare path with same prefix
+* [#6049](https://github.com/apache/nuttx/pull/6049) fs/vfs/fs_truncate.c: Use ioctl to truncate on non-mountpoint inode
+* [#5891](https://github.com/apache/nuttx/pull/5891) opendir: use inode_find() instead when opendir()
+* [#6024](https://github.com/apache/nuttx/pull/6024) fs/fcntl: add O_APPEND flag judge in fcntl
+* [#6023](https://github.com/apache/nuttx/pull/6023) littelfs: deal with block devices w/o ioctl
+* [#6773](https://github.com/apache/nuttx/pull/6773) FS disable FS_LARGEFILE by default
+* [#5934](https://github.com/apache/nuttx/pull/5934) fs/unionfs: fix some warning and bug
+* [#5938](https://github.com/apache/nuttx/pull/5938) fs/procfstcbinfo: minor bug about print address
+* [#5883](https://github.com/apache/nuttx/pull/5883) lseek: use type:off_t for return value
+* [#5764](https://github.com/apache/nuttx/pull/5764) procfs: Remove mallinfo from struct procfs_meminfo_entry_s
+* [#5924](https://github.com/apache/nuttx/pull/5924) fs and unistd: increase OPEN_MAX by claiming a Kconfig
+* [#5937](https://github.com/apache/nuttx/pull/5937) fs/epoll: change type of eventset from uint8_t to uint32_t
+* [#5807](https://github.com/apache/nuttx/pull/5807) sys/type.h: Change pid_t from int16_t to int
+* [#6307](https://github.com/apache/nuttx/pull/6307) littlefs_stat: Fix directory size
+* [#6724](https://github.com/apache/nuttx/pull/6724) add heapcheck(memcheck) flag
+* [#5935](https://github.com/apache/nuttx/pull/5935) fs/rpmsgfs: fix bug about using uninit variable "times"
+* [#5936](https://github.com/apache/nuttx/pull/5936) fs/romfs: fix string overflow
+* [#5844](https://github.com/apache/nuttx/pull/5844) rpmsgfs: do NOT access the pointer when do remote ioctl
+* [#5856](https://github.com/apache/nuttx/pull/5856) rpmsgfs/rename: fix bug about pathname align with 8bytes
+* [#5892](https://github.com/apache/nuttx/pull/5892) rpmsgfs related update
+* [#5846](https://github.com/apache/nuttx/pull/5846) epoll: fix epoll close error, report by kasan
+* [#6680](https://github.com/apache/nuttx/pull/6680) poll: defalut set POLLERR POLLHUP to events
+* [#6681](https://github.com/apache/nuttx/pull/6681) unlink: don't do unlink with inode_semtake
+* [#6637](https://github.com/apache/nuttx/pull/6637) mtd/smartfs: Fix uninitialized variable
 
 # Networking
 
 ## Bug Fixes and Improvements
 
-* [#5967](https://github.com/apache/incubator-nuttx/pull/5967) net:fix coverity warning
-* [#5972](https://github.com/apache/incubator-nuttx/pull/5972) net/utils: fix IPv4 checksum calculation
-* [#5769](https://github.com/apache/incubator-nuttx/pull/5769) net/local: correct the socket flags from client socket
-* [#5750](https://github.com/apache/incubator-nuttx/pull/5750) net/udp: clear the connection structure after free
-* [#5748](https://github.com/apache/incubator-nuttx/pull/5748) net/local: correct the socket flags from server socket
-* [#6368](https://github.com/apache/incubator-nuttx/pull/6368) net/tcp: Hold the net lock in tcp_timer_expiry
-* [#6355](https://github.com/apache/incubator-nuttx/pull/6355) tcp: remove all devif_timer
-* [#6154](https://github.com/apache/incubator-nuttx/pull/6154) net/tcp:make initial tcp port more random
-* [#5794](https://github.com/apache/incubator-nuttx/pull/5794) netdb/getaddrinfo: fix NULL pointer reference
-* [#5791](https://github.com/apache/incubator-nuttx/pull/5791) netinitialize: call xxx_netinitialize unconditionally
-* [#5770](https://github.com/apache/incubator-nuttx/pull/5770) net/sockopt: bypass the SO_RCVBUF/SO_SNDBUF to usrsock
-* [#6735](https://github.com/apache/incubator-nuttx/pull/6735) make sure conn's domain is matched with addr's family
-* [#6608](https://github.com/apache/incubator-nuttx/pull/6608) net: Fix frame count check fail and race condition
-* [#6330](https://github.com/apache/incubator-nuttx/pull/6330) tcp: move wd_timer from wifi driver to tcp stack
-* [#6289](https://github.com/apache/incubator-nuttx/pull/6289) net: fix the build when CONFIG_NET_TCP_WRITE_BUFFERS is not enabled
-* [#6262](https://github.com/apache/incubator-nuttx/pull/6262) icmp: Fixed replies to broadcasts
-* [#6161](https://github.com/apache/incubator-nuttx/pull/6161) Fix udp recvfrom to correctly return addrlen
-* [#5799](https://github.com/apache/incubator-nuttx/pull/5799) net/netdev: fix switch case missing break
-* [#6398](https://github.com/apache/incubator-nuttx/pull/6398) net/tcp: wave hands on background
-* [#6297](https://github.com/apache/incubator-nuttx/pull/6297) net/tcp: Zero keeptimer in case caller set keepalive to false
-* [#6290](https://github.com/apache/incubator-nuttx/pull/6290) net/tcp: Use the decrease timer in TCP_TIME_WAIT/TCP_FIN_WAIT_2
-* [#6264](https://github.com/apache/incubator-nuttx/pull/6264) Fix ENOENT errors when polling on Netlink socket
-* [#6428](https://github.com/apache/incubator-nuttx/pull/6428) net/tcp: d_appdata should remove the tcp specific option field
-* [#6399](https://github.com/apache/incubator-nuttx/pull/6399) Packet dropped in IPv4/v6 input is now an info, not a warning
-* [#6770](https://github.com/apache/incubator-nuttx/pull/6770) delay creating DNS bind socket
-* [#6751](https://github.com/apache/incubator-nuttx/pull/6751) Net thread-safe ether_ntoa_r & inet_ntoa_r
-* [#6740](https://github.com/apache/incubator-nuttx/pull/6740) [TCP] Close RAM usage optimization
-* [#6747](https://github.com/apache/incubator-nuttx/pull/6747) Fix notify disassocitaion
-* [#6702](https://github.com/apache/incubator-nuttx/pull/6702) tcp: check option length before d_len update
-* [#6701](https://github.com/apache/incubator-nuttx/pull/6701) udp: Use s_sndtimeo as the actual timeout time
-* [#6700](https://github.com/apache/incubator-nuttx/pull/6700) netdev: add return value for ifup / ifdown
-* [#6563](https://github.com/apache/incubator-nuttx/pull/6563) net/tcp: discard connect reference before free
-* [#6562](https://github.com/apache/incubator-nuttx/pull/6562) net/tcp: fix regression of invalid update the rexmit_seq in buffer mode
-* [#6543](https://github.com/apache/incubator-nuttx/pull/6543) net_if: add IFF_LOOPBACK/POINTOPOINT/MULTICAST/BROADCAST
-* [#6529](https://github.com/apache/incubator-nuttx/pull/6529) net: Ensure sendmsg and sendfile return -EAGAIN in case of timeout
-* [#6519](https://github.com/apache/incubator-nuttx/pull/6519) netdev/carrier: check the IF stautus before carrier
-* [#6451](https://github.com/apache/incubator-nuttx/pull/6451) net/tcp(buffered): retransmit only one the earliest not acknowledged segment
-* [#6640](https://github.com/apache/incubator-nuttx/pull/6640) net/slip: Rename and clarify orphaned Kconfig options
-* [#6590](https://github.com/apache/incubator-nuttx/pull/6590) net/poll: fix race condition if connect free before poll teardown
-* [#6589](https://github.com/apache/incubator-nuttx/pull/6589) net/tcp: fix assertion of fallback connection alloc
-* [#5943](https://github.com/apache/incubator-nuttx/pull/5943) This PR mainly contains some USRSOCK related changes
-* [#6041](https://github.com/apache/incubator-nuttx/pull/6041) rpmsg_usrsock: Support the wireless ioctl which contain pointer
-* [#5945](https://github.com/apache/incubator-nuttx/pull/5945) fix:Remove udp send large pkt assert
-* [#5944](https://github.com/apache/incubator-nuttx/pull/5944) net: tcp/udp/icmp/icmpv6 add FIONSPACE support
-* [#5926](https://github.com/apache/incubator-nuttx/pull/5926) local socket: cancel assert about backlog exceed 255
-* [#5933](https://github.com/apache/incubator-nuttx/pull/5933) netdev_file_ioctl: Fix fcntl F_SETFL O_NONBLOCK regression
-* [#5889](https://github.com/apache/incubator-nuttx/pull/5889) rpmsg_socket: fix kasan report error
-* [#5848](https://github.com/apache/incubator-nuttx/pull/5848) local_socket: default set block mode if accept() a new socket
-* [#5755](https://github.com/apache/incubator-nuttx/pull/5755) wireless/80211: update the 80211 header
-* [#6432](https://github.com/apache/incubator-nuttx/pull/6432) wireless/bcm43xxx: add extended join parameters
-* [#6358](https://github.com/apache/incubator-nuttx/pull/6358) wireless: add Wireless statistics definition
-* [#6420](https://github.com/apache/incubator-nuttx/pull/6420) wireless/bcm43xxx: add support of bcm43013 chip
-* [#6463](https://github.com/apache/incubator-nuttx/pull/6463) wireless/bcm43xxx: add status print on bcmf_wl_auth_event_handler()
-* [#6461](https://github.com/apache/incubator-nuttx/pull/6461) wireless/bcm43xxx: Don't call bcmf_board_setup_oob_irq in bcmf_sdio_thread
-* [#6457](https://github.com/apache/incubator-nuttx/pull/6457) wireless/bcm43xxx: configurable buffer size of escan result
-* [#6453](https://github.com/apache/incubator-nuttx/pull/6453) wireless/bcm43xxx: replace all busy delay to nxsig_usleep
-* [#6447](https://github.com/apache/incubator-nuttx/pull/6447) bcm43xxx: Remove bcmf_txavail_work and resue bcmf_tx_poll_work
-* [#6446](https://github.com/apache/incubator-nuttx/pull/6446) wireless/bcm43xxx: improve throughput of net driver
-* [#6444](https://github.com/apache/incubator-nuttx/pull/6444) wireless/bcm43xxx: configurable schedule priority of daemon thread
-* [#6442](https://github.com/apache/incubator-nuttx/pull/6442) wireless/bcm43xxx: fix typo sq_init() -> dq_init()
-* [#6441](https://github.com/apache/incubator-nuttx/pull/6441) wireless/bcm43xx: replace sem_wait to uninterruptible version
-* [#6431](https://github.com/apache/incubator-nuttx/pull/6431) wirless/sdio: frame length should with guard bound
-* [#6430](https://github.com/apache/incubator-nuttx/pull/6430) wireless/bcm430xx: rename chip minor id to 'x'
-* [#6427](https://github.com/apache/incubator-nuttx/pull/6427) wireless/bcm43xxx: load nvram from file system
-* [#6561](https://github.com/apache/incubator-nuttx/pull/6561) wireless/bcm43xxx: only break out the send loop if no data
-* [#6560](https://github.com/apache/incubator-nuttx/pull/6560) wireless/bcm43xxx: remove flowctrl check
-* [#6559](https://github.com/apache/incubator-nuttx/pull/6559) wireless/bcm43xxx: filter out the bssi with same ssid name
-* [#6558](https://github.com/apache/incubator-nuttx/pull/6558) wireless/bcm43xxx: mac address does not need to be updated in ifup
-* [#6557](https://github.com/apache/incubator-nuttx/pull/6557) wireless/bcm43xxx: discard auth event if netdev down
-* [#6556](https://github.com/apache/incubator-nuttx/pull/6556) wireless/bcm43xxx: set listen interval on lowpower
-* [#6555](https://github.com/apache/incubator-nuttx/pull/6555) wireless/bcm43xxx: country code should terminating with null
-* [#6554](https://github.com/apache/incubator-nuttx/pull/6554) wireless/bcm43xxx: fix memory leak if tx fail
-* [#6533](https://github.com/apache/incubator-nuttx/pull/6533) wireless/bcm43xxx: enable tx flow control to improve performance
-* [#6524](https://github.com/apache/incubator-nuttx/pull/6524) wireless/bcm43xxx: replace private queue implement to list_node
-* [#6523](https://github.com/apache/incubator-nuttx/pull/6523) wireless/bcm43xxx: remove unused tx_queue_count
-* [#6518](https://github.com/apache/incubator-nuttx/pull/6518) wireless/bcm43xxx: add dynamic kso control support
-* [#6517](https://github.com/apache/incubator-nuttx/pull/6517) wireless/bcm43xxx: correct the return value
-* [#6501](https://github.com/apache/incubator-nuttx/pull/6501) wireless/bcm43xxx: add get country code support
-* [#6494](https://github.com/apache/incubator-nuttx/pull/6494) wireless/bcm43xxx: add set country code support
-* [#6488](https://github.com/apache/incubator-nuttx/pull/6488) wireless/bcm43xxx: add auto power saving support
-* [#6481](https://github.com/apache/incubator-nuttx/pull/6481) wireless/bcm43xxx: remove small chunks to improve clm download speed
-* [#6480](https://github.com/apache/incubator-nuttx/pull/6480) wireless/bcm43xxx: prefer HPWORK if bcmf task has higher priority than HPWORK
-* [#6479](https://github.com/apache/incubator-nuttx/pull/6479) wireless/bcm43xxx: merge frame send to once to improve the performance
-* [#6471](https://github.com/apache/incubator-nuttx/pull/6471) wireless/bcm43xxx: enable power saving on netdev up/down
-* [#6470](https://github.com/apache/incubator-nuttx/pull/6470) wireless/bcm43xxx: add customized MAC address support
-* [#6469](https://github.com/apache/incubator-nuttx/pull/6469) wireless/bcm43xxx: remove global variable for bcmf_sdio_thread
-* [#6467](https://github.com/apache/incubator-nuttx/pull/6467) wireless/bcm43xxx: handle disassoc correctly
-* [#6466](https://github.com/apache/incubator-nuttx/pull/6466) wireless/bcm43xxx: sort scan result by rssi
-* [#6464](https://github.com/apache/incubator-nuttx/pull/6464) wireless/bcm43xxx: add more ioctl command support
-* [#6636](https://github.com/apache/incubator-nuttx/pull/6636) wireless/ieee802154: Don't set IFF_DOWN in mac802154netdev_register
-* [#6695](https://github.com/apache/incubator-nuttx/pull/6695) bluetooth: fixing BT buffer addref/release balance
-* [#6782](https://github.com/apache/incubator-nuttx/pull/6782) bluetooth: fix net lock imbalance in drop casse
-* [#6672](https://github.com/apache/incubator-nuttx/pull/6672) rpmsg socket related update
-* [#6670](https://github.com/apache/incubator-nuttx/pull/6670) local socket related update
+* [#5967](https://github.com/apache/nuttx/pull/5967) net:fix coverity warning
+* [#5972](https://github.com/apache/nuttx/pull/5972) net/utils: fix IPv4 checksum calculation
+* [#5769](https://github.com/apache/nuttx/pull/5769) net/local: correct the socket flags from client socket
+* [#5750](https://github.com/apache/nuttx/pull/5750) net/udp: clear the connection structure after free
+* [#5748](https://github.com/apache/nuttx/pull/5748) net/local: correct the socket flags from server socket
+* [#6368](https://github.com/apache/nuttx/pull/6368) net/tcp: Hold the net lock in tcp_timer_expiry
+* [#6355](https://github.com/apache/nuttx/pull/6355) tcp: remove all devif_timer
+* [#6154](https://github.com/apache/nuttx/pull/6154) net/tcp:make initial tcp port more random
+* [#5794](https://github.com/apache/nuttx/pull/5794) netdb/getaddrinfo: fix NULL pointer reference
+* [#5791](https://github.com/apache/nuttx/pull/5791) netinitialize: call xxx_netinitialize unconditionally
+* [#5770](https://github.com/apache/nuttx/pull/5770) net/sockopt: bypass the SO_RCVBUF/SO_SNDBUF to usrsock
+* [#6735](https://github.com/apache/nuttx/pull/6735) make sure conn's domain is matched with addr's family
+* [#6608](https://github.com/apache/nuttx/pull/6608) net: Fix frame count check fail and race condition
+* [#6330](https://github.com/apache/nuttx/pull/6330) tcp: move wd_timer from wifi driver to tcp stack
+* [#6289](https://github.com/apache/nuttx/pull/6289) net: fix the build when CONFIG_NET_TCP_WRITE_BUFFERS is not enabled
+* [#6262](https://github.com/apache/nuttx/pull/6262) icmp: Fixed replies to broadcasts
+* [#6161](https://github.com/apache/nuttx/pull/6161) Fix udp recvfrom to correctly return addrlen
+* [#5799](https://github.com/apache/nuttx/pull/5799) net/netdev: fix switch case missing break
+* [#6398](https://github.com/apache/nuttx/pull/6398) net/tcp: wave hands on background
+* [#6297](https://github.com/apache/nuttx/pull/6297) net/tcp: Zero keeptimer in case caller set keepalive to false
+* [#6290](https://github.com/apache/nuttx/pull/6290) net/tcp: Use the decrease timer in TCP_TIME_WAIT/TCP_FIN_WAIT_2
+* [#6264](https://github.com/apache/nuttx/pull/6264) Fix ENOENT errors when polling on Netlink socket
+* [#6428](https://github.com/apache/nuttx/pull/6428) net/tcp: d_appdata should remove the tcp specific option field
+* [#6399](https://github.com/apache/nuttx/pull/6399) Packet dropped in IPv4/v6 input is now an info, not a warning
+* [#6770](https://github.com/apache/nuttx/pull/6770) delay creating DNS bind socket
+* [#6751](https://github.com/apache/nuttx/pull/6751) Net thread-safe ether_ntoa_r & inet_ntoa_r
+* [#6740](https://github.com/apache/nuttx/pull/6740) [TCP] Close RAM usage optimization
+* [#6747](https://github.com/apache/nuttx/pull/6747) Fix notify disassocitaion
+* [#6702](https://github.com/apache/nuttx/pull/6702) tcp: check option length before d_len update
+* [#6701](https://github.com/apache/nuttx/pull/6701) udp: Use s_sndtimeo as the actual timeout time
+* [#6700](https://github.com/apache/nuttx/pull/6700) netdev: add return value for ifup / ifdown
+* [#6563](https://github.com/apache/nuttx/pull/6563) net/tcp: discard connect reference before free
+* [#6562](https://github.com/apache/nuttx/pull/6562) net/tcp: fix regression of invalid update the rexmit_seq in buffer mode
+* [#6543](https://github.com/apache/nuttx/pull/6543) net_if: add IFF_LOOPBACK/POINTOPOINT/MULTICAST/BROADCAST
+* [#6529](https://github.com/apache/nuttx/pull/6529) net: Ensure sendmsg and sendfile return -EAGAIN in case of timeout
+* [#6519](https://github.com/apache/nuttx/pull/6519) netdev/carrier: check the IF stautus before carrier
+* [#6451](https://github.com/apache/nuttx/pull/6451) net/tcp(buffered): retransmit only one the earliest not acknowledged segment
+* [#6640](https://github.com/apache/nuttx/pull/6640) net/slip: Rename and clarify orphaned Kconfig options
+* [#6590](https://github.com/apache/nuttx/pull/6590) net/poll: fix race condition if connect free before poll teardown
+* [#6589](https://github.com/apache/nuttx/pull/6589) net/tcp: fix assertion of fallback connection alloc
+* [#5943](https://github.com/apache/nuttx/pull/5943) This PR mainly contains some USRSOCK related changes
+* [#6041](https://github.com/apache/nuttx/pull/6041) rpmsg_usrsock: Support the wireless ioctl which contain pointer
+* [#5945](https://github.com/apache/nuttx/pull/5945) fix:Remove udp send large pkt assert
+* [#5944](https://github.com/apache/nuttx/pull/5944) net: tcp/udp/icmp/icmpv6 add FIONSPACE support
+* [#5926](https://github.com/apache/nuttx/pull/5926) local socket: cancel assert about backlog exceed 255
+* [#5933](https://github.com/apache/nuttx/pull/5933) netdev_file_ioctl: Fix fcntl F_SETFL O_NONBLOCK regression
+* [#5889](https://github.com/apache/nuttx/pull/5889) rpmsg_socket: fix kasan report error
+* [#5848](https://github.com/apache/nuttx/pull/5848) local_socket: default set block mode if accept() a new socket
+* [#5755](https://github.com/apache/nuttx/pull/5755) wireless/80211: update the 80211 header
+* [#6432](https://github.com/apache/nuttx/pull/6432) wireless/bcm43xxx: add extended join parameters
+* [#6358](https://github.com/apache/nuttx/pull/6358) wireless: add Wireless statistics definition
+* [#6420](https://github.com/apache/nuttx/pull/6420) wireless/bcm43xxx: add support of bcm43013 chip
+* [#6463](https://github.com/apache/nuttx/pull/6463) wireless/bcm43xxx: add status print on bcmf_wl_auth_event_handler()
+* [#6461](https://github.com/apache/nuttx/pull/6461) wireless/bcm43xxx: Don't call bcmf_board_setup_oob_irq in bcmf_sdio_thread
+* [#6457](https://github.com/apache/nuttx/pull/6457) wireless/bcm43xxx: configurable buffer size of escan result
+* [#6453](https://github.com/apache/nuttx/pull/6453) wireless/bcm43xxx: replace all busy delay to nxsig_usleep
+* [#6447](https://github.com/apache/nuttx/pull/6447) bcm43xxx: Remove bcmf_txavail_work and resue bcmf_tx_poll_work
+* [#6446](https://github.com/apache/nuttx/pull/6446) wireless/bcm43xxx: improve throughput of net driver
+* [#6444](https://github.com/apache/nuttx/pull/6444) wireless/bcm43xxx: configurable schedule priority of daemon thread
+* [#6442](https://github.com/apache/nuttx/pull/6442) wireless/bcm43xxx: fix typo sq_init() -> dq_init()
+* [#6441](https://github.com/apache/nuttx/pull/6441) wireless/bcm43xx: replace sem_wait to uninterruptible version
+* [#6431](https://github.com/apache/nuttx/pull/6431) wirless/sdio: frame length should with guard bound
+* [#6430](https://github.com/apache/nuttx/pull/6430) wireless/bcm430xx: rename chip minor id to 'x'
+* [#6427](https://github.com/apache/nuttx/pull/6427) wireless/bcm43xxx: load nvram from file system
+* [#6561](https://github.com/apache/nuttx/pull/6561) wireless/bcm43xxx: only break out the send loop if no data
+* [#6560](https://github.com/apache/nuttx/pull/6560) wireless/bcm43xxx: remove flowctrl check
+* [#6559](https://github.com/apache/nuttx/pull/6559) wireless/bcm43xxx: filter out the bssi with same ssid name
+* [#6558](https://github.com/apache/nuttx/pull/6558) wireless/bcm43xxx: mac address does not need to be updated in ifup
+* [#6557](https://github.com/apache/nuttx/pull/6557) wireless/bcm43xxx: discard auth event if netdev down
+* [#6556](https://github.com/apache/nuttx/pull/6556) wireless/bcm43xxx: set listen interval on lowpower
+* [#6555](https://github.com/apache/nuttx/pull/6555) wireless/bcm43xxx: country code should terminating with null
+* [#6554](https://github.com/apache/nuttx/pull/6554) wireless/bcm43xxx: fix memory leak if tx fail
+* [#6533](https://github.com/apache/nuttx/pull/6533) wireless/bcm43xxx: enable tx flow control to improve performance
+* [#6524](https://github.com/apache/nuttx/pull/6524) wireless/bcm43xxx: replace private queue implement to list_node
+* [#6523](https://github.com/apache/nuttx/pull/6523) wireless/bcm43xxx: remove unused tx_queue_count
+* [#6518](https://github.com/apache/nuttx/pull/6518) wireless/bcm43xxx: add dynamic kso control support
+* [#6517](https://github.com/apache/nuttx/pull/6517) wireless/bcm43xxx: correct the return value
+* [#6501](https://github.com/apache/nuttx/pull/6501) wireless/bcm43xxx: add get country code support
+* [#6494](https://github.com/apache/nuttx/pull/6494) wireless/bcm43xxx: add set country code support
+* [#6488](https://github.com/apache/nuttx/pull/6488) wireless/bcm43xxx: add auto power saving support
+* [#6481](https://github.com/apache/nuttx/pull/6481) wireless/bcm43xxx: remove small chunks to improve clm download speed
+* [#6480](https://github.com/apache/nuttx/pull/6480) wireless/bcm43xxx: prefer HPWORK if bcmf task has higher priority than HPWORK
+* [#6479](https://github.com/apache/nuttx/pull/6479) wireless/bcm43xxx: merge frame send to once to improve the performance
+* [#6471](https://github.com/apache/nuttx/pull/6471) wireless/bcm43xxx: enable power saving on netdev up/down
+* [#6470](https://github.com/apache/nuttx/pull/6470) wireless/bcm43xxx: add customized MAC address support
+* [#6469](https://github.com/apache/nuttx/pull/6469) wireless/bcm43xxx: remove global variable for bcmf_sdio_thread
+* [#6467](https://github.com/apache/nuttx/pull/6467) wireless/bcm43xxx: handle disassoc correctly
+* [#6466](https://github.com/apache/nuttx/pull/6466) wireless/bcm43xxx: sort scan result by rssi
+* [#6464](https://github.com/apache/nuttx/pull/6464) wireless/bcm43xxx: add more ioctl command support
+* [#6636](https://github.com/apache/nuttx/pull/6636) wireless/ieee802154: Don't set IFF_DOWN in mac802154netdev_register
+* [#6695](https://github.com/apache/nuttx/pull/6695) bluetooth: fixing BT buffer addref/release balance
+* [#6782](https://github.com/apache/nuttx/pull/6782) bluetooth: fix net lock imbalance in drop casse
+* [#6672](https://github.com/apache/nuttx/pull/6672) rpmsg socket related update
+* [#6670](https://github.com/apache/nuttx/pull/6670) local socket related update
 
 Compatibility Concerns
 

--- a/_releases/9.1.0.md
+++ b/_releases/9.1.0.md
@@ -78,7 +78,7 @@ information).  SHA512 checksums:
           implementation assumed that (void *) would be of size long.  There is
           more discussion of this issue in the GitHub issue ticket here:
 
-          https://github.com/apache/incubator-nuttx/issues/959
+          https://github.com/apache/nuttx/issues/959
 
         - PR-962 PR-964 Add new interface sched_get_stackinfo that simplifies
           interfaces for things like TLS


### PR DESCRIPTION
## Summary

NuttX has graduated the Incubator and the repositories will be renamed to remove the `incubator-` prefix.

This PR updates all links, documentation, etc., to the new names.

Note: Please DO NOT MERGE until Infra has renamed the repositories.

See the Infra Jira ticket: https://issues.apache.org/jira/browse/INFRA-23935

## Impact

Affects GitHub workflows.

## Testing

N/A