### PR TITLE
Fix social media hyperlinks on the Community page.

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -58,3 +58,7 @@ source_repository_apps_mirror: https://github.com/apache/nuttx-apps
 website_repository: https://gitbox.apache.org/repos/asf?p=nuttx-website.git
 website_repository_mirror: https://github.com/apache/nuttx-website
 
+socialmedia_youtube: https://www.youtube.com/@nuttxchannel
+socialmedia_hackster: https://www.hackster.io/nuttx
+socialmedia_linkedin_company: https://www.linkedin.com/company/nuttx
+socialmedia_linkedin_group: https://www.linkedin.com/groups/12002792

--- a/community.md
+++ b/community.md
@@ -56,9 +56,9 @@ Get help using {{ site.data.project.short_name }} or contribute to the project o
 
 The mailing list and project website is our central hub of information, but there are several social media channels where you can find interesting videos, updates, DIY projects that may help you work with NuttX RTOS.
 
-* YouTube: https://www.youtube.com/@nuttxchannel.
-* Hackster: https://www.hackster.io/nuttx.
-* LinkedIn: https://www.linkedin.com/company/nuttx , https://www.linkedin.com/groups/12002792.
+* YouTube: [https://www.youtube.com/@nuttxchannel]({{ site.data.project.socialmedia_youtube }}).
+* Hackster: [https://www.hackster.io/nuttx]({{ site.data.project.socialmedia_hackster }}).
+* LinkedIn: [https://www.linkedin.com/company/nuttx]({{ site.data.project.socialmedia_linkedin_company }}) , [https://www.linkedin.com/groups/12002792]({{ site.data.project.socialmedia_linkedin_group }}).
 
 
 ### Issue tracker


### PR DESCRIPTION
## Summary
* Fix social media hyperlinks on the Community page.

## Impact
* Hyperlinks are not generated automatically.
* External sites URLs are added to `_data/project.yml`.

## Testing
* Please verify :-)
