### PR TITLE
project.yml: Fix typo in value of unix_name

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -17,7 +17,7 @@
 #
 name: Apache NuttX
 short_name: NuttX
-unix_name: nuxxt
+unix_name: nuttx
 incubator_name: nuttx
 incubator_slash_name: incubator/nuttx
 description: Apache NuttX is a mature, real-time embedded operating system (RTOS).


### PR DESCRIPTION
## Summary

Although `unix_name` is not currently utilized (except in a commented section), fixing this typo to prevent it being used by mistake in the future.

## Impact

None, but may prevent future errors.

## Testing

N/A