### PR TITLE
Add Events website to navigation bar.

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -58,6 +58,8 @@ source_repository_apps_mirror: https://github.com/apache/nuttx-apps
 website_repository: https://gitbox.apache.org/repos/asf?p=nuttx-website.git
 website_repository_mirror: https://github.com/apache/nuttx-website
 
+community_events: https://events.nuttx.apache.org
+
 socialmedia_youtube: https://www.youtube.com/@nuttxchannel
 socialmedia_hackster: https://www.hackster.io/nuttx
 socialmedia_linkedin_company: https://www.linkedin.com/company/nuttx

--- a/_includes/themes/apache/_navigation.html
+++ b/_includes/themes/apache/_navigation.html
@@ -21,7 +21,8 @@
                 <li><a href="{{ site.baseurl }}/community-members">Who we are</a></li>
                </ul>
             </li>
-	    <li><a href="{{ site.baseurl }}/docs/latest">Documentation</a></li>
+            <li><a href="{{ site.data.project.community_events }}">Events</a></li>
+            <li><a href="{{ site.baseurl }}/docs/latest">Documentation</a></li>
             <li><a href="{{ site.data.project.source_repository_os_mirror }}">GitHub</a></li>
             <li id="apache">
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Apache<b class="caret"></b></a>


### PR DESCRIPTION
## Summary
* Add https://events.nuttx.apache.org to the top navigation bar. This is our community conference events website.

## Impact
* Provide quick access to community conference events website.

## Testing
* Please verify :-)
