### PR TITLE
Added International Workshop 2024 information to index site.

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -59,6 +59,8 @@ website_repository: https://gitbox.apache.org/repos/asf?p=nuttx-website.git
 website_repository_mirror: https://github.com/apache/nuttx-website
 
 community_events: https://events.nuttx.apache.org
+community_events_workshop_2024_cfp: https://docs.google.com/forms/d/1eAvddku9WaNn0au2QJEkOdChq4XxPP6Sj0EgIfmDXS0/edit
+community_events_workshop_2024_linkedin_event: https://www.linkedin.com/events/7165682114275876869
 
 socialmedia_youtube: https://www.youtube.com/@nuttxchannel
 socialmedia_hackster: https://www.hackster.io/nuttx

--- a/index.md
+++ b/index.md
@@ -36,6 +36,41 @@ for functionality that is not appropriate for deeply-embedded environments (such
 as fork()).
 
 
+## Community Events
+
+### International Workshop 2024
+
+The [Apache NuttX International Workshop]({{ site.data.project.community_events }})
+is organized every year. You can attend online or in person for free.
+This year we meet on 13-14 Jun 2024 at Sony Office, Tokyo, Japan. See you there!
+
+Please visit [events website]({{ site.data.project.community_events }}) for more details.
+You can join the event at [LinkedIn]({{ site.data.project.community_events_workshop_2024_linkedin_event }}).
+[Call For Papers](({{ site.data.project.community_events_workshop_2024_cfp }}) is now open!
+
+The scope of the workshop is the Apache Nuttx® Real Time Operating System, the
+tools used for its design, development, deployment, debugging, and maintenance,
+the applications that use it, and the hardware on which it typically runs.
+The target audience is embedded systems practitioners across both industry and
+academia.
+
+Apache NuttX® International Workshop has four primary objectives; (i) To allow
+the developers and users of Apache NuttX® to meet up, to network together,
+exchange ideas, and to understand their mutual needs and aspirations for the
+OS. (ii) To agree on directions for the future development of Apache NuttX®
+together with Apache Software Foundation and to coalesce development groups
+to work on these initiatives. (iii) To raise the profile of Apache NuttX®
+and allow potential adopters from around the world to see how widely it is
+already used and (iv) to understand how we can make the development process
+for Apache NuttX® more diverse and robust.
+
+Participation at the workshop shall be limited to 200 attendees and we
+strongly prefer delegates that will contribute to the event. Active
+participation may take a form of short lecture or full presentation.
+All proposals will be considered with a duration from 20 minutes (short
+lecture) to 40 minutes (full presentation).
+
+
 ## Documentation
 
 Extensive documentation can be found [here]({{ site.baseurl }}/docs/latest).


### PR DESCRIPTION
## Summary

The information on International Workshop 2024 has been added to the main side under new Community Events section above Documentation section.

## Impact

Provide information with some details on the Workshop directly on our main site.

## Testing

Please verify content, form, and formatting (cannot build local preview https://github.com/apache/nuttx-website/issues/106).