### PR TITLE
ci: Properly capture username it git config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,8 @@ jobs:
         export PATH=$PATH:$GEM_HOME/bin
         username="`git log -1 --pretty=format:'%an'`"
         email="`git log -1 --pretty=format:'%ae'`"
-        git config --global user.name $username
-        git config --global user.email $email
+        git config --global user.name "$username"
+        git config --global user.email "$email"
         ./publish.sh
 
     - name: Upload artifact of staged site


### PR DESCRIPTION
## Summary
Git username that contained certain symbols such as `Tomasz 'CeDeROM' CEDRO` does not get captured properly when setting the git config in the workflow

```
~/nuttx-wrk/nuttx-website on  master via 💎 v3.0.2 
❯  username="`git log -1 --pretty=format:'%an'`"
email="`git log -1 --pretty=format:'%ae'`"
❯ echo $username
Tomasz 'CeDeROM' CEDRO
❯ echo $email
tomek@cedro.info
❯ git config user.name $username
usage: git config [<options>]

Config file location
    --global              use global config file
    --system              use system config file
....
```

With this change
```
❯ git config user.name "$username"
❯ git config user.name
Tomasz 'CeDeROM' CEDRO
```
