### PR TITLE
Updated Contributors PMC list.

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -21,7 +21,7 @@
 - name: Abdelatif Guettouche
   apacheId: aguettouche
   githubId: Ouss4
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Adam Feuer
@@ -33,25 +33,25 @@
 - name: Alan Carvalho de Assis
   apacheId: acassis
   githubId: acassis
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Alin Jerpelea
   apacheId: jerpelea
   githubId: jerpelea
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Anthony Merlino
   apacheId: antmerlino
   githubId: antmerlino
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Brennan Ashton
   apacheId: btashton
   githubId: btashton
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Chao An
@@ -63,25 +63,25 @@
 - name: David Sidrane
   apacheId: davids5
   githubId: davids5
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Duo Zhang
   apacheId: zhangduo
   githubId: Apache9
-  role: Mentor, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, PPMC, Committer
   org:
 
 - name:	Flavio Paiva Junqueira
   apacheId: fpj
   githubId: fpj
-  role: Mentor, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, PPMC, Committer
   org:
 
 - name: Gregory Nutt
   apacheId: gnutt
   githubId: patacongo
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Gustavo Henrique Nihei
@@ -104,19 +104,19 @@
 - name: Justin Mclean
   apacheId: jmclean
   githubId: justinmclean
-  role: Mentor, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, PPMC, Committer
   org:
 
 - name: Junping Du
   apacheId: junping_du
   githubId: JunpingDu
-  role: Champion, Mentor, IPMC, PPMC, Committer
+  role: Champion, Mentor, PMC, IPMC, PPMC, Committer
   org:
 
 - name: Masayuki Ishikawa
   apacheId: masayuki
   githubId: masayuki2009
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Mateusz Szafoni
@@ -134,13 +134,13 @@
 - name: Mohammad Asif Siddiqui
   apacheId: asifdxtreme
   githubId: asifdxtreme
-  role: Mentor, IPMC, PPMC, Committer
+  role: Mentor, PMC, IPMC, PPMC, Committer
   org:
 
 - name: Nathan Hartman
   apacheId: hartmannathan
   githubId: hartmannathan
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Petro Karashchenko
@@ -152,7 +152,7 @@
 - name: Sara da Cunha Monteiro de Souza
   apacheId: sara
   githubId: saramonteiro
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Sebastian Ene
@@ -170,7 +170,7 @@
 - name: Xiang Xiao
   apacheId: xiaoxiang
   githubId: xiaoxiang781216
-  role: PPMC, Committer
+  role: PMC, PPMC, Committer
   org:
 
 - name: Yamamoto Takashi


### PR DESCRIPTION
## Summary
* Added current PMC status along the IPMC/PPMC to preserve history.

## Impact
* Keep the IPMC/PPMC roles to preserve history.

## Testing
* Please let me know if we want to preserve IPMC/PPMC hostory or simply replace them with PMC?
