### PR TITLE
Navigation: Use https for user-facing apache.org links

### DIFF
--- a/_includes/themes/apache/_navigation.html
+++ b/_includes/themes/apache/_navigation.html
@@ -26,13 +26,13 @@
             <li id="apache">
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Apache<b class="caret"></b></a>
                <ul class="dropdown-menu">
-                <li><a href="http://www.apache.org/foundation/how-it-works.html">Apache Software Foundation</a></li>
-                <li><a href="http://www.apache.org/licenses/">License</a></li>
-                <li><a href="http://www.apache.org/security/">Security</a></li>
+                <li><a href="https://www.apache.org/foundation/how-it-works.html">Apache Software Foundation</a></li>
+                <li><a href="https://www.apache.org/licenses/">License</a></li>
+                <li><a href="https://www.apache.org/security/">Security</a></li>
                 <li><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a></li>
-                <li><a href="http://www.apache.org/events/current-event">Events</a></li>
-                <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
-                <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
+                <li><a href="https://www.apache.org/events/current-event">Events</a></li>
+                <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+                <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
                 </ul>
             </li>
           </ul>


### PR DESCRIPTION
## Summary

In the navigation dropdown menu, change http to https for foundation-wide links.

## Impact

None.

## Testing

Verified links work with https.