### PR TITLE
main.yml: fix buid NuttX documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Site
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - run: |
         git fetch --prune --unshallow
 
     - name: Checkout NuttX repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: apache/nuttx
         fetch-depth: 0
         ref: master
         path: nuttx
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.8'
     - name: Build docs
@@ -50,7 +50,7 @@ jobs:
         echo " Select nuttx/Documentation version candidates"
         echo "======================================================="
 
-        NUTTX_TAGS=$(git tag -l 'nuttx-1?.*' | fgrep -v RC)
+        NUTTX_TAGS=$(git tag -l --sort=taggerdate 'nuttx-1?.*' | fgrep -v RC)
         export NUTTX_VERSIONS=$(echo -n "$NUTTX_TAGS" | sed -r 's|^nuttx-||g' | tr '\n' ',')
         
         echo " ==> BUILD NUTTX DOCUMENTATION FOR: $NUTTX_VERSIONS (and master)."


### PR DESCRIPTION


## Summary

fix

Warning, treated as error:
/home/runner/work/nuttx-website/nuttx-website/nuttx/Documentation/_tags/arch-arm64.rst:6:toctree contains reference to nonexisting document 'platforms/arm64/imx9/boards/imx93-evk/index' make: *** [Makefile:45: html] Error 2
Error: Process completed with exit code 2.

The error seems to be due to the construction order

12.1.0 -> 12.10.0 -> 12.2.0

==> BUILD NUTTX DOCUMENTATION FOR: 10.0.0,10.0.1,10.1.0,10.2.0,10.3.0,11.0.0,12.0.0,12.1.0,12.10.0,12.2.0,12.2.1,12.3.0,12.4.0,12.5.0,12.5.1,12.6.0,12.7.0,12.8.0,12.9.0 (and master).

Bump 
actions/checkout@v4 and actions/setup-python@v5

## Impact
fix buid NuttX documentation

## Testing
CI
