### PR TITLE
Use correct Uppercase for POSIX

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ limitations under the License.
 
 NuttX is a real-time operating system (RTOS) with an emphasis on standards
 compliance and small footprint. Scalable from 8-bit to 64-bit microcontroller
-environments, the primary governing standards in NuttX are Posix and ANSI
+environments, the primary governing standards in NuttX are POSIX and ANSI
 standards. Additional standard APIs from Unix and other common RTOS's (such as
 VxWorks) are adopted for functionality not available under these standards, or
 for functionality that is not appropriate for deeply-embedded environments (such


### PR DESCRIPTION
As POSIX is an acronym for Portable Operating System Interface, it must be written in all capitalized form.
