### PR TITLE
Update information on NuttX International Workshop 2025.

### DIFF
--- a/_data/project.yml
+++ b/_data/project.yml
@@ -59,8 +59,8 @@ website_repository: https://gitbox.apache.org/repos/asf?p=nuttx-website.git
 website_repository_mirror: https://github.com/apache/nuttx-website
 
 community_events: https://events.nuttx.apache.org
-community_events_workshop_2024_cfp: https://docs.google.com/forms/d/1eAvddku9WaNn0au2QJEkOdChq4XxPP6Sj0EgIfmDXS0/edit
-community_events_workshop_2024_linkedin_event: https://www.linkedin.com/events/7165682114275876869
+community_events_workshop_2025_cfp: https://docs.google.com/forms/d/e/1FAIpQLSecMK1Jt264Ykc_t6WRe0u8MYMgbGLW2ophtG-26F6zup9ppw/viewform
+community_events_workshop_2025_linkedin_event: https://www.linkedin.com/company/nuttx/
 
 socialmedia_youtube: https://www.youtube.com/@nuttxchannel
 socialmedia_hackster: https://www.hackster.io/nuttx

--- a/index.md
+++ b/index.md
@@ -48,15 +48,16 @@ Try the online demo [here]({{ site.baseurl }}/demo).
 
 ## Community Events
 
-### International Workshop 2024
+### International Workshop 2025
 
 The [Apache NuttX International Workshop]({{ site.data.project.community_events }})
 is organized every year. You can attend online or in person for free.
-This year we meet on 13-14 Jun 2024 at Sony Office, Tokyo, Japan. See you there!
+This year we meet on 16-17th October 2025 in Costa Rica.
+We hope to meet with Gregory Nutt on site. See you there!
 
 Please visit [events website]({{ site.data.project.community_events }}) for more details.
-You can join the event at [LinkedIn]({{ site.data.project.community_events_workshop_2024_linkedin_event }}).
-[Call For Papers]({{ site.data.project.community_events_workshop_2024_cfp }}) is now open!
+You can join the event at [LinkedIn]({{ site.data.project.community_events_workshop_2025_linkedin_event }}).
+[Call For Papers]({{ site.data.project.community_events_workshop_2025_cfp }}) is now open!
 
 The scope of the workshop is the Apache Nuttx® Real Time Operating System, the
 tools used for its design, development, deployment, debugging, and maintenance,


### PR DESCRIPTION
## Summary

Update information on NuttX International Workshop 2024 -> 2025.

## Impact

This year event shows up on out main website.